### PR TITLE
Fixed issue with parsing of trade price.

### DIFF
--- a/src/js/ripple/orderbook.js
+++ b/src/js/ripple/orderbook.js
@@ -137,9 +137,9 @@ OrderBook.prototype.is_valid = function () {
 
 OrderBook.prototype.trade = function(type) {
   var tradeStr = '0'
-  + (this['_currency_' + type] === 'XRP') ? '' : '/' 
+  + ((this['_currency_' + type] === 'XRP') ? '' : '/'
   + this['_currency_' + type ] + '/' 
-  + this['_issuer_' + type];
+  + this['_issuer_' + type]);
   return Amount.from_json(tradeStr);
 };
 


### PR DESCRIPTION
The + operator has higher precedence, which causes the price to be read
as '' (empty string) no matter what the currency and issuer.

I believe this will fix the "Last price = n/a" error in the default
client as well.
