### PR TITLE
[FIX] return null for _getServer if there's no connected server

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -820,6 +820,10 @@ Remote.prototype.getServer = function() {
   }
 
   var connectedServers = this.getConnectedServers();
+  if (connectedServers.length === 0 || !connectedServers[0]) {
+    return null;
+  }
+
   var server = connectedServers[0];
   var cScore = server._score + server._fee;
 


### PR DESCRIPTION
_getServer would use an undefined server object if there were no connected servers, causing the server._score call to crash.
