### PR TITLE
Improvement `remote.request_book_offers` parameters passing

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -905,6 +905,20 @@ Remote.prototype.requestTxHistory = function(start, callback) {
 };
 
 Remote.prototype.requestBookOffers = function(gets, pays, taker, callback) {
+  if (gets.hasOwnProperty('pays')) {
+    var options = gets;
+    callback = pays;
+    taker = options.taker;
+    pays = options.pays;
+    gets = options.gets;
+  }
+
+  var lastArg = arguments[arguments.length - 1];
+
+  if (typeof lastArg === 'function') {
+    callback = lastArg;
+  }
+  
   var request = new Request(this, 'book_offers');
 
   request.message.taker_gets = {


### PR DESCRIPTION
As the example  in doc reference:

``` js
var request = remote.request_book_offers({
  gets: {
      'currency':'XRP'
  },
  pays: {
    'currency':'USD',
    'issuer': 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
  }
});
```

It will raise `TypeError: Cannot read property 'currency' of undefined`. 
Fixed issue with parsing parameters
