### PR TITLE
fix: set ledger_index to `validated`

### DIFF
--- a/src/sugar/autofill.ts
+++ b/src/sugar/autofill.ts
@@ -127,6 +127,7 @@ async function setNextValidSequenceNumber(
   const request: AccountInfoRequest = {
     command: 'account_info',
     account: tx.Account,
+    ledger_index: 'validated',
   }
   const data = await client.request(request)
   // eslint-disable-next-line no-param-reassign, require-atomic-updates -- param reassign is safe with no race condition

--- a/src/sugar/autofill.ts
+++ b/src/sugar/autofill.ts
@@ -127,7 +127,6 @@ async function setNextValidSequenceNumber(
   const request: AccountInfoRequest = {
     command: 'account_info',
     account: tx.Account,
-    ledger_index: 'validated',
   }
   const data = await client.request(request)
   // eslint-disable-next-line no-param-reassign, require-atomic-updates -- param reassign is safe with no race condition

--- a/src/sugar/orderbook.ts
+++ b/src/sugar/orderbook.ts
@@ -54,7 +54,7 @@ async function getOrderbook(
     command: 'book_offers',
     taker_pays: takerPays,
     taker_gets: takerGets,
-    ledger_index: options.ledger_index,
+    ledger_index: options.ledger_index ?? 'validated',
     ledger_hash: options.ledger_hash,
     limit: options.limit ?? DEFAULT_LIMIT,
     taker: options.taker,

--- a/src/wallet/generateFaucetWallet.ts
+++ b/src/wallet/generateFaucetWallet.ts
@@ -220,6 +220,7 @@ async function getAddressXrpBalance(
     const balances = await client.request({
       command: 'account_info',
       account: address,
+      ledger_index: 'validated',
     })
 
     return balances.result.account_data.Balance

--- a/test/integration/transactions/paymentChannelClaim.ts
+++ b/test/integration/transactions/paymentChannelClaim.ts
@@ -13,7 +13,7 @@ import { generateFundedWallet, testTransaction } from '../utils'
 // how long before each test case times out
 const TIMEOUT = 20000
 
-describe('PaymentChannelFund', function () {
+describe('PaymentChannelClaim', function () {
   this.timeout(TIMEOUT)
 
   before(suiteClientSetup)

--- a/test/integration/transactions/paymentChannelFund.ts
+++ b/test/integration/transactions/paymentChannelFund.ts
@@ -35,7 +35,6 @@ describe('PaymentChannelFund', function () {
       this.wallet,
       paymentChannelCreate,
     )
-
     await testTransaction(this.client, paymentChannelCreate, this.wallet)
 
     const paymentChannelFund: PaymentChannelFund = {

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -89,9 +89,6 @@ export async function testTransaction(
   // sign/submit the transaction
   const response = await client.submitTransaction(wallet, transaction)
 
-  // Validate the transaction
-  await ledgerAccept(client)
-
   // check that the transaction was successful
   assert.equal(response.status, 'success')
   assert.equal(response.type, 'response')

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -83,8 +83,14 @@ export async function testTransaction(
   transaction: Transaction,
   wallet: Wallet,
 ): Promise<void> {
+  // Accept any un-validated changes.
+  await ledgerAccept(client)
+
   // sign/submit the transaction
   const response = await client.submitTransaction(wallet, transaction)
+
+  // Validate the transaction
+  await ledgerAccept(client)
 
   // check that the transaction was successful
   assert.equal(response.status, 'success')


### PR DESCRIPTION
## High Level Overview of Change
There were a couple of places where we were assuming the default value for `ledger_index` was validated. This PR explicitly specifies `ledger_index: validated` in those places.


### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release