### PR TITLE
bug: Fix race condition in path_find integration test

### DIFF
--- a/test/integration/requests/pathFind.ts
+++ b/test/integration/requests/pathFind.ts
@@ -63,6 +63,27 @@ describe('path_find', function () {
           destination_account: wallet2.getClassicAddress(),
           destination_amount: '100',
         }
+
+        const expectedStreamResult: PathFindStream = {
+          type: 'path_find',
+          source_account: pathFind.source_account,
+          destination_account: pathFind.destination_account,
+          destination_amount: pathFind.destination_amount,
+          full_reply: true,
+          id: 10,
+          alternatives: [],
+        }
+
+        const client: Client = this.client
+        client.on('path_find', (path) => {
+          assert.equal(path.type, 'path_find')
+          assert.deepEqual(
+            _.omit(path, 'id'),
+            _.omit(expectedStreamResult, 'id'),
+          )
+          subscribeDone(this.client, done)
+        })
+
         this.client.request(pathFind).then((response) => {
           const expectedResponse: PathFindResponse = {
             id: response.id,
@@ -76,26 +97,6 @@ describe('path_find', function () {
               id: response.id,
             },
           }
-
-          const expectedStreamResult: PathFindStream = {
-            type: 'path_find',
-            source_account: pathFind.source_account,
-            destination_account: pathFind.destination_account,
-            destination_amount: pathFind.destination_amount,
-            full_reply: true,
-            id: 10,
-            alternatives: [],
-          }
-
-          const client: Client = this.client
-          client.on('path_find', (path) => {
-            assert.equal(path.type, 'path_find')
-            assert.deepEqual(
-              _.omit(path, 'id'),
-              _.omit(expectedStreamResult, 'id'),
-            )
-            subscribeDone(this.client, done)
-          })
 
           assert.deepEqual(response, expectedResponse)
         })


### PR DESCRIPTION
## High Level Overview of Change

path_find test occasionally failed because the listener was added after the request was issued.

### Context of Change

Found by @mvadari due to a CI test failing in a flaky way.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes

<!--
## Future Tasks
For future tasks related to PR.
-->