### PR TITLE
fix: adds browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "directories": {
     "test": "test"
   },
+  "browser": {
+    "ws": "./dist/npm/client/wsWrapper.js",
+    "https-proxy-agent": false
+  },
   "dependencies": {
     "@types/lodash": "^4.14.136",
     "@types/ws": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "test": "test"
   },
   "browser": {
-    "ws": "./dist/npm/client/wsWrapper.js",
-    "https-proxy-agent": false
+    "ws": "./dist/npm/client/wsWrapper.js"
   },
   "dependencies": {
     "@types/lodash": "^4.14.136",


### PR DESCRIPTION
## High Level Overview of Change
Adds a browser field to package.json.

### Context of Change
When `xrpl.js` was being used in react, the react polyfills were attempting to use ws in the browser, which doesn't work. The `wsWrapper.js` specifies that in the browser, use `client/wsWrapper.js` instead of ws. 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release