### PR TITLE
build: silence warning while webpacking

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,7 @@ function webpackForTest(testFileName) {
   }
 
   const test = {
+    mode: 'production',
     cache: true,
     externals: [
       {


### PR DESCRIPTION
## High Level Overview of Change
Adds the `mode: production` to webpack config to silence a warning.
