### PR TITLE
[FIX] value parsing for amount/currency order pairs

### DIFF
--- a/src/js/ripple/amount.js
+++ b/src/js/ripple/amount.js
@@ -617,8 +617,8 @@ Amount.prototype.parse_human = function(j, opts) {
   var m = String(j).match(Amount.human_RE);
 
   if (m) {
-    var currency   = m[1] || m[5] || 'XRP';
-    var integer    = m[3] || '0';
+    var currency   = m[5] || m[1] || 'XRP';
+    var integer    = m[5] && m[1] ? m[1] + '' + m[3] : (m[3] || '0');
     var fraction   = m[4] || '';
     var precision  = null;
 

--- a/test/amount-test.js
+++ b/test/amount-test.js
@@ -26,6 +26,24 @@ describe('Amount', function() {
     it('0.1 USD', function() {
       assert.strictEqual(Amount.from_human("0.1 USD").to_text_full(), '0.1/USD/NaN');
     });
+    it('10000 USD', function() {
+      assert.strictEqual(Amount.from_human("10000 USD").to_text_full(), '10000/USD/NaN');
+    });
+    it('USD 10000', function() {
+      assert.strictEqual(Amount.from_human("USD 10000").to_text_full(), '10000/USD/NaN');
+    });
+    it('12345.6789 XAU', function() {
+      assert.strictEqual(Amount.from_human("12345.6789 XAU").to_text_full(), '12345.6789/XAU/NaN');
+    });
+    it('XAU 12345.6789', function() {
+      assert.strictEqual(Amount.from_human("XAU 12345.6789").to_text_full(), '12345.6789/XAU/NaN');
+    });
+    it('101 12345.6789', function() {
+      assert.strictEqual(Amount.from_human("101 12345.6789").to_text_full(), '12345.6789/101/NaN');
+    });
+    it('12345.6789 101', function() {
+      assert.strictEqual(Amount.from_human("12345.6789 101").to_text_full(), '12345.6789/101/NaN');
+    });
   });
   describe('from_json', function() {
     it('1 XRP', function() {


### PR DESCRIPTION
e.g. `100000 USD` and `USD 100000` should have the same result
