### PR TITLE
fix: remove undefined from generateFaucetWallet return type

### DIFF
--- a/src/wallet/generateFaucetWallet.ts
+++ b/src/wallet/generateFaucetWallet.ts
@@ -36,7 +36,7 @@ const MAX_ATTEMPTS = 20
 async function generateFaucetWallet(
   this: Client,
   wallet?: Wallet,
-): Promise<Wallet | undefined> {
+): Promise<Wallet> {
   if (!this.isConnected()) {
     throw new RippledError('Client not connected, cannot call faucet')
   }
@@ -83,7 +83,7 @@ async function returnPromise(
   startingBalance: number,
   fundWallet: Wallet,
   postBody: Uint8Array,
-): Promise<Wallet | undefined> {
+): Promise<Wallet> {
   return new Promise((resolve, reject) => {
     const request = httpsRequest(options, (response) => {
       const chunks: Uint8Array[] = []
@@ -132,7 +132,7 @@ async function onEnd(
   client: Client,
   startingBalance: number,
   fundWallet: Wallet,
-  resolve: (wallet?: Wallet) => void,
+  resolve: (wallet: Wallet) => void,
   reject: (err: ErrorConstructor | Error | unknown) => void,
 ): Promise<void> {
   const body = Buffer.concat(chunks).toString()
@@ -166,7 +166,7 @@ async function processSuccessfulResponse(
   body: string,
   startingBalance: number,
   fundWallet: Wallet,
-  resolve: (wallet?: Wallet) => void,
+  resolve: (wallet: Wallet) => void,
   reject: (err: ErrorConstructor | Error | unknown) => void,
 ): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- We know this is safe and correct

--- a/test/integration/generateFaucetWallet.ts
+++ b/test/integration/generateFaucetWallet.ts
@@ -16,12 +16,12 @@ describe('generateFaucetWallet', function () {
     const wallet = await api.generateFaucetWallet()
 
     assert.notEqual(wallet, undefined)
-    assert(isValidClassicAddress(wallet?.classicAddress ?? ''))
-    assert(isValidXAddress(wallet?.getXAddress() ?? ''))
+    assert(isValidClassicAddress(wallet.classicAddress))
+    assert(isValidXAddress(wallet.getXAddress()))
 
     const info = await api.request({
       command: 'account_info',
-      account: wallet?.classicAddress ?? '',
+      account: wallet.classicAddress,
     })
     assert.equal(info.result.account_data.Balance, '1000000000')
 
@@ -29,8 +29,9 @@ describe('generateFaucetWallet', function () {
 
     const afterSent = await api.request({
       command: 'account_info',
-      account: wallet?.classicAddress ?? '',
+      account: wallet.classicAddress,
     })
+
     assert.equal(afterSent.result.account_data.Balance, '2000000000')
 
     await api.disconnect()
@@ -42,12 +43,12 @@ describe('generateFaucetWallet', function () {
     const wallet = await api.generateFaucetWallet()
 
     assert.notEqual(wallet, undefined)
-    assert(isValidClassicAddress(wallet?.classicAddress ?? ''))
-    assert(isValidXAddress(wallet?.getXAddress() ?? ''))
+    assert(isValidClassicAddress(wallet.classicAddress))
+    assert(isValidXAddress(wallet.getXAddress()))
 
     const info = await api.request({
       command: 'account_info',
-      account: wallet?.classicAddress ?? '',
+      account: wallet.classicAddress,
     })
     assert.equal(info.result.account_data.Balance, '1000000000')
 
@@ -55,7 +56,7 @@ describe('generateFaucetWallet', function () {
 
     const afterSent = await api.request({
       command: 'account_info',
-      account: wallet?.classicAddress ?? '',
+      account: wallet.classicAddress,
     })
     assert.equal(afterSent.result.account_data.Balance, '2000000000')
 


### PR DESCRIPTION
## High Level Overview of Change
This PR removes `undefined` from the `generateFaucetWallet()` method's type signature.

### Context of Change
There is not a situation where `generateFaucetWallet()` should return an `undefined`.  As such, we can change `Promise<Wallet | undefined>` into `Promise<Wallet>`.


<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release