### PR TITLE
fix: disallow two pending requests with the same id

### DIFF
--- a/src/client/requestManager.ts
+++ b/src/client/requestManager.ts
@@ -138,7 +138,10 @@ export default class RequestManager {
    * @throws ResponseFormatError if the response format is invalid, RippledError if rippled returns an error.
    */
   public handleResponse(response: Partial<Response | ErrorResponse>): void {
-    if (response.id == null) {
+    if (
+      response.id == null ||
+      !(typeof response.id === 'string' || typeof response.id === 'number')
+    ) {
       throw new ResponseFormatError('valid id not found in response', response)
     }
     if (!this.promisesAwaitingResponse.has(response.id)) {

--- a/src/client/requestManager.ts
+++ b/src/client/requestManager.ts
@@ -1,4 +1,9 @@
-import { ResponseFormatError, RippledError, TimeoutError } from '../errors'
+import {
+  ResponseFormatError,
+  RippledError,
+  TimeoutError,
+  XrplError,
+} from '../errors'
 import { Response } from '../models/methods'
 import { BaseRequest, ErrorResponse } from '../models/methods/baseMethod'
 
@@ -77,6 +82,7 @@ export default class RequestManager {
   public rejectAll(error: Error): void {
     this.promisesAwaitingResponse.forEach((_promise, id, _map) => {
       this.reject(id, error)
+      this.deletePromise(id)
     })
   }
 
@@ -110,6 +116,9 @@ export default class RequestManager {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Reason above.
     if (timer.unref) {
       timer.unref()
+    }
+    if (this.promisesAwaitingResponse.has(newId)) {
+      throw new XrplError(`Response with id ${newId} is already pending`)
     }
     const newPromise = new Promise<Response>(
       (resolve: (value: Response | PromiseLike<Response>) => void, reject) => {

--- a/src/client/requestManager.ts
+++ b/src/client/requestManager.ts
@@ -93,8 +93,13 @@ export default class RequestManager {
     request: T,
     timeout: number,
   ): [string | number, string, Promise<Response>] {
-    const newId = request.id ? request.id : this.nextId
-    this.nextId += 1
+    let newId: string | number
+    if (request.id == null) {
+      newId = this.nextId
+      this.nextId += 1
+    } else {
+      newId = request.id
+    }
     const newRequest = JSON.stringify({ ...request, id: newId })
     const timer = setTimeout(
       () => this.reject(newId, new TimeoutError()),

--- a/src/client/requestManager.ts
+++ b/src/client/requestManager.ts
@@ -94,6 +94,7 @@ export default class RequestManager {
    * @param request - Request to create.
    * @param timeout - Timeout length to catch hung responses.
    * @returns Request ID, new request form, and the promise for resolving the request.
+   * @throws XrplError if request with the same ID is already pending.
    */
   public createRequest<T extends BaseRequest>(
     request: T,
@@ -118,7 +119,7 @@ export default class RequestManager {
       timer.unref()
     }
     if (this.promisesAwaitingResponse.has(newId)) {
-      throw new XrplError(`Response with id ${newId} is already pending`)
+      throw new XrplError(`Response with id '${newId}' is already pending`)
     }
     const newPromise = new Promise<Response>(
       (resolve: (value: Response | PromiseLike<Response>) => void, reject) => {
@@ -137,11 +138,7 @@ export default class RequestManager {
    * @throws ResponseFormatError if the response format is invalid, RippledError if rippled returns an error.
    */
   public handleResponse(response: Partial<Response | ErrorResponse>): void {
-    if (
-      response.id == null ||
-      !Number.isInteger(response.id) ||
-      response.id < 0
-    ) {
+    if (response.id == null) {
       throw new ResponseFormatError('valid id not found in response', response)
     }
     if (!this.promisesAwaitingResponse.has(response.id)) {

--- a/src/client/requestManager.ts
+++ b/src/client/requestManager.ts
@@ -179,7 +179,6 @@ export default class RequestManager {
    * @param id - ID of the request.
    */
   private deletePromise(id: string | number): void {
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Needs to delete promise after request has been fulfilled.
-    delete this.promisesAwaitingResponse[id]
+    this.promisesAwaitingResponse.delete(id)
   }
 }

--- a/test/client/submitSignedTransaction.ts
+++ b/test/client/submitSignedTransaction.ts
@@ -62,7 +62,7 @@ describe('client.submitSignedTransaction', function () {
 
     this.mockRippled.addResponse('submit', rippled.submit.success)
 
-    assertRejects(
+    await assertRejects(
       this.client.submitSignedTransaction(signedTx),
       ValidationError,
       'Transaction must be signed',

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -621,9 +621,16 @@ describe('Connection', function () {
   })
 
   it('should throw error if pending response with same ID', async function () {
-    await this.client.connection.request({ id: 'test', command: 'ping' })
-    assertRejects(
-      this.client.connection.request({ id: 'test', command: 'ping' }),
+    const promise1 = this.client.connection.request({
+      id: 'test',
+      command: 'ping',
+    })
+    const promise2 = this.client.connection.request({
+      id: 'test',
+      command: 'ping',
+    })
+    await assertRejects(
+      Promise.all([promise1, promise2]),
       XrplError,
       "Response with id 'test' is already pending",
     )

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -514,13 +514,13 @@ describe('Connection', function () {
     this.client.on('error', (errorCode, errorMessage, message) => {
       assert.strictEqual(errorCode, 'badMessage')
       assert.strictEqual(errorMessage, 'valid id not found in response')
-      assert.strictEqual(message, '{"type":"response","id":"must be integer"}')
+      assert.strictEqual(message, '{"type":"response","id":{}}')
       done()
     })
     this.client.connection.onMessage(
       JSON.stringify({
         type: 'response',
-        id: 'must be integer',
+        id: {},
       }),
     )
   })

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -17,7 +17,7 @@ import { Connection } from 'xrpl-local/client/connection'
 
 import rippled from './fixtures/rippled'
 import { setupClient, teardownClient } from './setupClient'
-import { ignoreWebSocketDisconnect } from './testUtils'
+import { assertRejects, ignoreWebSocketDisconnect } from './testUtils'
 
 // how long before each test case times out
 const TIMEOUT = 20000
@@ -618,5 +618,14 @@ describe('Connection', function () {
       })
       .then(() => new Error('Should not have succeeded'))
       .catch(done())
+  })
+
+  it('should throw error if pending response with same ID', async function () {
+    await this.client.connection.request({ id: 'test', command: 'ping' })
+    assertRejects(
+      this.client.connection.request({ id: 'test', command: 'ping' }),
+      XrplError,
+      "Response with id 'test' is already pending",
+    )
   })
 })

--- a/test/mockRippled.ts
+++ b/test/mockRippled.ts
@@ -180,6 +180,16 @@ export default function createMockRippled(port: number): MockedWebSocketServer {
       )
     } else if (request.data.closeServer) {
       conn.close()
+    } else if (request.data.delayedResponseIn) {
+      setTimeout(() => {
+        conn.send(
+          createResponse(request, {
+            status: 'success',
+            type: 'response',
+            result: {},
+          }),
+        )
+      }, request.data.delayedResponseIn)
     }
   }
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -58,7 +58,7 @@ export function assertResultMatch(
  * @param message - Expected error message/substring of the error message.
  */
 export async function assertRejects(
-  promise: PromiseLike<Record<string, unknown>>,
+  promise: PromiseLike<any>,
   instanceOf: any,
   message?: string | RegExp,
 ): Promise<void> {
@@ -72,7 +72,7 @@ export async function assertRejects(
 
     assert(error instanceof instanceOf, error.message)
     if (typeof message === 'string') {
-      assert.strictEqual(error.message, message)
+      assert.strictEqual(error.message, message, 'Messages do not match')
     } else if (message instanceof RegExp) {
       assert(message.test(error.message))
     }


### PR DESCRIPTION
## High Level Overview of Change

There was a bug in `RequestManager` where if someone hand-inputted an ID into their request, they could have 2 requests with the same IDs. This PR fixes that (and improves handling of string request IDs).

### Context of Change

@ledhed2222 pointed out a bug

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.