### PR TITLE
[FIX] Cannot use demmurage currencies in path_find

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -2036,7 +2036,7 @@ Remote.prepareCurrencies = function(currency) {
   }
 
   if (currency.hasOwnProperty('currency')) {
-    newCurrency.currency = Currency.json_rewrite(currency.currency);
+    newCurrency.currency = Currency.json_rewrite(currency.currency, {force_hex:true});
   }
 
   return newCurrency;


### PR DESCRIPTION
Use hex format instead of json for currencies.
