### PR TITLE
[FEATURE] improve memo support

### DIFF
--- a/src/js/ripple/binformat.js
+++ b/src/js/ripple/binformat.js
@@ -2,6 +2,9 @@
  * Data type map.
  *
  * Mapping of type ids to data types. The type id is specified by the high
+ *
+ * For reference, see rippled's definition:
+ * https://github.com/ripple/rippled/blob/develop/src/ripple/data/protocol/SField.cpp
  */
 var TYPES_MAP = exports.types = [
   void(0),
@@ -375,7 +378,7 @@ exports.ledger = {
     ['Balance',             REQUIRED],
     ['LowLimit',            REQUIRED],
     ['HighLimit',           REQUIRED]])
-}
+};
 
 exports.metadata = [
   [ 'TransactionIndex'     , REQUIRED ],

--- a/test/serializedobject-test.js
+++ b/test/serializedobject-test.js
@@ -35,6 +35,7 @@ describe('Serialized object', function() {
       assert.deepEqual(input_json, output_json);
     });
   });
+
   describe('#from_json', function() {
     it('understands TransactionType as a Number', function() {
       var input_json = {
@@ -52,6 +53,7 @@ describe('Serialized object', function() {
       assert.equal(0, input_json.TransactionType);
       assert.equal("Payment", output_json.TransactionType);
     });
+
     it('understands LedgerEntryType as a Number', function() {
       var input_json = {
         // no, non required fields
@@ -65,6 +67,7 @@ describe('Serialized object', function() {
       assert.equal(100, input_json.LedgerEntryType);
       assert.equal("DirectoryNode", output_json.LedgerEntryType);
     });
+
     describe('Format validation', function() {
       // Peercover actually had a problem submitting transactions without a `Fee`
       // and rippled was only informing of "transaction is invalid"
@@ -80,14 +83,198 @@ describe('Serialized object', function() {
         };
         assert.throws (
           function() {
-            var output_json = SerializedObject.from_json(input_json);
+            SerializedObject.from_json(input_json);
           },
           /Payment is missing fields: \["Fee"\]/
         );
       });
     });
 
-  })
+    describe('Memos', function() {
+
+      var input_json;
+
+      beforeEach(function()  {
+        input_json = {
+          "Flags": 2147483648,
+          "TransactionType": "Payment",
+          "Account": "rhXzSyt1q9J8uiFXpK3qSugAAPJKXLtnrF",
+          "Amount": "1",
+          "Destination": "radqi6ppXFxVhJdjzaATRBxdrPcVTf1Ung",
+          "Sequence": 281,
+          "SigningPubKey": "03D642E6457B8AB4D140E2C66EB4C484FAFB1BF267CB578EC4815FE6CD06379C51",
+          "Fee": "12000",
+          "LastLedgerSequence": 10074214,
+          "TxnSignature": "304402201180636F2CE215CE97A29CD302618FAE60D63EBFC8903DE17A356E857A449C430220290F4A54F9DE4AC79034C8BEA5F1F8757F7505F1A6FF04D2E19B6D62E867256B"
+        };
+      });
+
+      it('should serialize and parse - full memo, all strings text/plain ', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "text",
+              "MemoData": "some data"
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'text';
+        input_json.Memos[0].Memo.parsed_memo_data = 'some data';
+
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should serialize and parse - full memo, all strings, invalid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "application/json",
+              "MemoData": "some data"
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'application/json';
+        assert.deepEqual(so, input_json);
+        assert.strictEqual(input_json.Memos[0].Memo.parsed_memo_data, void(0));
+      });
+
+      it('should throw an error - full memo, json data, invalid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "text",
+              "MemoData": {
+                "string" : "some_string",
+                "boolean" : true
+              }
+            }
+          }
+        ];
+
+        assert.throws(function() {
+          SerializedObject.from_json(input_json);
+        }, /^Error: MemoData can only be a JSON object with a valid json MemoFormat \(Memo\) \(Memos\)/);
+      });
+
+      it('should serialize and parse - full memo, json data, valid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "json",
+              "ignored" : "ignored",
+              "MemoData": {
+                "string" : "some_string",
+                "boolean" : true
+              }
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        delete input_json.Memos[0].Memo.ignored;
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'json';
+        input_json.Memos[0].Memo.parsed_memo_data = {
+          "string" : "some_string",
+          "boolean" : true
+        };
+
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should serialize and parse - full memo, json data, valid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "json",
+              "MemoData": {
+                "string" : "some_string",
+                "boolean" : true
+              }
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'json';
+        input_json.Memos[0].Memo.parsed_memo_data = {
+          "string" : "some_string",
+          "boolean" : true
+        };
+
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should serialize and parse - full memo, json data, valid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "json",
+              "MemoData": 3
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'json';
+        input_json.Memos[0].Memo.parsed_memo_data = 3;
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should serialize and parse - full memo, json data, valid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "json",
+              "MemoData": 3
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'json';
+        input_json.Memos[0].Memo.parsed_memo_data = 3;
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should throw an error - invalid Memo field', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoParty": "json",
+              "MemoData": 3
+            }
+          }
+        ];
+
+        assert.throws(function() {
+          SerializedObject.from_json(input_json);
+        }, /^Error: JSON contains unknown field: "MemoParty" \(Memo\) \(Memos\)/);
+      });
+
+
+    });
+
+  });
+
+
 });
 
 


### PR DESCRIPTION
- add MemoFormat property for memo
- MemoFormat and MemoType must be valid ASCII
- Memo content is converted on the serialization level
- add parsed_\* version of Memo content if the parser understand the format
- support `text` and `json` MemoFormat
