### PR TITLE
Link to xrpl-announce (updated from ripple-lib-announce)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
-# ripple-lib Release History
+# xrpl.js (ripple-lib) Release History
 
-Subscribe to [the **ripple-lib-announce** mailing list](https://groups.google.com/forum/#!forum/ripple-lib-announce) for release announcements. We recommend that ripple-lib users stay up-to-date with the latest stable release.
+Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## 1.10.0 (2021-08-12)
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ import xrpl from 'https://dev.jspm.io/npm:xrpl';
 
 We have a low-traffic mailing list for announcements of new xrpl.js releases. (About 1 email per week)
 
-+ [Subscribe to ripple-lib-announce](https://groups.google.com/forum/#!forum/ripple-lib-announce)
++ [Subscribe to xrpl-announce](https://groups.google.com/g/xrpl-announce)
 
 If you're using the XRP Ledger in production, you should run a [rippled server](https://github.com/ripple/rippled) and subscribe to the ripple-server mailing list as well.
 
-+ [Subscribe to ripple-server](https://groups.google.com/forum/#!forum/ripple-server)
++ [Subscribe to ripple-server](https://groups.google.com/g/ripple-server)
 
 ## Development
 
@@ -145,6 +145,6 @@ Update the documentation by running `npm run docgen`.
 
 ## More Information
 
-+ [ripple-lib-announce mailing list](https://groups.google.com/forum/#!forum/ripple-lib-announce) - subscribe for release announcements
++ [xrpl-announce mailing list](https://groups.google.com/g/xrpl-announce) - subscribe for release announcements
 + [RippleAPI Reference](https://xrpl.org/rippleapi-reference.html) - XRP Ledger Dev Portal
 + [XRP Ledger Dev Portal](https://xrpl.org/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,13 +159,13 @@
 				<a href="#mailing-lists" id="mailing-lists" style="color: inherit; text-decoration: none;">
 					<h3>Mailing Lists</h3>
 				</a>
-				<p>We have a low-traffic mailing list for announcements of new ripple-lib releases. (About 1 email per week)</p>
+				<p>We have a low-traffic mailing list for announcements of new xrpl.js (ripple-lib) releases. (About 1 email per week)</p>
 				<ul>
-					<li><a href="https://groups.google.com/forum/#!forum/ripple-lib-announce">Subscribe to ripple-lib-announce</a></li>
+					<li><a href="https://groups.google.com/g/xrpl-announce">Subscribe to xrpl-announce</a></li>
 				</ul>
 				<p>If you&#39;re using the XRP Ledger in production, you should run a <a href="https://github.com/ripple/rippled">rippled server</a> and subscribe to the ripple-server mailing list as well.</p>
 				<ul>
-					<li><a href="https://groups.google.com/forum/#!forum/ripple-server">Subscribe to ripple-server</a></li>
+					<li><a href="https://groups.google.com/g/ripple-server">Subscribe to ripple-server</a></li>
 				</ul>
 				<a href="#development" id="development" style="color: inherit; text-decoration: none;">
 					<h2>Development</h2>
@@ -201,7 +201,7 @@
 					<h2>More Information</h2>
 				</a>
 				<ul>
-					<li><a href="https://groups.google.com/forum/#!forum/ripple-lib-announce">ripple-lib-announce mailing list</a> - subscribe for release announcements</li>
+					<li><a href="https://groups.google.com/g/xrpl-announce">xrpl-announce mailing list</a> - subscribe for release announcements</li>
 					<li><a href="https://xrpl.org/rippleapi-reference.html">RippleAPI Reference</a> - XRP Ledger Dev Portal</li>
 					<li><a href="https://xrpl.org/">XRP Ledger Dev Portal</a></li>
 				</ul>


### PR DESCRIPTION
## High Level Overview of Change

We renamed the Google Group to xrpl-announce. In the future, the same list may be used for releases of other client libraries as well. It's a small list (less than 60 subscribers) and not very noisy, so it should be okay to include release announcements about libraries in other languages, especially since many developers are polyglots. Of course, we hope the list will grow in the future.

### Context of Change

Historically, many developers asked for a way to get notified by email when a new version of the library is available. We created ripple-lib-announce for that purpose. Now, this library has been renamed to xrpl.js, so we renamed the mailing list to xrpl-announce.

### Type of Change

- [x] Documentation Updates
