### PR TITLE
[FEATURE] improve memo support

### DIFF
--- a/src/js/ripple/binformat.js
+++ b/src/js/ripple/binformat.js
@@ -2,6 +2,9 @@
  * Data type map.
  *
  * Mapping of type ids to data types. The type id is specified by the high
+ *
+ * For reference, see rippled's definition:
+ * https://github.com/ripple/rippled/blob/develop/src/ripple/data/protocol/SField.cpp
  */
 var TYPES_MAP = exports.types = [
   void(0),
@@ -375,7 +378,7 @@ exports.ledger = {
     ['Balance',             REQUIRED],
     ['LowLimit',            REQUIRED],
     ['HighLimit',           REQUIRED]])
-}
+};
 
 exports.metadata = [
   [ 'TransactionIndex'     , REQUIRED ],

--- a/src/js/ripple/serializedobject.js
+++ b/src/js/ripple/serializedobject.js
@@ -42,7 +42,7 @@ function SerializedObject(buf) {
 
 SerializedObject.from_json = function(obj) {
   // Create a copy of the object so we don't modify it
-  var obj = extend({}, obj);
+  var obj = extend(true, {}, obj);
   var so  = new SerializedObject();
   var typedef;
 

--- a/src/js/ripple/serializedtypes.js
+++ b/src/js/ripple/serializedtypes.js
@@ -24,6 +24,7 @@ var Currency  = amount.Currency;
 // Shortcuts
 var hex = sjcl.codec.hex;
 var bytes = sjcl.codec.bytes;
+var utf8 = sjcl.codec.utf8String;
 
 var BigInteger = utils.jsbn.BigInteger;
 
@@ -52,7 +53,7 @@ function isBigInteger(val) {
   return val instanceof BigInteger;
 };
 
-function serialize_hex(so, hexData, noLength) {
+function serializeHex(so, hexData, noLength) {
   var byteData = bytes.fromBits(hex.toBits(hexData));
   if (!noLength) {
     SerializedType.serialize_varint(so, byteData.length);
@@ -63,9 +64,17 @@ function serialize_hex(so, hexData, noLength) {
 /**
  * parses bytes as hex
  */
-function convert_bytes_to_hex (byte_array) {
+function convertByteArrayToHex (byte_array) {
   return sjcl.codec.hex.fromBits(sjcl.codec.bytes.toBits(byte_array)).toUpperCase();
 };
+
+function convertStringToHex(string) {
+  return hex.fromBits(utf8.toBits(string)).toUpperCase();
+}
+
+function convertHexToString(hexString) {
+  return utf8.fromBits(hex.toBits(hexString));
+}
 
 SerializedType.serialize_varint = function (so, val) {
   if (val < 0) {
@@ -115,7 +124,7 @@ SerializedType.prototype.parse_varint = function (so) {
  *
  * The result is appended to the serialized object ('so').
  */
-function append_byte_array(so, val, bytes) {
+function convertIntegerToByteArray(val, bytes) {
   if (!isNumber(val)) {
     throw new Error('Value is not a number', bytes);
   }
@@ -130,7 +139,7 @@ function append_byte_array(so, val, bytes) {
     newBytes.unshift(val >>> (i * 8) & 0xff);
   }
 
-  so.append(newBytes);
+  return newBytes;
 };
 
 // Convert a certain number of bytes from the serialized object ('so') into an integer.
@@ -152,7 +161,7 @@ function readAndSum(so, bytes) {
 
 var STInt8 = exports.Int8 = new SerializedType({
   serialize: function (so, val) {
-    append_byte_array(so, val, 1);
+    so.append(convertIntegerToByteArray(val, 1));
   },
   parse: function (so) {
     return readAndSum(so, 1);
@@ -163,7 +172,7 @@ STInt8.id = 16;
 
 var STInt16 = exports.Int16 = new SerializedType({
   serialize: function (so, val) {
-    append_byte_array(so, val, 2);
+    so.append(convertIntegerToByteArray(val, 2));
   },
   parse: function (so) {
     return readAndSum(so, 2);
@@ -174,7 +183,7 @@ STInt16.id = 1;
 
 var STInt32 = exports.Int32 = new SerializedType({
   serialize: function (so, val) {
-    append_byte_array(so, val, 4);
+    so.append(convertIntegerToByteArray(val, 4));
   },
   parse: function (so) {
     return readAndSum(so, 4);
@@ -217,7 +226,7 @@ var STInt64 = exports.Int64 = new SerializedType({
       hex = '0' + hex;
     }
 
-    serialize_hex(so, hex, true); //noLength = true
+    serializeHex(so, hex, true); //noLength = true
   },
   parse: function (so) {
     var bytes = so.read(8);
@@ -237,7 +246,7 @@ var STHash128 = exports.Hash128 = new SerializedType({
     if (!hash.is_valid()) {
       throw new Error('Invalid Hash128');
     }
-    serialize_hex(so, hash.to_hex(), true); //noLength = true
+    serializeHex(so, hash.to_hex(), true); //noLength = true
   },
   parse: function (so) {
     return UInt128.from_bytes(so.read(16));
@@ -252,7 +261,7 @@ var STHash256 = exports.Hash256 = new SerializedType({
     if (!hash.is_valid()) {
       throw new Error('Invalid Hash256');
     }
-    serialize_hex(so, hash.to_hex(), true); //noLength = true
+    serializeHex(so, hash.to_hex(), true); //noLength = true
   },
   parse: function (so) {
     return UInt256.from_bytes(so.read(32));
@@ -267,7 +276,7 @@ var STHash160 = exports.Hash160 = new SerializedType({
     if (!hash.is_valid()) {
       throw new Error('Invalid Hash160');
     }
-    serialize_hex(so, hash.to_hex(), true); //noLength = true
+    serializeHex(so, hash.to_hex(), true); //noLength = true
   },
   parse: function (so) {
     return UInt160.from_bytes(so.read(20));
@@ -294,7 +303,7 @@ var STCurrency = new SerializedType({
     //     UInt160 value and consider it valid. But it doesn't, so for the
     //     deserialization to be usable, we need to allow invalid results for now.
     //if (!currency.is_valid()) {
-    //  throw new Error('Invalid currency: '+convert_bytes_to_hex(bytes));
+    //  throw new Error('Invalid currency: '+convertByteArrayToHex(bytes));
     //}
     return currency;
   }
@@ -409,15 +418,16 @@ STAmount.id = 6;
 
 var STVL = exports.VariableLength = exports.VL = new SerializedType({
   serialize: function (so, val) {
+
     if (typeof val === 'string') {
-      serialize_hex(so, val);
+      serializeHex(so, val);
     } else {
       throw new Error('Unknown datatype.');
     }
   },
   parse: function (so) {
     var len = this.parse_varint(so);
-    return convert_bytes_to_hex(so.read(len));
+    return convertByteArrayToHex(so.read(len));
   }
 });
 
@@ -429,7 +439,7 @@ var STAccount = exports.Account = new SerializedType({
     if (!account.is_valid()) {
       throw new Error('Invalid account!');
     }
-    serialize_hex(so, account.to_hex());
+    serializeHex(so, account.to_hex());
   },
   parse: function (so) {
     var len = this.parse_varint(so);
@@ -441,7 +451,6 @@ var STAccount = exports.Account = new SerializedType({
     var result = UInt160.from_bytes(so.read(len));
     result.set_version(Base.VER_ACCOUNT_ID);
 
-    //console.log('PARSED 160:', result.to_json());
     if (false && !result.is_valid()) {
       throw new Error('Invalid Account');
     }
@@ -593,6 +602,105 @@ var STVector256 = exports.Vector256 = new SerializedType({
 
 STVector256.id = 19;
 
+// Internal
+var STMemo = exports.STMemo = new SerializedType({
+  serialize: function(so, val, no_marker) {
+
+    var keys = [];
+
+    Object.keys(val).forEach(function (key) {
+      // Ignore lowercase field names - they're non-serializable fields by
+      // convention.
+      if (key[0] === key[0].toLowerCase()) {
+        return;
+      }
+
+      if (typeof binformat.fieldsInverseMap[key] === 'undefined') {
+        throw new Error('JSON contains unknown field: "' + key + '"');
+      }
+
+      keys.push(key);
+    });
+
+    // Sort fields
+    keys = sort_fields(keys);
+
+    // store that we're dealing with json
+    var isJson = val.MemoFormat === 'json';
+
+    for (var i=0; i<keys.length; i++) {
+      var key = keys[i];
+      var value = val[key];
+      switch (key) {
+
+        // MemoType and MemoFormat are always ASCII strings
+        case 'MemoType':
+        case 'MemoFormat':
+          value = convertStringToHex(value);
+          break;
+
+        // MemoData can be a JSON object, otherwise it's a string
+        case 'MemoData':
+          if (typeof value !== 'string') {
+            if (isJson) {
+              try {
+                value = convertStringToHex(JSON.stringify(value));
+              } catch (e) {
+                throw new Error('MemoFormat json with invalid JSON in MemoData field');
+              }
+            } else {
+              throw new Error('MemoData can only be a JSON object with a valid json MemoFormat');
+            }
+          } else if (isString(value)) {
+            value = convertStringToHex(value);
+          }
+          break;
+      }
+
+      serialize(so, key, value);
+    }
+
+    if (!no_marker) {
+      //Object ending marker
+      STInt8.serialize(so, 0xe1);
+    }
+
+  },
+  parse: function(so) {
+    var output = {};
+    while (so.peek(1)[0] !== 0xe1) {
+      var keyval = parse(so);
+      output[keyval[0]] = keyval[1];
+    }
+
+    if (output['MemoType'] !== void(0)) {
+      output['parsed_memo_type'] = convertHexToString(output['MemoType']);
+    }
+
+    if (output['MemoFormat'] !== void(0)) {
+      output['parsed_memo_format'] = convertHexToString(output['MemoFormat']);
+    }
+
+    if (output['MemoData'] !== void(0)) {
+
+      // see if we can parse JSON
+      if (output['parsed_memo_format'] === 'json') {
+        try {
+          output['parsed_memo_data'] = JSON.parse(convertHexToString(output['MemoData']));
+        } catch(e) {
+          // fail, which is fine, we just won't add the memo_data field
+        }
+      } else if(output['parsed_memo_format'] === 'text') {
+        output['parsed_memo_data'] = convertHexToString(output['MemoData']);
+      }
+    }
+
+    so.read(1);
+    return output;
+  }
+
+});
+
 exports.serialize = exports.serialize_whatever = serialize;
 
 function serialize(so, field_name, value) {
@@ -622,9 +730,15 @@ function serialize(so, field_name, value) {
     STInt8.serialize(so, field_bits);
   }
 
-  // Get the serializer class (ST...) for a field based on the type bits.
-  var serialized_object_type = exports[binformat.types[type_bits]];
-  //do something with val[keys] and val[keys[i]];
+  // Get the serializer class (ST...)
+  var serialized_object_type;
+  if (field_name === 'Memo' && typeof value === 'object') {
+    // for Memo we override the default behavior with our STMemo serializer
+    serialized_object_type = exports.STMemo;
+  } else {
+    // for a field based on the type bits.
+    serialized_object_type = exports[binformat.types[type_bits]];
+  }
 
   try {
     serialized_object_type.serialize(so, value);
@@ -645,17 +759,20 @@ function parse(so) {
     type_bits = so.read(1)[0];
   }
 
-  // Get the parser class (ST...) for a field based on the type bits.
-  var type = exports[binformat.types[type_bits]];
-
-  assert(type, 'Unknown type - header byte is 0x' + tag_byte.toString(16));
 
   var field_bits = tag_byte & 0x0f;
   var field_name = (field_bits === 0)
-  ? field_name = binformat.fields[type_bits][so.read(1)[0]]
-  : field_name = binformat.fields[type_bits][field_bits];
+    ? field_name = binformat.fields[type_bits][so.read(1)[0]]
+    : field_name = binformat.fields[type_bits][field_bits];
 
   assert(field_name, 'Unknown field - header byte is 0x' + tag_byte.toString(16));
+
+  // Get the parser class (ST...) for a field based on the type bits.
+  var type = (field_name === 'Memo')
+    ? exports.STMemo
+    : exports[binformat.types[type_bits]];
+
+  assert(type, 'Unknown type - header byte is 0x' + tag_byte.toString(16));
 
   return [ field_name, type.parse(so) ]; //key, value
 };
@@ -678,18 +795,20 @@ function sort_fields(keys) {
 
 var STObject = exports.Object = new SerializedType({
   serialize: function (so, val, no_marker) {
-    var keys = Object.keys(val);
+    var keys = [];
 
-    // Ignore lowercase field names - they're non-serializable fields by
-    // convention.
-    keys = keys.filter(function (key) {
-      return key[0] !== key[0].toLowerCase();
-    });
+    Object.keys(val).forEach(function (key) {
+      // Ignore lowercase field names - they're non-serializable fields by
+      // convention.
+      if (key[0] === key[0].toLowerCase()) {
+        return;
+      }
 
-    keys.forEach(function (key) {
       if (typeof binformat.fieldsInverseMap[key] === 'undefined') {
         throw new Error('JSON contains unknown field: "' + key + '"');
       }
+
+      keys.push(key);
     });
 
     // Sort fields

--- a/test/serializedobject-test.js
+++ b/test/serializedobject-test.js
@@ -1,8 +1,23 @@
 var utils            = require('./testutils');
 var assert           = require('assert');
 var SerializedObject = utils.load_module('serializedobject').SerializedObject;
+var sjcl             = require('./../src/js/ripple/utils').sjcl;
+
+// Shortcuts
+var hex = sjcl.codec.hex;
+var bytes = sjcl.codec.bytes;
+var utf8 = sjcl.codec.utf8String;
 
 describe('Serialized object', function() {
+
+  function convertStringToHex(string) {
+    return hex.fromBits(utf8.toBits(string)).toUpperCase();
+  }
+
+  function convertHexToString(hexString) {
+    return utf8.fromBits(hex.toBits(hexString));
+  }
+
   describe('#from_json(v).to_json() == v', function(){
     it('outputs same as passed to from_json', function() {
       var input_json = {
@@ -35,6 +50,7 @@ describe('Serialized object', function() {
       assert.deepEqual(input_json, output_json);
     });
   });
+
   describe('#from_json', function() {
     it('understands TransactionType as a Number', function() {
       var input_json = {
@@ -52,6 +68,7 @@ describe('Serialized object', function() {
       assert.equal(0, input_json.TransactionType);
       assert.equal("Payment", output_json.TransactionType);
     });
+
     it('understands LedgerEntryType as a Number', function() {
       var input_json = {
         // no, non required fields
@@ -65,6 +82,7 @@ describe('Serialized object', function() {
       assert.equal(100, input_json.LedgerEntryType);
       assert.equal("DirectoryNode", output_json.LedgerEntryType);
     });
+
     describe('Format validation', function() {
       // Peercover actually had a problem submitting transactions without a `Fee`
       // and rippled was only informing of "transaction is invalid"
@@ -80,15 +98,231 @@ describe('Serialized object', function() {
         };
         assert.throws (
           function() {
-            var output_json = SerializedObject.from_json(input_json);
+            SerializedObject.from_json(input_json);
           },
           /Payment is missing fields: \["Fee"\]/
         );
       });
     });
 
-  })
-});
+    describe('Memos', function() {
 
+      var input_json;
+
+      beforeEach(function()  {
+        input_json = {
+          "Flags": 2147483648,
+          "TransactionType": "Payment",
+          "Account": "rhXzSyt1q9J8uiFXpK3qSugAAPJKXLtnrF",
+          "Amount": "1",
+          "Destination": "radqi6ppXFxVhJdjzaATRBxdrPcVTf1Ung",
+          "Sequence": 281,
+          "SigningPubKey": "03D642E6457B8AB4D140E2C66EB4C484FAFB1BF267CB578EC4815FE6CD06379C51",
+          "Fee": "12000",
+          "LastLedgerSequence": 10074214,
+          "TxnSignature": "304402201180636F2CE215CE97A29CD302618FAE60D63EBFC8903DE17A356E857A449C430220290F4A54F9DE4AC79034C8BEA5F1F8757F7505F1A6FF04D2E19B6D62E867256B"
+        };
+      });
+
+      it('should serialize and parse - full memo, all strings text/plain ', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "text",
+              "MemoData": "some data"
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'text';
+        input_json.Memos[0].Memo.parsed_memo_data = 'some data';
+        input_json.Memos[0].Memo.MemoType = convertStringToHex('test');
+        input_json.Memos[0].Memo.MemoFormat = convertStringToHex('text');
+        input_json.Memos[0].Memo.MemoData = convertStringToHex('some data');
+
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should serialize and parse - full memo, all strings, invalid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "application/json",
+              "MemoData": "some data"
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'application/json';
+        input_json.Memos[0].Memo.MemoType = convertStringToHex('test');
+        input_json.Memos[0].Memo.MemoFormat = convertStringToHex('application/json');
+        input_json.Memos[0].Memo.MemoData = convertStringToHex('some data');
+
+        assert.deepEqual(so, input_json);
+        assert.strictEqual(input_json.Memos[0].Memo.parsed_memo_data, void(0));
+      });
+
+      it('should throw an error - full memo, json data, invalid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "text",
+              "MemoData": {
+                "string" : "some_string",
+                "boolean" : true
+              }
+            }
+          }
+        ];
+
+        assert.throws(function() {
+          SerializedObject.from_json(input_json);
+        }, /^Error: MemoData can only be a JSON object with a valid json MemoFormat \(Memo\) \(Memos\)/);
+      });
+
+      it('should serialize and parse - full memo, json data, valid MemoFormat, ignored field', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "json",
+              "ignored" : "ignored",
+              "MemoData": {
+                "string" : "some_string",
+                "boolean" : true
+              }
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        delete input_json.Memos[0].Memo.ignored;
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'json';
+        input_json.Memos[0].Memo.parsed_memo_data = {
+          "string" : "some_string",
+          "boolean" : true
+        };
+        input_json.Memos[0].Memo.MemoType = convertStringToHex('test');
+        input_json.Memos[0].Memo.MemoFormat = convertStringToHex('json');
+        input_json.Memos[0].Memo.MemoData = convertStringToHex(JSON.stringify(
+          {
+            "string" : "some_string",
+            "boolean" : true
+          }
+        ));
+
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should serialize and parse - full memo, json data, valid MemoFormat', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "json",
+              "MemoData": {
+                "string" : "some_string",
+                "boolean" : true
+              }
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'json';
+        input_json.Memos[0].Memo.parsed_memo_data = {
+          "string" : "some_string",
+          "boolean" : true
+        };
+        input_json.Memos[0].Memo.MemoType = convertStringToHex('test');
+        input_json.Memos[0].Memo.MemoFormat = convertStringToHex('json');
+        input_json.Memos[0].Memo.MemoData = convertStringToHex(JSON.stringify(
+          {
+            "string" : "some_string",
+            "boolean" : true
+          }
+        ));
+
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should serialize and parse - full memo, json data, valid MemoFormat, integer', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoFormat": "json",
+              "MemoData": 3
+            }
+          }
+        ];
+
+        var so = SerializedObject.from_json(input_json).to_json();
+        input_json.Memos[0].Memo.parsed_memo_type = 'test';
+        input_json.Memos[0].Memo.parsed_memo_format = 'json';
+        input_json.Memos[0].Memo.parsed_memo_data = 3;
+        input_json.Memos[0].Memo.MemoType = convertStringToHex('test');
+        input_json.Memos[0].Memo.MemoFormat = convertStringToHex('json');
+        input_json.Memos[0].Memo.MemoData = convertStringToHex(JSON.parse(3));
+        assert.deepEqual(so, input_json);
+      });
+
+      it('should throw an error - invalid Memo field', function() {
+        input_json.Memos = [
+          {
+            "Memo": {
+              "MemoType": "test",
+              "MemoParty": "json",
+              "MemoData": 3
+            }
+          }
+        ];
+
+        assert.throws(function() {
+          SerializedObject.from_json(input_json);
+        }, /^Error: JSON contains unknown field: "MemoParty" \(Memo\) \(Memos\)/);
+      });
+
+
+      it('should serialize json with memo - match hex output', function() {
+        var input_json = {
+          Flags: 2147483648,
+          TransactionType: 'Payment',
+          Account: 'rhXzSyt1q9J8uiFXpK3qSugAAPJKXLtnrF',
+          Amount: '1',
+          Destination: 'radqi6ppXFxVhJdjzaATRBxdrPcVTf1Ung',
+          Memos: [
+            {
+              Memo: {
+                MemoType: 'image'
+              }
+            }
+          ],
+          Sequence: 294,
+          SigningPubKey: '03D642E6457B8AB4D140E2C66EB4C484FAFB1BF267CB578EC4815FE6CD06379C51',
+          Fee: '12000',
+          LastLedgerSequence: 10404607,
+          TxnSignature: '304402206B53EDFA6EFCF6FE5BA76C81BABB60A3B55E9DE8A1462DEDC5F387879575E498022015AE7B59AA49E735D7F2E252802C4406CD00689BCE5057C477FE979D38D2DAC9'
+        };
+
+        var serializedHex = '12000022800000002400000126201B009EC2FF614000000000000001684000000000002EE0732103D642E6457B8AB4D140E2C66EB4C484FAFB1BF267CB578EC4815FE6CD06379C517446304402206B53EDFA6EFCF6FE5BA76C81BABB60A3B55E9DE8A1462DEDC5F387879575E498022015AE7B59AA49E735D7F2E252802C4406CD00689BCE5057C477FE979D38D2DAC9811426C4CFB3BD05A9AA23936F2E81634C66A9820C9483143DD06317D19C6110CAFF150AE528F58843BE2CA1F9EA7C05696D616765E1F1';
+        assert.strictEqual(SerializedObject.from_json(input_json).to_hex(), serializedHex);
+
+      });
+
+    });
+
+  });
+
+});
 
 // vim:sw=2:sts=2:ts=8:et

--- a/test/transaction-test.js
+++ b/test/transaction-test.js
@@ -1051,26 +1051,84 @@ describe('Transaction', function() {
     var transaction = new Transaction();
     transaction.tx_json.TransactionType = 'Payment';
 
-    transaction.addMemo('testkey', 'testvalue');
-    transaction.addMemo('testkey2', 'testvalue2');
-    transaction.addMemo('testkey3');
-    transaction.addMemo(void(0), 'testvalue4');
+    var memoType = 'message';
+    var memoFormat = 'application/json';
+    var memoData = {
+      string: 'value',
+      bool: true,
+      integer: 1
+    };
+
+    transaction.addMemo(memoType, memoFormat, memoData);
+
+    var expected = [
+      {
+        Memo:
+        {
+          MemoType: memoType,
+          MemoFormat: memoFormat,
+          MemoData: memoData
+        }
+      }
+    ];
+
+    assert.deepEqual(transaction.tx_json.Memos, expected);
+  });
+
+  it('Add Memo - by object', function() {
+    var transaction = new Transaction();
+    transaction.tx_json.TransactionType = 'Payment';
+
+    var memo = {
+      memoType: 'type',
+      memoData: 'data'
+    };
+
+    transaction.addMemo(memo);
+
+    var expected = [
+      {
+        Memo: {
+          MemoType: memo.memoType,
+          MemoData: memo.memoData
+        }
+      }
+    ];
+
+    assert.deepEqual(transaction.tx_json.Memos, expected);
+  });
+
+  it('Add Memos', function() {
+    var transaction = new Transaction();
+    transaction.tx_json.TransactionType = 'Payment';
+
+    transaction.addMemo('testkey', void(0), 'testvalue');
+    transaction.addMemo('testkey2', void(0), 'testvalue2');
+    transaction.addMemo('testkey3', 'text/html');
+    transaction.addMemo(void(0), void(0), 'testvalue4');
+    transaction.addMemo('testkey4', 'text/html', '<html>');
 
     var expected = [
       { Memo: {
-        MemoType: new Buffer('testkey').toString('hex'),
-        MemoData: new Buffer('testvalue').toString('hex')
+        MemoType: 'testkey',
+        MemoData: 'testvalue'
       }},
       { Memo: {
-        MemoType: new Buffer('testkey2').toString('hex'),
-        MemoData: new Buffer('testvalue2').toString('hex')
+        MemoType: 'testkey2',
+        MemoData: 'testvalue2'
       }},
       { Memo: {
-        MemoType: new Buffer('testkey3').toString('hex')
+        MemoType: 'testkey3',
+        MemoFormat: 'text/html'
       }},
       { Memo: {
-        MemoData: new Buffer('testvalue4').toString('hex')
-      } }
+        MemoData: 'testvalue4'
+      }},
+      { Memo: {
+        MemoType: 'testkey4',
+        MemoFormat: 'text/html',
+        MemoData: '<html>'
+      }}
     ];
 
     assert.deepEqual(transaction.tx_json.Memos, expected);
@@ -1085,13 +1143,76 @@ describe('Transaction', function() {
     }, /^Error: MemoType must be a string$/);
   });
 
-  it('Add Memo - invalid MemoData', function() {
+  it('Add Memo - invalid ASCII MemoType', function() {
     var transaction = new Transaction();
     transaction.tx_json.TransactionType = 'Payment';
 
     assert.throws(function() {
-      transaction.addMemo('key', 1);
-    }, /^Error: MemoData must be a string$/);
+      transaction.addMemo('한국어');
+    }, /^Error: MemoType must be valid ASCII$/);
+  });
+
+  it('Add Memo - invalid MemoFormat', function() {
+    var transaction = new Transaction();
+    transaction.tx_json.TransactionType = 'Payment';
+
+    assert.throws(function() {
+      transaction.addMemo(void(0), 1);
+    }, /^Error: MemoFormat must be a string$/);
+  });
+
+  it('Add Memo - invalid ASCII MemoFormat', function() {
+    var transaction = new Transaction();
+    transaction.tx_json.TransactionType = 'Payment';
+
+    assert.throws(function() {
+      transaction.addMemo(void(0), 'России');
+    }, /^Error: MemoFormat must be valid ASCII$/);
+  });
+
+  it('Add Memo - MemoData string', function() {
+    var transaction = new Transaction();
+    transaction.tx_json.TransactionType = 'Payment';
+
+    transaction.addMemo({memoData:'some_string'});
+
+    assert.deepEqual(transaction.tx_json.Memos, [
+      {
+        Memo: {
+          MemoData: 'some_string'
+        }
+      }
+    ]);
+  });
+
+  it('Add Memo - MemoData complex object', function() {
+    var transaction = new Transaction();
+    transaction.tx_json.TransactionType = 'Payment';
+
+    var memo = {
+      memoData: {
+        string: 'string',
+        int: 1,
+        array: [
+          {
+            string: 'string'
+          }
+        ],
+        object: {
+          string: 'string'
+        }
+      }
+    };
+
+    transaction.addMemo(memo);
+
+    assert.deepEqual(transaction.tx_json.Memos, [
+      {
+        Memo: {
+          MemoData: memo.memoData
+        }
+      }
+    ]);
   });
 
   it('Construct AccountSet transaction', function() {
@@ -1268,7 +1389,7 @@ describe('Transaction', function() {
     var bid = '1/USD/rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm';
     var ask = '1/EUR/rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm';
     assert.throws(function() {
-      var transaction = new Transaction().offerCreate('xrsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm', bid, ask);
+      new Transaction().offerCreate('xrsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm', bid, ask);
     });
   });
 
@@ -1301,13 +1422,13 @@ describe('Transaction', function() {
 
   it('Construct SetRegularKey transaction - invalid account', function() {
     assert.throws(function() {
-      var transaction = new Transaction().setRegularKey('xrsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm', 'r36xtKNKR43SeXnGn7kN4r4JdQzcrkqpWe');
+      new Transaction().setRegularKey('xrsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm', 'r36xtKNKR43SeXnGn7kN4r4JdQzcrkqpWe');
     });
   });
 
   it('Construct SetRegularKey transaction - invalid regularKey', function() {
     assert.throws(function() {
-      var transaction = new Transaction().setRegularKey('rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm', 'xr36xtKNKR43SeXnGn7kN4r4JdQzcrkqpWe');
+      new Transaction().setRegularKey('rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm', 'xr36xtKNKR43SeXnGn7kN4r4JdQzcrkqpWe');
     });
   });
 


### PR DESCRIPTION
- add MemoFormat property for memo
- MemoFormat and MemoType must be valid ASCII
- Memo content is converted on the serialization level
- add parsed_\* version of Memo content if the parser understand the format
- support `text` and `json` MemoFormat

[FIX] double serialization overriding Memo contents

The copy made in from_json wasn't a deep copy
