### PR TITLE
Autofill: use current ledger for sequence number

### DIFF
--- a/src/sugar/autofill.ts
+++ b/src/sugar/autofill.ts
@@ -127,7 +127,7 @@ async function setNextValidSequenceNumber(
   const request: AccountInfoRequest = {
     command: 'account_info',
     account: tx.Account,
-    ledger_index: 'validated',
+    ledger_index: 'current',
   }
   const data = await client.request(request)
   // eslint-disable-next-line no-param-reassign, require-atomic-updates -- param reassign is safe with no race condition


### PR DESCRIPTION
## High Level Overview of Change
Uses the current open ledger, rather than the latest validated ledger, to get the next available sequence number for autofilling a transaction.

### Context of Change
I was noticing more failures when sending transactions on the Transaction Sender dev tool after updating to v2.0 beta 5 and I tracked this down as the probable cause.

Getting an account's next available sequence number is a case where using the open ledger usually makes more sense than getting the validated ledger. If you have any transactions pending, the sequence from the validated ledger will be behind, but one from the open ledger will be correct unless the pending transactions fail to achieve a consensus (which is rare).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
