### PR TITLE
[FEATURE] support numeric currency codes

### DIFF
--- a/src/js/ripple/amount.js
+++ b/src/js/ripple/amount.js
@@ -598,7 +598,7 @@ Amount.prototype.invert = function() {
  * The regular expression below matches above cases, broken down for better understanding:
  *
  * ^\s*                         // start with any amount of whitespace
- * ([a-z]{3})?                  // optional any 3 letters
+ * ([a-zA-Z]{3}|[0-9]{3})       // either 3 letter alphabetic currency-code or 3 digit numeric currency-code. See ISO 4217
  * \s*                          // any amount of whitespace
  * (-)?                         // optional dash
  * (\d+)                        // 1 or more digits
@@ -609,7 +609,7 @@ Amount.prototype.invert = function() {
  * $                            // end of string
  *
  */
-Amount.human_RE = /^\s*([a-z]{3})?\s*(-)?(\d+)(\.(\d*))?\s*([a-f0-9]{40}|[a-z0-9]{3})?\s*$/i;
+Amount.human_RE = /^\s*([a-z]{3}|[0-9]{3})?\s*(-)?(\d+)(\.(\d*))?\s*([a-f0-9]{40}|[a-z0-9]{3})?\s*$/i;
 
 Amount.prototype.parse_human = function(j, opts) {
   opts = opts || {};

--- a/src/js/ripple/currency.js
+++ b/src/js/ripple/currency.js
@@ -43,14 +43,14 @@ Currency.HEX_CURRENCY_BAD = '0000000000000000000000005852500000000000';
  *  The regular expression below matches above cases, broken down for better understanding:
  *
  *  ^\s*                      // start with any amount of whitespace
- *  ([a-zA-Z]{3})             // any 3 letter currency code
+ *  ([a-zA-Z]{3}|[0-9]{3})    // either 3 letter alphabetic currency-code or 3 digit numeric currency-code. See ISO 4217
  *  (\s*-\s*[- \w]+)          // optional full currency name following the dash after currency code,
  *                               full currency code can contain letters, numbers and dashes
  *  (\s*\(-?\d+\.?\d*%pa\))?  // optional demurrage rate, has optional - and . notation (-0.5%pa)
  *  \s*$                      // end with any amount of whitespace
  *
  */
-Currency.prototype.human_RE = /^\s*([a-zA-Z]{3})(\s*-\s*[- \w]+)?(\s*\(-?\d+\.?\d*%pa\))?\s*$/;
+Currency.prototype.human_RE = /^\s*([a-zA-Z]{3}|[0-9]{3})(\s*-\s*[- \w]+)?(\s*\(-?\d+\.?\d*%pa\))?\s*$/;
 
 Currency.from_json = function(j, shouldInterpretXrpAsIou) {
   if (j instanceof this) {

--- a/test/amount-test.js
+++ b/test/amount-test.js
@@ -143,6 +143,12 @@ describe('Amount', function() {
     it('Parse -0.0/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
       assert.strictEqual('0/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', Amount.from_json('-0.0/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh').to_text_full());
     });
+    it('Parse 0.0/111/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
+      assert.strictEqual('0/111/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', Amount.from_json('0/111/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh').to_text_full());
+    });
+    it('Parse 0.0/12D/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
+      assert.strictEqual('0/XRP/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', Amount.from_json('0/12D/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh').to_text_full());
+    });
   });
   describe('Amount operations', function() {
     it('Negate native 123', function () {

--- a/test/currency-test.js
+++ b/test/currency-test.js
@@ -27,6 +27,16 @@ describe('Currency', function() {
       assert(r.is_native());
       assert.strictEqual('XRP', r.to_json());
     });
+    it('from_json("111").to_human()', function() {
+      var r = currency.from_json("111");
+      assert(r.is_valid());
+      assert.strictEqual('111', r.to_json());
+    });
+    it('from_json("1D2").to_human()', function() {
+      var r = currency.from_json("1D2");
+      assert(!r.is_valid());
+      assert.strictEqual('XRP', r.to_json());
+    });
   });
 
   describe('from_human', function() {


### PR DESCRIPTION
ISO 4217 states support for both alphabetic and numeric codes. rippled adheres to the ISO 4217 as stated in the Currency_Format on the wiki (https://ripple.com/wiki/Currency_Format) and there are trustlines out there with numeric currency codes.

The three-digit numeric code is useful when currency codes need to be understood in countries that do not use Latin scripts and for computerised systems. Where possible the 3 digit numeric code is the same as the numeric country code.
