### PR TITLE
[FIX] change handling of requestLedger options

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -949,10 +949,19 @@ Remote.prototype.requestLedger = function(options, callback) {
           case 'expand':
           case 'transactions':
           case 'accounts':
-          case 'ledger_index':
-          case 'ledger_hash':
             request.message[o] = true;
             break;
+            
+          case 'ledger_index':
+          case 'ledger_hash':
+            request.message[o] = options[o];
+            break;  
+            
+          case 'closed' :
+          case 'current' :
+          case 'validated' :
+            request.message.ledger_index = o;
+            break;  
         }
       }, options);
       break;


### PR DESCRIPTION
ledger_index and ledger_hash were being set to true
instead of the specified value, and according to API
docs 'closed','validated', and 'current' can be
supplied to the ledger_index field to get the most
recent of the specified type
