### PR TITLE
[FIX] transaction without explicit remote

### DIFF
--- a/src/js/ripple/transaction.js
+++ b/src/js/ripple/transaction.js
@@ -60,7 +60,7 @@ function Transaction(remote) {
 
   var self = this;
 
-  var remote = remote || { };
+  var remote = remote || void(0);
 
   this.remote = remote;
 
@@ -69,7 +69,7 @@ function Transaction(remote) {
 
   this._secret = void(0);
   this._build_path = false;
-  this._maxFee = this.remote.max_fee;
+  this._maxFee = (typeof remote === 'object') ? this.remote.max_fee : void(0);
 
   this.state = 'unsubmitted';
   this.finalized = false;
@@ -241,7 +241,7 @@ Transaction.prototype.finalize = function(message) {
 };
 
 Transaction.prototype._accountSecret = function(account) {
-  return this.remote.secrets[account];
+  return this.remote ? this.remote.secrets[account] : void(0);
 };
 
 /**
@@ -266,6 +266,10 @@ Transaction.prototype.feeUnits = function() {
  */
 
 Transaction.prototype._computeFee = function() {
+  if (!this.remote) {
+    return void(0);
+  }
+
   var servers = this.remote._servers;
   var fees = [ ];
 
@@ -897,6 +901,10 @@ Transaction.prototype.submit = function(callback) {
   this.on('error', function(){});
 
   var account = this.tx_json.Account;
+
+  if (!this.remote) {
+    return this.emit('error', new Error('No remote found'));
+  }
 
   if (!UInt160.is_valid(account)) {
     return this.emit('error', new RippleError('tejInvalidAccount', 'Account is missing or invalid'));

--- a/test/transaction-test.js
+++ b/test/transaction-test.js
@@ -229,6 +229,11 @@ describe('Transaction', function() {
     assert.strictEqual(transaction._computeFee(), '72');
   });
 
+  it('Compute fee, no remote', function() {
+    var transaction = new Transaction();
+    assert.strictEqual(transaction._computeFee(10), void(0));
+  });
+
   it('Compute fee - no connected server', function() {
     var remote = new Remote();
 
@@ -365,6 +370,16 @@ describe('Transaction', function() {
     transaction._secret = 'sh2pTicynUEG46jjR4EoexHcQEoij';
     transaction.tx_json.Account = 'rMWwx3Ma16HnqSd4H6saPisihX9aKpXxHJ';
     transaction.tx_json.Flags = 0;
+
+    assert(transaction.complete());
+
+    done();
+  });
+
+  it('Complete transaction, local signing, no remote', function(done) {
+    var transaction = new Transaction();
+    transaction._secret = 'sh2pTicynUEG46jjR4EoexHcQEoij';
+    transaction.tx_json.Account = 'rMWwx3Ma16HnqSd4H6saPisihX9aKpXxHJ';
 
     assert(transaction.complete());
 
@@ -1503,6 +1518,18 @@ describe('Transaction', function() {
     };
 
     transaction.submit(submitCallback);
+  });
+
+  it('Submit transaction - submission error, no remote', function(done) {
+    var transaction = new Transaction();
+
+    transaction.once('error', function(error) {
+      assert(error);
+      assert.strictEqual(error.message, 'No remote found');
+      done();
+    });
+
+    transaction.submit();
   });
 
   it('Submit transaction - invalid account', function(done) {


### PR DESCRIPTION
remote was instantiated as an object and checks through the class for
`this.remote` would pass and cause unintended behavior

e.g. `.complete()` would view an undefined remote as untrusted and not allow
local signing
