### PR TITLE
Fix signingHash calls; make rsign output pre-sign hash.

### DIFF
--- a/bin/rsign.js
+++ b/bin/rsign.js
@@ -76,6 +76,7 @@ function sign_transaction() {
   tx.complete();
 
   var unsigned_blob = tx.serialize().to_hex();
+  var unsigned_hash = tx.signingHash();
   tx.sign();
 
   if (verbose) {
@@ -83,7 +84,7 @@ function sign_transaction() {
 
     sim.tx_blob         = tx.serialize().to_hex();
     sim.tx_json         = tx.tx_json;
-    sim.tx_signing_hash = tx.signing_hash().to_hex();
+    sim.tx_signing_hash = unsigned_hash;
     sim.tx_unsigned     = unsigned_blob;
 
     console.log(JSON.stringify(sim, null, 2));

--- a/src/js/ripple/transaction.js
+++ b/src/js/ripple/transaction.js
@@ -280,7 +280,7 @@ Transaction.prototype.sign = function() {
   var prev_sig = this.tx_json.TxnSignature;
   delete this.tx_json.TxnSignature;
 
-  var hash = this.signing_hash();
+  var hash = this.signingHash();
 
   // If the hash is the same, we can re-use the previous signature
   if (prev_sig && hash === this.previousSigningHash) {


### PR DESCRIPTION
Two things here:
- I needed to change the signing_hash() calls to signingHash(). Maybe the function was renamed?
- I changed the output of rsign.js to include the signingHash of the transaction that was actually used for the signature, that is, the binary version of the transaction _before_ TxnSignature is added to the object. This makes much more sense than showing a value that is never really used anywhere in the transaction process.
