### PR TITLE
[FIX] make orderbook resubscribe if its already in remote._books

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -1794,6 +1794,12 @@ Remote.prototype.createOrderBook = function(currency_gets, issuer_gets, currency
   var key = gets + ':' + pays;
 
   if (this._books.hasOwnProperty(key)) {
+    
+    if (!this._books[key]._subscribed) {
+      this._books[key]._shouldSubscribe = true;
+      this._books[key].subscribe();
+    }
+    
     return this._books[key];
   }
 


### PR DESCRIPTION
if remote.book() is called for a previously created book,
the previously created book does not subscribe automatically
if it had been unsubscribed.  This caused stale order books in
the ripple trade client.
