### PR TITLE
test: increase browser timeout

### DIFF
--- a/test/browser/browserIntegration.ts
+++ b/test/browser/browserIntegration.ts
@@ -97,5 +97,5 @@ describe('Browser Tests', function () {
     } finally {
       await browser.close()
     }
-  }).timeout(40000)
+  }).timeout(TIMEOUT)
 })


### PR DESCRIPTION
## High Level Overview of Change

This PR increases the timeout to match the timeout listed in other parts of the browser tests. 

### Context of Change

The tests failed on #1721 due to a timeout, even though that PR doesn't touch any of the actual code. 

I just ran the browser tests locally - they take about 37 seconds to run, and the timeout was 40 seconds. This is not enough of a buffer.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.