### PR TITLE
refactor: clean up getFaucetWallet starting balance

### DIFF
--- a/src/wallet/generateFaucetWallet.ts
+++ b/src/wallet/generateFaucetWallet.ts
@@ -53,22 +53,15 @@ async function generateFaucetWallet(
       destination: fundWallet.classicAddress,
     }),
   )
-  // Retrieve the existing account balance
-  let addressToFundBalance: undefined | string
+
+  let startingBalance = 0
   try {
-    addressToFundBalance = await getAddressXrpBalance(
-      this,
-      fundWallet.classicAddress,
+    startingBalance = Number(
+      await getAddressXrpBalance(this, fundWallet.classicAddress),
     )
   } catch {
-    /* addressToFundBalance remains undefined */
+    /* startingBalance remains '0' */
   }
-
-  // Check the address balance is not undefined and is a number
-  const startingBalance =
-    addressToFundBalance && !Number.isNaN(Number(addressToFundBalance))
-      ? Number(addressToFundBalance)
-      : 0
 
   // Options to pass to https.request
   const options = getOptions(this, postBody)


### PR DESCRIPTION
## High Level Overview of Change
Cleans up how `getFaucetWallet` was computing starting balance.

### Context of Change
Previously, if the xrp balance was undefined, starting balance was set to be zero. We can clean this up into one try/catch block, with the starting balance assumed to be zero if an error is thrown.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release