### PR TITLE
Set VER_ACCOUNT_ID on address returned by KeyPair.get_address

### DIFF
--- a/src/js/ripple/keypair.js
+++ b/src/js/ripple/keypair.js
@@ -2,6 +2,7 @@ var sjcl    = require('./utils').sjcl;
 
 var UInt160 = require('./uint160').UInt160;
 var UInt256 = require('./uint256').UInt256;
+var Base    = require('./base').Base;
 
 function KeyPair() {
   this._curve  = sjcl.ecc.curves['c256'];
@@ -82,7 +83,9 @@ KeyPair.prototype.get_address = function () {
 
   var hash = SHA256_RIPEMD160(bits);
 
-  return UInt160.from_bits(hash);
+  var address = UInt160.from_bits(hash);
+  address.set_version(Base.VER_ACCOUNT_ID);
+  return address;
 };
 
 KeyPair.prototype.sign = function (hash) {

--- a/test/keypair-test.js
+++ b/test/keypair-test.js
@@ -1,0 +1,14 @@
+var assert = require('assert');
+var utils  = require('./testutils');
+var Seed   = utils.load_module('seed').Seed;
+var config = require('./testutils').get_config();
+
+describe('KeyPair', function() {
+  it('can generate an address', function () {
+    var seed = Seed.from_json("masterpassphrase");
+    var address = seed.get_key().get_address();
+    assert.strictEqual(address.to_json(), 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+  });
+});
+
+// vim:sw=2:sts=2:ts=8:et


### PR DESCRIPTION
Just a decent default, client code can still set_version before base58 encoding.
