### PR TITLE
build: prepare for beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xrpl",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xrpl",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.4",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.136",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.4",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [


### PR DESCRIPTION
## High Level Overview of Change
Increases version to `2.0.0-beta.4`, including the fix for the `wsWrapper` issues we were having. 

### Context of Change
Issue first seen in #1691, and later in some react testing we were doing locally. This specifies that when running in the browser, xrpl.js should use `wsWrapper.js` instead of `ws`.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
