### PR TITLE
Request ledger_accept returns the Request, not Remote

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -1659,7 +1659,7 @@ Remote.prototype.requestLedgerAccept = function(callback) {
   request.callback(callback, 'ledger_closed');
   request.request();
 
-  return this;
+  return request;
 };
 
 /**


### PR DESCRIPTION
Found when testing on a standalone rippled that the `ledger_accept` function was returning the remote, leaving the caller no way to modify, or add additional event listeners to the request.

This is probably a breaking change, but only against test code, since this function won't work against the "live" network.
