### PR TITLE
[FEATURE] add paging account request

### DIFF
--- a/src/js/ripple/orderbook.js
+++ b/src/js/ripple/orderbook.js
@@ -458,10 +458,11 @@ OrderBook.prototype.requestFundedAmount = function(account, callback) {
 
   function requestLineBalance(callback) {
     var request = self._remote.requestAccountLines(
-      account, // account
-      void(0), // account index
-      'VALIDATED', // ledger
-      self._issuerGets //peer
+      account,
+      {
+        ledger: 'validated',
+        peer: self._issuerGets
+      }
     );
 
     request.request(function(err, res) {

--- a/src/js/ripple/server.js
+++ b/src/js/ripple/server.js
@@ -564,7 +564,7 @@ Server.prototype._handleServerStatus = function(message) {
   this._remote.emit('load', message, this);
 
   var loadChanged = message.load_base !== this._load_base
-  || message.load_factor !== this._load_factor
+  || message.load_factor !== this._load_factor;
 
   if (loadChanged) {
     this._load_base = message.load_base;


### PR DESCRIPTION
some requests return results that can be paged through, e.g. `account_lines`
use `limit` and `marker` options to specify results per response and position
