### PR TITLE
[FIX] amount precision bugs

### DIFF
--- a/src/js/ripple/amount.js
+++ b/src/js/ripple/amount.js
@@ -1109,13 +1109,24 @@ Amount.prototype.to_human = function(opts) {
   fraction_part = fraction_part.replace(/0*$/, '');
 
   if (fraction_part.length || !opts.skip_empty_fraction) {
+
     // Enforce the maximum number of decimal digits (precision)
     if (typeof opts.precision === 'number') {
-      if (opts.precision <= 0 && fraction_part.charCodeAt(0) >= 53) {
-        int_part = (Number(int_part) + 1).toString();
+      if (opts.precision <= 0) {
+
+        // increment the int_part if the first decimal is 5 or higher
+        if (fraction_part.charCodeAt(0) >= 53) {
+          int_part = (Number(int_part) + 1).toString();
+        }
         fraction_part = '';
       } else {
         fraction_part = Math.round(fraction_part / Math.pow(10, fraction_part.length - opts.precision)).toString();
+
+        // because the division above will cut off the leading 0's we have to add them back again
+        // XXX look for a more elegant alternative
+        while (fraction_part.length < opts.precision) {
+          fraction_part = '0' + fraction_part;
+        }
       }
     }
 

--- a/test/amount-test.js
+++ b/test/amount-test.js
@@ -50,6 +50,36 @@ describe('Amount', function() {
     it('to human, precision 5', function() {
       assert.strictEqual(Amount.from_human("12345.678901234 XAU").to_human({precision:5}), '12,345.67890');
     });
+    it('to human, precision -1, should be ignored, precision needs to be >= 0', function() {
+      assert.strictEqual(Amount.from_human("0.00012345 XAU").to_human({precision:-1}), '0');
+    });
+    it('to human, precision 0', function() {
+      assert.strictEqual(Amount.from_human("0.00012345 XAU").to_human({precision:0}), '0');
+    });
+    it('to human, precision 1', function() {
+      assert.strictEqual(Amount.from_human("0.00012345 XAU").to_human({precision:1}), '0.0');
+    });
+    it('to human, precision 2', function() {
+      assert.strictEqual(Amount.from_human("0.00012345 XAU").to_human({precision:2}), '0.00');
+    });
+    it('to human, precision 5', function() {
+      assert.strictEqual(Amount.from_human("0.00012345 XAU").to_human({precision:5}), '0.00012');
+    });
+    it('to human, precision 6', function() {
+      assert.strictEqual(Amount.from_human("0.00012345 XAU").to_human({precision:6}), '0.000123');
+    });
+    it('to human, precision 16', function() {
+      assert.strictEqual(Amount.from_human("0.00012345 XAU").to_human({precision:16}), '0.0001234500000000');
+    });
+    it('to human, precision 0, first decimal 4', function() {
+      assert.strictEqual(Amount.from_human("0.4 XAU").to_human({precision:0}), '0');
+    });
+    it('to human, precision 0, first decimal 5', function() {
+      assert.strictEqual(Amount.from_human("0.5 XAU").to_human({precision:0}), '1');
+    });
+    it('to human, precision 0, first decimal 8', function() {
+      assert.strictEqual(Amount.from_human("0.8 XAU").to_human({precision:0}), '1');
+    });
   });
   describe('from_human', function() {
     it('1 XRP', function() {


### PR DESCRIPTION
- leading 0's for fraction part disappearing
- first decimal lower than 5 wouldn't result in dropping the decimal
