### PR TITLE
Release xrpl.js 1.10.0 - Update repository.url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ripple-lib",
+  "name": "xrpl",
   "version": "1.10.0",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
@@ -90,7 +90,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/ripple/ripple-lib.git"
+    "url": "git@github.com:XRPLF/xrpl.js.git"
   },
   "readmeFilename": "README.md",
   "engines": {


### PR DESCRIPTION
## High Level Overview of Change

On npm - https://www.npmjs.com/package/xrpl - the Repository was wrong (because I previously published a "placeholder" package which had the wrong respository.url)

### Context of Change

Renaming ripple-lib to xrpl.js

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Release
