### PR TITLE
Add a constant for the maximum number representable as a Ripple value

### DIFF
--- a/src/js/ripple/amount.js
+++ b/src/js/ripple/amount.js
@@ -33,6 +33,10 @@ var consts = exports.consts = {
 
   cMinOffset:        -96,
   cMaxOffset:        80,
+
+  // Maximum possible amount for non-XRP currencies using the maximum mantissa
+  // with maximum exponent. Corresponds to hex 0xEC6386F26FC0FFFF.
+  max_value:         '9999999999999999e80'
 };
 
 

--- a/src/js/ripple/serializedtypes.js
+++ b/src/js/ripple/serializedtypes.js
@@ -345,7 +345,7 @@ var STAmount = exports.Amount = new SerializedType({
 
         // Next eight bits: offset/exponent
         hi |= ((97 + amount._offset) & 0xff) << 22;
-        // Remaining 52 bits: mantissa
+        // Remaining 54 bits: mantissa
         hi |= amount._value.shiftRight(32).intValue() & 0x3fffff;
         lo = amount._value.intValue() & 0xffffffff;
       }

--- a/test/serializedtypes-test.js
+++ b/test/serializedtypes-test.js
@@ -2,6 +2,7 @@ var utils            = require('./testutils');
 var assert           = require('assert');
 var SerializedObject = utils.load_module('serializedobject').SerializedObject;
 var types            = utils.load_module('serializedtypes');
+var amountConstants  = require('../src/js/ripple/amount').consts;
 var BigInteger       = require('../src/js/jsbn/jsbn').BigInteger;
 
 var config = require('./testutils').get_config();
@@ -550,6 +551,11 @@ describe('Serialized types', function() {
       });
       assert.strictEqual(so.to_hex(), 'D5438D7EA4C68000015841551A748AD23FEFFFFFFFEA028000000000E4FE687C90257D3D2D694C8531CDEECBE84F3367');
     });
+    it('Serialize max_value/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
+      var so = new SerializedObject();
+      types.Amount.serialize(so, amountConstants.max_value+'/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+      assert.strictEqual(so.to_hex(), 'EC6386F26FC0FFFF0000000000000000000000005553440000000000B5F762798A53D543A014CAF8B297CFF8F2F937E8');
+    });
     it('Parse 1 XRP', function () {
       var so = new SerializedObject('4000000000000001');
       assert.strictEqual(types.Amount.parse(so).to_json(), '1');
@@ -581,6 +587,10 @@ describe('Serialized types', function() {
     it('Parse -1/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
       var so = new SerializedObject('94838D7EA4C680000000000000000000000000005553440000000000B5F762798A53D543A014CAF8B297CFF8F2F937E8');
       assert.strictEqual(types.Amount.parse(so).to_text_full(), '-1/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+    });
+    it('Parse max_value/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
+      var so = new SerializedObject('EC6386F26FC0FFFF0000000000000000000000005553440000000000B5F762798A53D543A014CAF8B297CFF8F2F937E8');
+      assert.strictEqual(types.Amount.parse(so).to_text_full(), amountConstants.max_value+'/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
     });
   });
 


### PR DESCRIPTION
Add a constant for the maximum canonical value that can be expressed as a Ripple value.

It is possible to express larger values in both the binary and JSON formats, but I believe that these would be invalid since they exceed the cMaxOffset and cMaxValue constants. See: https://github.com/ripple/rippled/blob/develop/src/ripple/module/data/protocol/STAmount.h#L42-46
