### PR TITLE
feat: reliable submission for transactions

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -90,7 +90,12 @@ import getBalances from '../sugar/balances'
 import getFee from '../sugar/fee'
 import getLedgerIndex from '../sugar/ledgerIndex'
 import getOrderbook from '../sugar/orderbook'
-import { submitTransaction, submitSignedTransaction } from '../sugar/submit'
+import {
+  submitTransaction,
+  submitSignedTransaction,
+  submitTransactionReliable,
+  submitSignedTransactionReliable,
+} from '../sugar/submit'
 import { ensureClassicAddress } from '../sugar/utils'
 import generateFaucetWallet from '../wallet/generateFaucetWallet'
 
@@ -534,6 +539,8 @@ class Client extends EventEmitter {
 
   public submitTransaction = submitTransaction
   public submitSignedTransaction = submitSignedTransaction
+  public submitTransactionReliable = submitTransactionReliable
+  public submitSignedTransactionReliable = submitSignedTransactionReliable
 
   public getBalances = getBalances
   public getOrderbook = getOrderbook

--- a/src/sugar/submit.ts
+++ b/src/sugar/submit.ts
@@ -122,7 +122,13 @@ async function submitSignedTransactionReliable(
     tx_blob: signedTxEncoded,
     fail_hard: isAccountDelete(signedTransaction),
   }
-  await this.request(request)
+  const response = await this.request(request)
+  if (response.result.engine_result !== 'tesSUCCESS') {
+    throw new XrplError(
+      `Transaction failed, ${response.result.engine_result}: ${response.result.engine_result_message}`,
+    )
+  }
+
   return waitForFinalTransactionOutcome(this, txHash)
 }
 

--- a/src/sugar/submit.ts
+++ b/src/sugar/submit.ts
@@ -1,9 +1,20 @@
 import { decode, encode } from 'ripple-binary-codec'
 
 import type { Client, SubmitRequest, SubmitResponse, Wallet } from '..'
-import { ValidationError } from '../errors'
+import { ValidationError, XrplError } from '../errors'
+import { TxResponse } from '../models/methods'
 import { Transaction } from '../models/transactions'
+import { computeSignedTransactionHash } from '../utils'
 import { sign } from '../wallet/signer'
+
+// general time for a ledger to close, in milliseconds
+const LEDGER_CLOSE_TIME = 4000
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
 
 /**
  * Submits an unsigned transaction.
@@ -34,7 +45,7 @@ async function submitTransaction(
  * @param this - A Client.
  * @param signedTransaction - A signed transaction to encode (if not already) and submit.
  * @returns A promise that contains SubmitResponse.
- * @throws RippledError if submit request fails.
+ * @throws ValidationError if the transaction isn't signed, RippledError if submit request fails.
  */
 async function submitSignedTransaction(
   this: Client,
@@ -56,6 +67,101 @@ async function submitSignedTransaction(
   return this.request(request)
 }
 
+/**
+ * Asynchronously submits a transaction and verifies that it has been included in a
+ * validated ledger (or has errored/will not be included for some reason).
+ * See [Reliable Transaction Submission](https://xrpl.org/reliable-transaction-submission.html).
+ *
+ * @param this - A Client.
+ * @param wallet - A Wallet to sign a transaction.
+ * @param transaction - A transaction to autofill, sign & encode, and submit.
+ * @returns A promise that contains TxResponse, that will return when the transaction has been validated.
+ */
+async function submitTransactionReliable(
+  this: Client,
+  wallet: Wallet,
+  transaction: Transaction,
+): Promise<TxResponse> {
+  const tx = await this.autofill(transaction)
+  const signedTxEncoded = sign(wallet, tx)
+  return this.submitSignedTransactionReliable(signedTxEncoded)
+}
+
+/**
+ * Asynchronously submits a transaction and verifies that it has been included in a
+ * validated ledger (or has errored/will not be included for some reason).
+ * See [Reliable Transaction Submission](https://xrpl.org/reliable-transaction-submission.html).
+ *
+ * @param this - A Client.
+ * @param signedTransaction - A signed transaction to encode (if not already) and submit.
+ * @returns A promise that contains TxResponse, that will return when the transaction has been validated.
+ * @throws ValidationError if the request is not signed/doesn't have a LastLedgerSequence, RippledError if the submit request
+ *   fails, XrplError if the reliable submission fails.
+ */
+async function submitSignedTransactionReliable(
+  this: Client,
+  signedTransaction: Transaction | string,
+): Promise<TxResponse> {
+  if (!isSigned(signedTransaction)) {
+    throw new ValidationError('Transaction must be signed')
+  }
+  if (!hasLastLedgerSequence(signedTransaction)) {
+    throw new ValidationError(
+      'Transaction must contain a LastLedgerSequence value for reliable submission.',
+    )
+  }
+
+  const signedTxEncoded =
+    typeof signedTransaction === 'string'
+      ? signedTransaction
+      : encode(signedTransaction)
+  const txHash = computeSignedTransactionHash(signedTransaction)
+
+  const request: SubmitRequest = {
+    command: 'submit',
+    tx_blob: signedTxEncoded,
+    fail_hard: isAccountDelete(signedTransaction),
+  }
+  await this.request(request)
+  return waitForFinalTransactionOutcome(this, txHash)
+}
+
+// Helper functions
+
+// The core logic of reliable submission.  Polls the ledger until the result of the
+// transaction can be considered final, meaning it has either been included in a
+// validated ledger, or the transaction's lastLedgerSequence has been surpassed by the
+// latest ledger sequence (meaning it will never be included in a validated ledger).
+async function waitForFinalTransactionOutcome(
+  client: Client,
+  txHash: string,
+): Promise<TxResponse> {
+  await sleep(LEDGER_CLOSE_TIME)
+
+  const txResponse = await client.request({
+    command: 'tx',
+    transaction: txHash,
+  })
+  if (txResponse.result.validated) {
+    return txResponse
+  }
+
+  const txLastLedger = txResponse.result.LastLedgerSequence
+  if (txLastLedger == null) {
+    throw new XrplError('LastLedgerSequence cannot be null')
+  }
+  const latestLedger = await client.getLedgerIndex()
+
+  if (txLastLedger > latestLedger) {
+    return waitForFinalTransactionOutcome(client, txHash)
+  }
+
+  throw new XrplError(
+    `The latest ledger sequence ${latestLedger} is greater than the transaction's LastLedgerSequence (${txLastLedger}).`,
+  )
+}
+
+// checks if the transaction has been signed
 function isSigned(transaction: Transaction | string): boolean {
   const tx = typeof transaction === 'string' ? decode(transaction) : transaction
   return (
@@ -64,9 +170,21 @@ function isSigned(transaction: Transaction | string): boolean {
   )
 }
 
+// checks if there is a LastLedgerSequence as a part of the transaction
+function hasLastLedgerSequence(transaction: Transaction | string): boolean {
+  const tx = typeof transaction === 'string' ? decode(transaction) : transaction
+  return typeof tx !== 'string' && tx.LastLedgerSequence != null
+}
+
+// checks if the transaction is an AccountDelete transaction
 function isAccountDelete(transaction: Transaction | string): boolean {
   const tx = typeof transaction === 'string' ? decode(transaction) : transaction
   return tx.TransactionType === 'AccountDelete'
 }
 
-export { submitTransaction, submitSignedTransaction }
+export {
+  submitTransaction,
+  submitSignedTransaction,
+  submitTransactionReliable,
+  submitSignedTransactionReliable,
+}

--- a/test/integration/reliableSubmission.ts
+++ b/test/integration/reliableSubmission.ts
@@ -8,9 +8,10 @@ import { AccountSet, convertStringToHex } from 'xrpl-local'
 import serverUrl from './serverUrl'
 import { setupClient, suiteClientSetup, teardownClient } from './setup'
 import { ledgerAccept } from './utils'
+
 // how long before each test case times out
 const TIMEOUT = 60000
-// This test is reliant on external networks, and as such may be flaky.
+
 describe('reliable submission', function () {
   this.timeout(TIMEOUT)
 

--- a/test/integration/reliableSubmission.ts
+++ b/test/integration/reliableSubmission.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-misused-promises -- supposed to return a promise here */
+/* eslint-disable no-restricted-syntax -- not sure why this rule is here, definitely not needed here */
+import { assert } from 'chai'
+import _ from 'lodash'
+
+import { AccountSet, convertStringToHex } from 'xrpl-local'
+
+import serverUrl from './serverUrl'
+import { setupClient, suiteClientSetup, teardownClient } from './setup'
+import { ledgerAccept } from './utils'
+// how long before each test case times out
+const TIMEOUT = 60000
+// This test is reliant on external networks, and as such may be flaky.
+describe('reliable submission', function () {
+  this.timeout(TIMEOUT)
+
+  before(suiteClientSetup)
+  beforeEach(_.partial(setupClient, serverUrl))
+  afterEach(teardownClient)
+
+  it('submitTransactionReliable', async function () {
+    const accountSet: AccountSet = {
+      TransactionType: 'AccountSet',
+      Account: this.wallet.getClassicAddress(),
+      Domain: convertStringToHex('example.com'),
+    }
+    const responsePromise = this.client.submitTransactionReliable(
+      this.wallet,
+      accountSet,
+    )
+    const ledgerPromise = setTimeout(ledgerAccept, 1000, this.client)
+    return Promise.all([responsePromise, ledgerPromise]).then(
+      ([response, _ledger]) => {
+        assert.equal(response.type, 'response')
+        assert.equal(response.result.validated, true)
+      },
+    )
+  })
+
+  it('submitSignedTransactionReliable', async function () {
+    const accountSet: AccountSet = {
+      TransactionType: 'AccountSet',
+      Account: this.wallet.getClassicAddress(),
+      Domain: convertStringToHex('example.com'),
+    }
+    const signedAccountSet = this.wallet.signTransaction(
+      await this.client.autofill(accountSet),
+    )
+    const responsePromise =
+      this.client.submitSignedTransactionReliable(signedAccountSet)
+    const ledgerPromise = setTimeout(ledgerAccept, 1000, this.client)
+    return Promise.all([responsePromise, ledgerPromise]).then(
+      ([response, _ledger]) => {
+        assert.equal(response.type, 'response')
+        assert.equal(response.result.validated, true)
+      },
+    )
+  })
+
+  it('submitSignedTransactionReliable longer', async function () {
+    const accountSet: AccountSet = {
+      TransactionType: 'AccountSet',
+      Account: this.wallet.getClassicAddress(),
+      Domain: convertStringToHex('example.com'),
+    }
+    const signedAccountSet = this.wallet.signTransaction(
+      await this.client.autofill(accountSet),
+    )
+    const responsePromise =
+      this.client.submitSignedTransactionReliable(signedAccountSet)
+    const ledgerPromise = setTimeout(ledgerAccept, 5000, this.client)
+    return Promise.all([responsePromise, ledgerPromise]).then(
+      ([response, _ledger]) => {
+        assert.equal(response.type, 'response')
+        assert.equal(response.result.validated, true)
+      },
+    )
+  })
+})


### PR DESCRIPTION
## High Level Overview of Change

This PR adds two methods to the client:
* `submitTransactionReliable` - the relsub equivalent of `submitTransaction`
* `submitSignedTransactionReliable` - the relsub equivalent of `submitSignedTransaction`

### Context of Change

Reliable submission is a feature that we really want in our library. It makes it way easier to know when a transaction has been fully validated/is "official".

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added tests for the new methods. CI passes.