### PR TITLE
fix: convert uint8Array to Buffer

### DIFF
--- a/src/wallet/generateFaucetWallet.ts
+++ b/src/wallet/generateFaucetWallet.ts
@@ -48,10 +48,12 @@ async function generateFaucetWallet(
       : Wallet.generate()
 
   // Create the POST request body
-  const postBody = new TextEncoder().encode(
-    JSON.stringify({
-      destination: fundWallet.classicAddress,
-    }),
+  const postBody = Buffer.from(
+    new TextEncoder().encode(
+      JSON.stringify({
+        destination: fundWallet.classicAddress,
+      }),
+    ),
   )
 
   let startingBalance = 0
@@ -75,7 +77,7 @@ async function returnPromise(
   client: Client,
   startingBalance: number,
   fundWallet: Wallet,
-  postBody: Uint8Array,
+  postBody: Buffer,
 ): Promise<Wallet> {
   return new Promise((resolve, reject) => {
     const request = httpsRequest(options, (response) => {


### PR DESCRIPTION
## High Level Overview of Change
 This PR converts the `Uint8Array` to a `Buffer`

### Context of Change
`requests` in NodeJS expects the body to be in the form of a Buffer. We use `Buffer.from()` to convert the Array into a buffer.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release