### PR TITLE
add Regular Key Pair support

### DIFF
--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -31,6 +31,13 @@ function hexFromBuffer(buffer: Buffer): string {
   return buffer.toString('hex').toUpperCase()
 }
 
+interface WalletOptions {
+  // The classicAddress corresponding to its Regular Key Pair.
+  classicAddress?: string
+  // The seed used to derive the account keys.
+  seed?: string
+}
+
 /**
  * A utility for deriving a wallet composed of a keypair (publicKey/privateKey).
  * A wallet can be derived from either a seed, mnemnoic, or entropy (array of random numbers).
@@ -39,12 +46,6 @@ function hexFromBuffer(buffer: Buffer): string {
 class Wallet {
   public readonly publicKey: string
   public readonly privateKey: string
-  /**
-   * This only is correct if this wallet corresponds to your
-   * [master keypair](https://xrpl.org/cryptographic-keys.html#master-key-pair). If this wallet represents a
-   * [regular keypair](https://xrpl.org/cryptographic-keys.html#regular-key-pair) this will provide an incorrect address.
-   * TODO: Add support for Regular Keys to Wallet (And their corresponding impact on figuring out classicAddress).
-   */
   public readonly classicAddress: string
   public readonly seed?: string
 
@@ -53,13 +54,17 @@ class Wallet {
    *
    * @param publicKey - The public key for the account.
    * @param privateKey - The private key used for signing transactions for the account.
-   * @param seed - (Optional) The seed used to derive the account keys.
+   * @param opts - (Optional) The seed and classicAddress (corresponding to its Regular Key Pair) for the account.
    */
-  public constructor(publicKey: string, privateKey: string, seed?: string) {
+  public constructor(
+    publicKey: string,
+    privateKey: string,
+    opts: WalletOptions = {},
+  ) {
     this.publicKey = publicKey
     this.privateKey = privateKey
-    this.classicAddress = deriveAddress(publicKey)
-    this.seed = seed
+    this.classicAddress = opts.classicAddress ?? deriveAddress(publicKey)
+    this.seed = opts.seed
   }
 
   /**
@@ -154,7 +159,7 @@ class Wallet {
     algorithm: ECDSA = DEFAULT_ALGORITHM,
   ): Wallet {
     const { publicKey, privateKey } = deriveKeypair(seed, { algorithm })
-    return new Wallet(publicKey, privateKey, seed)
+    return new Wallet(publicKey, privateKey, { seed })
   }
 
   /**

--- a/test/wallet/index.ts
+++ b/test/wallet/index.ts
@@ -17,6 +17,23 @@ const { sign: RESPONSE_FIXTURES } = responses
  * Provides tests for Wallet class.
  */
 describe('Wallet', function () {
+  describe('constructor', function () {
+    it('initializes a wallet using a Regular Key Pair', function () {
+      const classicAddress = 'rUAi7pipxGpYfPNg3LtPcf2ApiS8aw9A93'
+      const regularPublicKey =
+        'aBRNH5wUurfhZcoyR6nRwDSa95gMBkovBJ8V4cp1C1pM28H7EPL1'
+      const regularPrivateKey = 'sh8i92YRnEjJy3fpFkL8txQSCVo79'
+
+      const wallet = new Wallet(regularPublicKey, regularPrivateKey, {
+        classicAddress,
+      })
+
+      assert.equal(wallet.publicKey, regularPublicKey)
+      assert.isString(wallet.privateKey, regularPrivateKey)
+      assert.isString(wallet.classicAddress, classicAddress)
+    })
+  })
+
   describe('generate', function () {
     const classicAddressPrefix = 'r'
     const ed25519KeyPrefix = 'ED'


### PR DESCRIPTION
## High Level Overview of Change

Adds Regular Key Pair support to `Wallet` class.

### Context of Change

Refactors `Wallet` constructor to add a `WalletOptions` param that contains:
- `classicAddress` that corresponds to its Regular Key Pair.
- `seed` used to derive the account keys.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

Adds a test to verify `Wallet` constructor supports Regular Key Pair initialization.