### PR TITLE
Add hooks for logging web socket messages

### DIFF
--- a/src/js/ripple/server.js
+++ b/src/js/ripple/server.js
@@ -203,6 +203,7 @@ Server.prototype.connect = function () {
   }
 
   ws.onmessage = function (msg) {
+    self.emit('before_message_for_non_mutators', msg.data);
     self.emit('message', msg.data);
   };
 };
@@ -217,6 +218,7 @@ Server.prototype.disconnect = function () {
 
 Server.prototype.send_message = function (message) {
   if (this._ws) {
+    this.emit('before_send_message_for_non_mutators', message)
     this._ws.send(JSON.stringify(message));
   }
 };


### PR DESCRIPTION
This can be used to capture web socket messages, interspersing them with metadata about the source of such messages. The rippled test suite could be captured (as per http://ndudfield.com/zencoding/rippled-capture) and it could also be useful for logging ripple-client messages for display.

The event names are pretty explicit about the intended use cases.
