### PR TITLE
Update Meta.parseBalanceChanges

### DIFF
--- a/src/js/ripple/amount.js
+++ b/src/js/ripple/amount.js
@@ -1257,23 +1257,6 @@ Amount.prototype.to_json = function() {
   return result;
 };
 
-Amount.prototype.toJSON = function() {
-  if (this._is_native) {
-    return {
-      issuer: '',
-      currency: 'XRP',
-      value: dropsToXrp(this.to_text())
-    };
-  } else {
-    return {
-      issuer: this._issuer.to_json(),
-      currency: this._currency.has_interest() ?
-        this._currency.to_hex() : this._currency.to_json().toString(),
-      value: this.to_text()
-    };
-  }
-};
-
 Amount.prototype.to_text_full = function(opts) {
   return this._value instanceof BigInteger
     ? this._is_native

--- a/test/fixtures/payment-redeems-then-issues.json
+++ b/test/fixtures/payment-redeems-then-issues.json
@@ -1,0 +1,83 @@
+{
+   "result" : {
+      "Account" : "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+      "Amount" : {
+         "currency" : "USD",
+         "issuer" : "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+         "value" : "200"
+      },
+      "Destination" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "Fee" : "10",
+      "Flags" : 2147483648,
+      "Sequence" : 3,
+      "SigningPubKey" : "02691AC5AE1C4C333AE5DF8A93BDC495F0EEBFC6DB0DA7EB6EF808F3AFC006E3FE",
+      "TransactionType" : "Payment",
+      "TxnSignature" : "304402207068EDB074FE388DB198A5D3B51A2846BB937F76F558D2D9245B11A20DFD5DAF022055A5B5D65C637A34C48361AFD0E97780D6FAED98A4221CE0838EE3598C0EECDE",
+      "date" : 472374260,
+      "hash" : "8EE52E8CC50AB0841A34E755E882BBC50F855A750AC954D7E7050E71672BE77E",
+      "inLedger" : 8,
+      "ledger_index" : 8,
+      "meta" : {
+         "AffectedNodes" : [
+            {
+               "ModifiedNode" : {
+                  "FinalFields" : {
+                     "Balance" : {
+                        "currency" : "USD",
+                        "issuer" : "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                        "value" : "100"
+                     },
+                     "Flags" : 196608,
+                     "HighLimit" : {
+                        "currency" : "USD",
+                        "issuer" : "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                        "value" : "500"
+                     },
+                     "HighNode" : "0000000000000000",
+                     "LowLimit" : {
+                        "currency" : "USD",
+                        "issuer" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                        "value" : "500"
+                     },
+                     "LowNode" : "0000000000000000"
+                  },
+                  "LedgerEntryType" : "RippleState",
+                  "LedgerIndex" : "88DA36A0E2F92E2E3504DC7936FDB719769486A6BE1BEC4F1E3B580538D28B4A",
+                  "PreviousFields" : {
+                     "Balance" : {
+                        "currency" : "USD",
+                        "issuer" : "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                        "value" : "-100"
+                     }
+                  },
+                  "PreviousTxnID" : "951C7AB715ECF4E2B2254F336D9529783AE924E8B4784884E45EA0697ED78B61",
+                  "PreviousTxnLgrSeq" : 7
+               }
+            },
+            {
+               "ModifiedNode" : {
+                  "FinalFields" : {
+                     "Account" : "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                     "Balance" : "999999970",
+                     "Flags" : 0,
+                     "OwnerCount" : 1,
+                     "Sequence" : 4
+                  },
+                  "LedgerEntryType" : "AccountRoot",
+                  "LedgerIndex" : "DE3BE7FDF6864FB024807B36BFCB4607E7CDA7D4C155C7AFB4B0973D638938BF",
+                  "PreviousFields" : {
+                     "Balance" : "999999980",
+                     "Sequence" : 3
+                  },
+                  "PreviousTxnID" : "8D380F8548020FAF6CD42D0E9EDA92B51D4D7DDC4327644893CA1F24688F3715",
+                  "PreviousTxnLgrSeq" : 6
+               }
+            }
+         ],
+         "TransactionIndex" : 0,
+         "TransactionResult" : "tesSUCCESS"
+      },
+      "status" : "success",
+      "validated" : true
+   }
+}

--- a/test/fixtures/payment-redeems.json
+++ b/test/fixtures/payment-redeems.json
@@ -1,0 +1,83 @@
+{
+   "result" : {
+      "Account" : "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+      "Amount" : {
+         "currency" : "USD",
+         "issuer" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "value" : "100"
+      },
+      "Destination" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "Fee" : "10",
+      "Flags" : 2147483648,
+      "Sequence" : 2,
+      "SigningPubKey" : "02691AC5AE1C4C333AE5DF8A93BDC495F0EEBFC6DB0DA7EB6EF808F3AFC006E3FE",
+      "TransactionType" : "Payment",
+      "TxnSignature" : "304402205523DC0073C7F7DB92765367526A7A2CF1B6E2A42C6B102E96F58FC69689CBF60220371264F1472C6694F8453506503351B256722274CE1324E2B3B1885C18485D59",
+      "date" : 472366860,
+      "hash" : "44AA46A2728AD7A7E856B27D8815D935D174F63CAA60E4BD90C5CC74D440E753",
+      "inLedger" : 6,
+      "ledger_index" : 6,
+      "meta" : {
+         "AffectedNodes" : [
+            {
+               "ModifiedNode" : {
+                  "FinalFields" : {
+                     "Balance" : {
+                        "currency" : "USD",
+                        "issuer" : "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                        "value" : "-100"
+                     },
+                     "Flags" : 131072,
+                     "HighLimit" : {
+                        "currency" : "USD",
+                        "issuer" : "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                        "value" : "500"
+                     },
+                     "HighNode" : "0000000000000000",
+                     "LowLimit" : {
+                        "currency" : "USD",
+                        "issuer" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                        "value" : "0"
+                     },
+                     "LowNode" : "0000000000000000"
+                  },
+                  "LedgerEntryType" : "RippleState",
+                  "LedgerIndex" : "88DA36A0E2F92E2E3504DC7936FDB719769486A6BE1BEC4F1E3B580538D28B4A",
+                  "PreviousFields" : {
+                     "Balance" : {
+                        "currency" : "USD",
+                        "issuer" : "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                        "value" : "-200"
+                     }
+                  },
+                  "PreviousTxnID" : "C0AA2D9C82E68C06F81340B633D36EA983A834F6377FA18139D4EE7AA6A2973D",
+                  "PreviousTxnLgrSeq" : 5
+               }
+            },
+            {
+               "ModifiedNode" : {
+                  "FinalFields" : {
+                     "Account" : "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+                     "Balance" : "999999980",
+                     "Flags" : 0,
+                     "OwnerCount" : 1,
+                     "Sequence" : 3
+                  },
+                  "LedgerEntryType" : "AccountRoot",
+                  "LedgerIndex" : "DE3BE7FDF6864FB024807B36BFCB4607E7CDA7D4C155C7AFB4B0973D638938BF",
+                  "PreviousFields" : {
+                     "Balance" : "999999990",
+                     "Sequence" : 2
+                  },
+                  "PreviousTxnID" : "88CD25B9BF28097156E1EA79281994FFD002EE3D3F67E99ED791C38DA3967CB6",
+                  "PreviousTxnLgrSeq" : 4
+               }
+            }
+         ],
+         "TransactionIndex" : 0,
+         "TransactionResult" : "tesSUCCESS"
+      },
+      "status" : "success",
+      "validated" : true
+   }
+}

--- a/test/metadata-test.js
+++ b/test/metadata-test.js
@@ -1,6 +1,11 @@
 var assert = require('assert');
 var fs = require('fs');
 var Meta = require('ripple-lib').Meta;
+var Amount = require('ripple-lib').Amount;
+
+function logj(a) {
+  console.log(JSON.stringify(a, undefined, 2));
+}
 
 // Pay 100 XRP from rKmB to rLDY to create rLDY account
 var createAccountBalanceChanges = [
@@ -121,57 +126,124 @@ var deleteTrustlineBalanceChanges = [
 // Set trust limit to zero on rLDY when it has a balance of 0.02 USD
 var removeTrustBalanceChanges = setTrustlineBalanceChanges;
 
-
 function loadFixture(filename) {
   var path = __dirname + '/fixtures/' + filename;
   return JSON.parse(fs.readFileSync(path));
 }
 
-function parseBalanceChanges(metadata) {
+/*
+* Our expectations are declared using ripple-rest style amounts where we use
+* an object, and the amount `value` is in XRP scale, not drops.
+*
+* We use use some JSON.stringify hackery to get the balance changes in the same
+* format as our expectations.
+*/
+function findBalanceChanges(metadata) {
+  function transformer(key, o) {
+    function rippleRestStyleAmountJSON() {
+      return this._is_native ?
+              {value: this.to_human(), currency: 'XRP',  issuer: ''} :
+               this.to_json();
+    };
+    return o instanceof Amount ? rippleRestStyleAmountJSON.call(o) : o;
+  }
+
   var meta = new Meta(metadata);
-  return JSON.parse(JSON.stringify(meta.parseBalanceChanges()));
+  var changes = JSON.stringify(meta.parseBalanceChanges(), transformer);
+  return JSON.parse(changes);
 }
 
 describe('parseBalanceChanges', function() {
   it('XRP create account', function() {
     var paymentResponse = loadFixture('payment-xrp-create-account.json');
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
     assert.deepEqual(result, createAccountBalanceChanges);
   });
   it('USD payment to account with no USD', function() {
     var filename = 'payment-iou-destination-no-balance.json';
     var paymentResponse = loadFixture(filename);
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
     assert.deepEqual(result, usdFirstPaymentBalanceChanges);
   });
   it('USD payment of all USD in source account', function() {
     var paymentResponse = loadFixture('payment-iou-spend-full-balance.json');
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
     assert.deepEqual(result, usdFullPaymentBalanceChanges);
   });
   it('USD payment to account with USD', function() {
     var paymentResponse = loadFixture('payment-iou.json');
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
     assert.deepEqual(result, usdPaymentBalanceChanges);
   });
   it('Set trust limit to 0 with balance remaining', function() {
     var paymentResponse = loadFixture('trustline-set-limit-to-zero.json');
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
     assert.deepEqual(result, removeTrustBalanceChanges);
   });
   it('Create trustline', function() {
     var paymentResponse = loadFixture('trustline-create.json');
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
+    // logj(result)
     assert.deepEqual(result, createTrustlineBalanceChanges);
   });
   it('Set trustline', function() {
     var paymentResponse = loadFixture('trustline-set-limit.json');
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
     assert.deepEqual(result, setTrustlineBalanceChanges);
   });
   it('Delete trustline', function() {
     var paymentResponse = loadFixture('trustline-delete.json');
-    var result = parseBalanceChanges(paymentResponse.metadata);
+    var result = findBalanceChanges(paymentResponse.metadata);
     assert.deepEqual(result, deleteTrustlineBalanceChanges);
+  });
+  it('Payment redeems', function() {
+    var expected = [
+      // Balance as oriented to address to issuer is -100
+      {
+        "address": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+        "balance_change": {
+          "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+          "currency": "USD",
+          "value": "-100"
+        }
+      },
+      {
+        "address": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+        "balance_change": {
+          "issuer": "",
+          "currency": "XRP",
+          "value": "-0.00001"
+        }
+      }
+    ]
+    var filename = 'payment-redeems.json';
+    var paymentResponse = loadFixture(filename);
+    var result = findBalanceChanges(paymentResponse.result.meta);
+    // logj(result)
+    assert.deepEqual(result, expected);
+  });
+  it('Payment redeems then issues', function() {
+    var expected = [
+      {
+        "address": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "balance_change": {
+          "issuer": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+          "currency": "USD",
+          "value": "200"
+        }
+      },
+      {
+        "address": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+        "balance_change": {
+          "issuer": "",
+          "currency": "XRP",
+          "value": "-0.00001"
+        }
+      }
+    ]
+    var filename = 'payment-redeems-then-issues.json';
+    var paymentResponse = loadFixture(filename);
+    var result = findBalanceChanges(paymentResponse.result.meta);
+    assert.deepEqual(result, expected);
   });
 });


### PR DESCRIPTION
It was hard to understand the intent of the recent changes, so I could have misunderstood it, but it seemed like it wanted to group balance changes in a way, that the `address` was not an issuer ( gateway).  

In any case, I added two test cases. We should at least add these and define the expected balance changes.

The changes: 
- Remove Amount.toJSON as it introduces XRP semantics changes.
- In any balance change address and issuer will never be equal.
- Attempt to put `balance_change.issuer` as account that is
  issuer in the sense of having a negative balance (or ability to). 
  The address is the opposite account on the line.

The changes in logic pass all previous tests, but also the new test cases with redeeming and redeeming becoming issuing. I believe we should consider/discuss use cases, before adding these sorts of thing to ripple-lib. Also, If we want to ripple-restify amount representation, it would be good to do so in a planned manner.
