### PR TITLE
[fix] NOT READY: generator isn't seeded error

### DIFF
--- a/src/js/ripple/crypt.js
+++ b/src/js/ripple/crypt.js
@@ -17,6 +17,12 @@ var cryptConfig = {
   iter   : 1000  // iterations (key derivation)
 };
 
+// Initializing sjcl.random doesn't really belong here, but there is no other
+// good place for it yet.
+for (var i = 0; i < 8; i++) {
+  sjcl.random.addEntropy(Math.random(), 32, "Math.random()");
+}
+
 /**
  * Full domain hash based on SHA512
  */


### PR DESCRIPTION
When I run the following code, it will lead to `throw new sjcl.exception.notReady (" generator isn't seeded ");` 
So, I patched

```
var ripple  = require('ripple-lib');

config = {
  domain: 'www.rippletrade.com'
}

vaultClient = new ripple.VaultClient(config.domain)


vaultClient.register({
  username: 'kissripple1',
  password: 'password',
  email: 'mpr0xy@live.com',
  domain: config.domain,
  activateLink: config.domain + '/#/register/activate'
}, function(err, result){
  if (err){
    console.error(err)
  }
  else {
    console.dir(result)
  }
})
```
