### PR TITLE
refactor: Replace wallet.getClassicAddress with wallet.classicAddress

### DIFF
--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -235,7 +235,7 @@ class Wallet {
     if (typeof multisign === 'string' && multisign.startsWith('X')) {
       multisignAddress = multisign
     } else if (multisign) {
-      multisignAddress = this.getClassicAddress()
+      multisignAddress = this.classicAddress
     }
 
     if (transaction.TxnSignature || transaction.Signers) {
@@ -295,17 +295,6 @@ class Wallet {
    */
   public getXAddress(tag: number | false = false, isTestnet = false): string {
     return classicAddressToXAddress(this.classicAddress, tag, isTestnet)
-  }
-
-  /**
-   * Gets the classic address of the account this wallet represents. This only is correct if this wallet corresponds
-   * to your [master keypair](https://xrpl.org/cryptographic-keys.html#master-key-pair). If this wallet represents a
-   * [regular keypair](https://xrpl.org/cryptographic-keys.html#regular-key-pair) this will provide an incorrect address.
-   *
-   * @returns A classic address.
-   */
-  public getClassicAddress(): string {
-    return this.classicAddress
   }
 
   /**

--- a/test/integration/integration.ts
+++ b/test/integration/integration.ts
@@ -37,17 +37,17 @@ describe('integration tests', function () {
     // set up the multisigners for the account
     const signerListSet: SignerListSet = {
       TransactionType: 'SignerListSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       SignerEntries: [
         {
           SignerEntry: {
-            Account: signerWallet1.getClassicAddress(),
+            Account: signerWallet1.classicAddress,
             SignerWeight: 1,
           },
         },
         {
           SignerEntry: {
-            Account: signerWallet2.getClassicAddress(),
+            Account: signerWallet2.classicAddress,
             SignerWeight: 1,
           },
         },
@@ -59,7 +59,7 @@ describe('integration tests', function () {
     // try to multisign
     const accountSet: AccountSet = {
       TransactionType: 'AccountSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Domain: convertStringToHex('example.com'),
     }
     const accountSetTx = await client.autofill(accountSet, 2)

--- a/test/integration/reliableSubmission.ts
+++ b/test/integration/reliableSubmission.ts
@@ -21,7 +21,7 @@ describe('reliable submission', function () {
   it('submitReliable', async function () {
     const accountSet: AccountSet = {
       TransactionType: 'AccountSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Domain: convertStringToHex('example.com'),
     }
     const responsePromise = this.client.submitReliable(this.wallet, accountSet)
@@ -37,7 +37,7 @@ describe('reliable submission', function () {
   it('submitSignedReliable', async function () {
     const accountSet: AccountSet = {
       TransactionType: 'AccountSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Domain: convertStringToHex('example.com'),
     }
     const { tx_blob: signedAccountSet } = this.wallet.sign(
@@ -56,7 +56,7 @@ describe('reliable submission', function () {
   it('submitSignedReliable longer', async function () {
     const accountSet: AccountSet = {
       TransactionType: 'AccountSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Domain: convertStringToHex('example.com'),
     }
     const { tx_blob: signedAccountSet } = this.wallet.sign(

--- a/test/integration/requests/accountChannels.ts
+++ b/test/integration/requests/accountChannels.ts
@@ -18,14 +18,14 @@ describe('account_channels', function () {
   it('base', async function () {
     const request: AccountChannelsRequest = {
       command: 'account_channels',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       ledger_index: 'validated',
     }
     const response = await this.client.request(request)
     const expected = {
       id: 0,
       result: {
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
         channels: [],
         ledger_hash:
           'C8BFA74A740AA22AD9BD724781589319052398B0C6C817B88D55628E07B7B4A1',

--- a/test/integration/requests/accountCurrencies.ts
+++ b/test/integration/requests/accountCurrencies.ts
@@ -18,7 +18,7 @@ describe('account_currencies', function () {
   it('base', async function () {
     const request: AccountCurrenciesRequest = {
       command: 'account_currencies',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       strict: true,
       ledger_index: 'validated',
     }

--- a/test/integration/requests/accountInfo.ts
+++ b/test/integration/requests/accountInfo.ts
@@ -18,7 +18,7 @@ describe('account_info', function () {
   it('base', async function () {
     const request: AccountInfoRequest = {
       command: 'account_info',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       strict: true,
       ledger_index: 'validated',
     }
@@ -27,7 +27,7 @@ describe('account_info', function () {
       id: 0,
       result: {
         account_data: {
-          Account: this.wallet.getClassicAddress(),
+          Account: this.wallet.classicAddress,
           Balance: '400000000',
           Flags: 0,
           LedgerEntryType: 'AccountRoot',

--- a/test/integration/requests/accountLines.ts
+++ b/test/integration/requests/accountLines.ts
@@ -18,7 +18,7 @@ describe('account_lines', function () {
   it('base', async function () {
     const request: AccountLinesRequest = {
       command: 'account_lines',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       strict: true,
       ledger_index: 'validated',
     }
@@ -26,7 +26,7 @@ describe('account_lines', function () {
     const expected = {
       id: 0,
       result: {
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
         ledger_hash:
           '0C09AAFA88AC1A616058220CF33269788D3985DAA6F2386196D4A7404252BB61',
         ledger_index: 1074,

--- a/test/integration/requests/accountObjects.ts
+++ b/test/integration/requests/accountObjects.ts
@@ -18,14 +18,14 @@ describe('account_objects', function () {
   it('base', async function () {
     const request: AccountObjectsRequest = {
       command: 'account_objects',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       ledger_index: 'validated',
     }
     const response = await this.client.request(request)
     const expected = {
       id: 0,
       result: {
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
         account_objects: [],
         ledger_hash:
           '28D68B351ED58B9819502EF5FC05BA4412A048597E5159E1C226703BDF7C7897',

--- a/test/integration/requests/accountOffers.ts
+++ b/test/integration/requests/accountOffers.ts
@@ -18,14 +18,14 @@ describe('account_offers', function () {
   it('base', async function () {
     const request: AccountOffersRequest = {
       command: 'account_offers',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       strict: true,
     }
     const response = await this.client.request(request)
     const expected = {
       id: 0,
       result: {
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
         ledger_current_index: 1443,
         offers: [],
         validated: false,

--- a/test/integration/requests/accountTx.ts
+++ b/test/integration/requests/accountTx.ts
@@ -18,20 +18,20 @@ describe('account_tx', function () {
   it('base', async function () {
     const request: AccountTxRequest = {
       command: 'account_tx',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       ledger_index: 'validated',
     }
     const response = await this.client.request(request)
     const expected = {
       result: {
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
         limit: 400,
         transactions: [
           {
             tx: {
               Account: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
               Amount: '400000000',
-              Destination: this.wallet.getClassicAddress(),
+              Destination: this.wallet.classicAddress,
               Fee: '12',
               Flags: 0,
               LastLedgerSequence: 1753,

--- a/test/integration/requests/bookOffers.ts
+++ b/test/integration/requests/bookOffers.ts
@@ -23,7 +23,7 @@ describe('book_offers', function () {
       },
       taker_pays: {
         currency: 'USD',
-        issuer: this.wallet.getClassicAddress(),
+        issuer: this.wallet.classicAddress,
       },
     }
     const response = await this.client.request(bookOffer)

--- a/test/integration/requests/depositAuthorized.ts
+++ b/test/integration/requests/depositAuthorized.ts
@@ -20,8 +20,8 @@ describe('deposit_authorized', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const depositAuthorized: DepositAuthorizedRequest = {
       command: 'deposit_authorized',
-      source_account: this.wallet.getClassicAddress(),
-      destination_account: wallet2.getClassicAddress(),
+      source_account: this.wallet.classicAddress,
+      destination_account: wallet2.classicAddress,
     }
 
     const response = await this.client.request(depositAuthorized)

--- a/test/integration/requests/gatewayBalances.ts
+++ b/test/integration/requests/gatewayBalances.ts
@@ -18,7 +18,7 @@ describe('gateway_balances', function () {
   it('base', async function () {
     const request: GatewayBalancesRequest = {
       command: 'gateway_balances',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       ledger_index: 'validated',
       strict: true,
     }
@@ -26,7 +26,7 @@ describe('gateway_balances', function () {
     const expected = {
       id: 0,
       result: {
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
         ledger_hash:
           '28D68B351ED58B9819502EF5FC05BA4412A048597E5159E1C226703BDF7C7897',
         ledger_index: 1294,

--- a/test/integration/requests/noRippleCheck.ts
+++ b/test/integration/requests/noRippleCheck.ts
@@ -18,7 +18,7 @@ describe('noripple_check', function () {
   it('base', async function () {
     const request: NoRippleCheckRequest = {
       command: 'noripple_check',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       role: 'gateway',
       ledger_index: 'current',
       transactions: true,
@@ -31,7 +31,7 @@ describe('noripple_check', function () {
         problems: ['You should immediately set your default ripple flag'],
         transactions: [
           {
-            Account: this.wallet.getClassicAddress(),
+            Account: this.wallet.classicAddress,
             Fee: 10,
             Sequence: 1268,
             SetFlag: 8,

--- a/test/integration/requests/pathFind.ts
+++ b/test/integration/requests/pathFind.ts
@@ -26,8 +26,8 @@ describe('path_find', function () {
     const pathFind: PathFindRequest = {
       command: 'path_find',
       subcommand: 'create',
-      source_account: this.wallet.getClassicAddress(),
-      destination_account: wallet2.getClassicAddress(),
+      source_account: this.wallet.classicAddress,
+      destination_account: wallet2.classicAddress,
       destination_amount: '100',
     }
 
@@ -59,8 +59,8 @@ describe('path_find', function () {
         const pathFind: PathFindRequest = {
           command: 'path_find',
           subcommand: 'create',
-          source_account: this.wallet.getClassicAddress(),
-          destination_account: wallet2.getClassicAddress(),
+          source_account: this.wallet.classicAddress,
+          destination_account: wallet2.classicAddress,
           destination_amount: '100',
         }
         this.client.request(pathFind).then((response) => {

--- a/test/integration/requests/ripplePathFind.ts
+++ b/test/integration/requests/ripplePathFind.ts
@@ -21,8 +21,8 @@ describe('ripple_path_find', function () {
     const ripplePathFind: RipplePathFindRequest = {
       command: 'ripple_path_find',
       subcommand: 'create',
-      source_account: this.wallet.getClassicAddress(),
-      destination_account: wallet2.getClassicAddress(),
+      source_account: this.wallet.classicAddress,
+      destination_account: wallet2.classicAddress,
       destination_amount: '100',
     }
 
@@ -33,7 +33,7 @@ describe('ripple_path_find', function () {
       type: 'response',
       result: {
         alternatives: response.result.alternatives,
-        destination_account: wallet2.getClassicAddress(),
+        destination_account: wallet2.classicAddress,
         destination_currencies: response.result.destination_currencies,
         destination_amount: ripplePathFind.destination_amount,
         full_reply: true,

--- a/test/integration/requests/submit.ts
+++ b/test/integration/requests/submit.ts
@@ -28,7 +28,7 @@ describe('submit', function () {
   it('submit', async function () {
     const accountSet: AccountSet = {
       TransactionType: 'AccountSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Domain: convertStringToHex('example.com'),
     }
 

--- a/test/integration/requests/submitMultisigned.ts
+++ b/test/integration/requests/submitMultisigned.ts
@@ -41,17 +41,17 @@ describe('submit_multisigned', function () {
     // set up the multisigners for the account
     const signerListSet: SignerListSet = {
       TransactionType: 'SignerListSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       SignerEntries: [
         {
           SignerEntry: {
-            Account: signerWallet1.getClassicAddress(),
+            Account: signerWallet1.classicAddress,
             SignerWeight: 1,
           },
         },
         {
           SignerEntry: {
-            Account: signerWallet2.getClassicAddress(),
+            Account: signerWallet2.classicAddress,
             SignerWeight: 1,
           },
         },
@@ -63,7 +63,7 @@ describe('submit_multisigned', function () {
     // try to multisign
     const accountSet: AccountSet = {
       TransactionType: 'AccountSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Domain: convertStringToHex('example.com'),
     }
     const accountSetTx = await client.autofill(accountSet, 2)

--- a/test/integration/requests/subscribe.ts
+++ b/test/integration/requests/subscribe.ts
@@ -35,7 +35,7 @@ async function createTxHandlerTest(
   const request: SubscribeRequest = {
     command: 'subscribe',
     streams: [subscriptionStream],
-    accounts: [wallet.getClassicAddress()],
+    accounts: [wallet.classicAddress],
   }
 
   client.request(request).then((response) => {
@@ -85,11 +85,11 @@ describe('subscribe', function () {
       // Trigger the event
       const tx: OfferCreate = {
         TransactionType: 'OfferCreate',
-        Account: this.wallet.getClassicAddress(),
+        Account: this.wallet.classicAddress,
         TakerGets: '13100000',
         TakerPays: {
           currency: 'USD',
-          issuer: this.wallet.getClassicAddress(),
+          issuer: this.wallet.classicAddress,
           value: '10',
         },
       }
@@ -107,11 +107,11 @@ describe('subscribe', function () {
     ).then(() => {
       const tx: OfferCreate = {
         TransactionType: 'OfferCreate',
-        Account: this.wallet.getClassicAddress(),
+        Account: this.wallet.classicAddress,
         TakerGets: '13100000',
         TakerPays: {
           currency: 'USD',
-          issuer: this.wallet.getClassicAddress(),
+          issuer: this.wallet.classicAddress,
           value: '10',
         },
       }
@@ -127,7 +127,7 @@ describe('subscribe', function () {
     const request: SubscribeRequest = {
       command: 'subscribe',
       streams: ['ledger'],
-      accounts: [this.wallet.getClassicAddress()],
+      accounts: [this.wallet.classicAddress],
     }
 
     this.client.request(request).then((response) => {

--- a/test/integration/requests/tx.ts
+++ b/test/integration/requests/tx.ts
@@ -18,7 +18,7 @@ describe('tx', function () {
   afterEach(teardownClient)
 
   it('base', async function () {
-    const account = this.wallet.getClassicAddress()
+    const account = this.wallet.classicAddress
     const accountSet: AccountSet = {
       TransactionType: 'AccountSet',
       Account: account,

--- a/test/integration/transactions/accountDelete.ts
+++ b/test/integration/transactions/accountDelete.ts
@@ -26,8 +26,8 @@ describe('AccountDelete', function () {
     await Promise.all(promises)
     const tx: AccountDelete = {
       TransactionType: 'AccountDelete',
-      Account: this.wallet.getClassicAddress(),
-      Destination: wallet2.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Destination: wallet2.classicAddress,
     }
     await testTransaction(this.client, tx, this.wallet)
   })

--- a/test/integration/transactions/accountSet.ts
+++ b/test/integration/transactions/accountSet.ts
@@ -18,7 +18,7 @@ describe('AccountSet', function () {
   it('base', async function () {
     const tx: AccountSet = {
       TransactionType: 'AccountSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
     }
     await testTransaction(this.client, tx, this.wallet)
   })

--- a/test/integration/transactions/checkCancel.ts
+++ b/test/integration/transactions/checkCancel.ts
@@ -20,8 +20,8 @@ describe('CheckCancel', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const setupTx: CheckCreate = {
       TransactionType: 'CheckCreate',
-      Account: this.wallet.getClassicAddress(),
-      Destination: wallet2.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Destination: wallet2.classicAddress,
       SendMax: '50',
     }
 
@@ -30,7 +30,7 @@ describe('CheckCancel', function () {
     // get check ID
     const response1 = await this.client.request({
       command: 'account_objects',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       type: 'check',
     })
     assert.lengthOf(
@@ -43,7 +43,7 @@ describe('CheckCancel', function () {
     // actual test - cancel the check
     const tx: CheckCancel = {
       TransactionType: 'CheckCancel',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       CheckID: checkId,
     }
 
@@ -52,7 +52,7 @@ describe('CheckCancel', function () {
     // confirm that the check no longer exists
     const accountOffersResponse = await this.client.request({
       command: 'account_objects',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       type: 'check',
     })
     assert.lengthOf(

--- a/test/integration/transactions/checkCash.ts
+++ b/test/integration/transactions/checkCash.ts
@@ -22,8 +22,8 @@ describe('CheckCash', function () {
 
     const setupTx: CheckCreate = {
       TransactionType: 'CheckCreate',
-      Account: this.wallet.getClassicAddress(),
-      Destination: wallet2.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Destination: wallet2.classicAddress,
       SendMax: amount,
     }
 
@@ -32,7 +32,7 @@ describe('CheckCash', function () {
     // get check ID
     const response1 = await this.client.request({
       command: 'account_objects',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       type: 'check',
     })
     assert.lengthOf(
@@ -45,7 +45,7 @@ describe('CheckCash', function () {
     // actual test - cash the check
     const tx: CheckCash = {
       TransactionType: 'CheckCash',
-      Account: wallet2.getClassicAddress(),
+      Account: wallet2.classicAddress,
       CheckID: checkId,
       Amount: amount,
     }
@@ -55,7 +55,7 @@ describe('CheckCash', function () {
     // confirm that the check no longer exists
     const accountOffersResponse = await this.client.request({
       command: 'account_objects',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       type: 'check',
     })
     assert.lengthOf(

--- a/test/integration/transactions/checkCreate.ts
+++ b/test/integration/transactions/checkCreate.ts
@@ -20,8 +20,8 @@ describe('CheckCreate', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const tx: CheckCreate = {
       TransactionType: 'CheckCreate',
-      Account: this.wallet.getClassicAddress(),
-      Destination: wallet2.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Destination: wallet2.classicAddress,
       SendMax: '50',
     }
 
@@ -30,7 +30,7 @@ describe('CheckCreate', function () {
     // confirm that the check actually went through
     const accountOffersResponse = await this.client.request({
       command: 'account_objects',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
       type: 'check',
     })
     assert.lengthOf(

--- a/test/integration/transactions/depositPreauth.ts
+++ b/test/integration/transactions/depositPreauth.ts
@@ -20,8 +20,8 @@ describe('DepositPreauth', function () {
     fundAccount(this.client, wallet2)
     const tx: DepositPreauth = {
       TransactionType: 'DepositPreauth',
-      Account: this.wallet.getClassicAddress(),
-      Authorize: wallet2.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Authorize: wallet2.classicAddress,
     }
     await testTransaction(this.client, tx, this.wallet)
   })

--- a/test/integration/transactions/escrowCancel.ts
+++ b/test/integration/transactions/escrowCancel.ts
@@ -27,10 +27,10 @@ describe('EscrowCancel', function () {
     const wallet1 = await generateFundedWallet(this.client)
 
     const createTx: EscrowCreate = {
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       TransactionType: 'EscrowCreate',
       Amount: '10000',
-      Destination: wallet1.getClassicAddress(),
+      Destination: wallet1.classicAddress,
       CancelAfter: CLOSE_TIME + 3,
       FinishAfter: CLOSE_TIME + 2,
     }
@@ -43,7 +43,7 @@ describe('EscrowCancel', function () {
     const accountObjects = (
       await this.client.request({
         command: 'account_objects',
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
       })
     ).result.account_objects
 
@@ -58,8 +58,8 @@ describe('EscrowCancel', function () {
 
     const cancelTx: EscrowCancel = {
       TransactionType: 'EscrowCancel',
-      Account: this.wallet.getClassicAddress(),
-      Owner: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Owner: this.wallet.classicAddress,
       OfferSequence: sequence,
     }
 

--- a/test/integration/transactions/escrowCreate.ts
+++ b/test/integration/transactions/escrowCreate.ts
@@ -27,10 +27,10 @@ describe('EscrowCreate', function () {
 
     const wallet1 = await generateFundedWallet(this.client)
     const tx: EscrowCreate = {
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       TransactionType: 'EscrowCreate',
       Amount: '10000',
-      Destination: wallet1.getClassicAddress(),
+      Destination: wallet1.classicAddress,
       FinishAfter: CLOSE_TIME + 2,
     }
 
@@ -41,7 +41,7 @@ describe('EscrowCreate', function () {
       (
         await this.client.request({
           command: 'account_objects',
-          account: this.wallet.getClassicAddress(),
+          account: this.wallet.classicAddress,
         })
       ).result.account_objects.length,
       1,

--- a/test/integration/transactions/escrowFinish.ts
+++ b/test/integration/transactions/escrowFinish.ts
@@ -29,10 +29,10 @@ describe('EscrowFinish', function () {
     const AMOUNT = 10000
 
     const createTx: EscrowCreate = {
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       TransactionType: 'EscrowCreate',
       Amount: '10000',
-      Destination: wallet1.getClassicAddress(),
+      Destination: wallet1.classicAddress,
       FinishAfter: CLOSE_TIME + 2,
     }
 
@@ -44,7 +44,7 @@ describe('EscrowFinish', function () {
     const accountObjects = (
       await this.client.request({
         command: 'account_objects',
-        account: this.wallet.getClassicAddress(),
+        account: this.wallet.classicAddress,
       })
     ).result.account_objects
 
@@ -59,8 +59,8 @@ describe('EscrowFinish', function () {
 
     const finishTx: EscrowFinish = {
       TransactionType: 'EscrowFinish',
-      Account: this.wallet.getClassicAddress(),
-      Owner: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Owner: this.wallet.classicAddress,
       OfferSequence: sequence,
     }
 

--- a/test/integration/transactions/offerCancel.ts
+++ b/test/integration/transactions/offerCancel.ts
@@ -20,11 +20,11 @@ describe('OfferCancel', function () {
     // set up an offer
     const setupTx: OfferCreate = {
       TransactionType: 'OfferCreate',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       TakerGets: '13100000',
       TakerPays: {
         currency: 'USD',
-        issuer: this.wallet.getClassicAddress(),
+        issuer: this.wallet.classicAddress,
         value: '10',
       },
     }
@@ -33,7 +33,7 @@ describe('OfferCancel', function () {
 
     const accountOffersResponse = await this.client.request({
       command: 'account_offers',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
     })
     assert.lengthOf(
       accountOffersResponse.result.offers,
@@ -45,7 +45,7 @@ describe('OfferCancel', function () {
     // actually test OfferCancel
     const tx: OfferCancel = {
       TransactionType: 'OfferCancel',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       OfferSequence: seq,
     }
 
@@ -53,7 +53,7 @@ describe('OfferCancel', function () {
 
     const accountOffersResponse2 = await this.client.request({
       command: 'account_offers',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
     })
     assert.lengthOf(
       accountOffersResponse2.result.offers,

--- a/test/integration/transactions/offerCreate.ts
+++ b/test/integration/transactions/offerCreate.ts
@@ -19,11 +19,11 @@ describe('OfferCreate', function () {
   it('base', async function () {
     const tx: OfferCreate = {
       TransactionType: 'OfferCreate',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       TakerGets: '13100000',
       TakerPays: {
         currency: 'USD',
-        issuer: this.wallet.getClassicAddress(),
+        issuer: this.wallet.classicAddress,
         value: '10',
       },
     }
@@ -33,7 +33,7 @@ describe('OfferCreate', function () {
     // confirm that the offer actually went through
     const accountOffersResponse = await this.client.request({
       command: 'account_offers',
-      account: this.wallet.getClassicAddress(),
+      account: this.wallet.classicAddress,
     })
     assert.lengthOf(
       accountOffersResponse.result.offers,

--- a/test/integration/transactions/payment.ts
+++ b/test/integration/transactions/payment.ts
@@ -19,8 +19,8 @@ describe('Payment', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const tx: Payment = {
       TransactionType: 'Payment',
-      Account: this.wallet.getClassicAddress(),
-      Destination: wallet2.getClassicAddress(),
+      Account: this.wallet.classicAddress,
+      Destination: wallet2.classicAddress,
       Amount: '1000',
     }
     await testTransaction(this.client, tx, this.wallet)

--- a/test/integration/transactions/paymentChannelClaim.ts
+++ b/test/integration/transactions/paymentChannelClaim.ts
@@ -20,9 +20,9 @@ describe('PaymentChannelClaim', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const paymentChannelCreate: PaymentChannelCreate = {
       TransactionType: 'PaymentChannelCreate',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Amount: '100',
-      Destination: wallet2.getClassicAddress(),
+      Destination: wallet2.classicAddress,
       SettleDelay: 86400,
       PublicKey: this.wallet.publicKey,
     }
@@ -35,11 +35,11 @@ describe('PaymentChannelClaim', function () {
     await testTransaction(this.client, paymentChannelCreate, this.wallet)
 
     const paymentChannelClaim: PaymentChannelClaim = {
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       TransactionType: 'PaymentChannelClaim',
       Channel: hashPaymentChannel(
-        this.wallet.getClassicAddress(),
-        wallet2.getClassicAddress(),
+        this.wallet.classicAddress,
+        wallet2.classicAddress,
         paymentChannelResponse.result.tx_json.Sequence ?? 0,
       ),
       Amount: '100',

--- a/test/integration/transactions/paymentChannelCreate.ts
+++ b/test/integration/transactions/paymentChannelCreate.ts
@@ -19,9 +19,9 @@ describe('PaymentChannelCreate', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const paymentChannelCreate: PaymentChannelCreate = {
       TransactionType: 'PaymentChannelCreate',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Amount: '100',
-      Destination: wallet2.getClassicAddress(),
+      Destination: wallet2.classicAddress,
       SettleDelay: 86400,
       PublicKey: this.wallet.publicKey,
     }

--- a/test/integration/transactions/paymentChannelFund.ts
+++ b/test/integration/transactions/paymentChannelFund.ts
@@ -20,9 +20,9 @@ describe('PaymentChannelFund', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const paymentChannelCreate: PaymentChannelCreate = {
       TransactionType: 'PaymentChannelCreate',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       Amount: '100',
-      Destination: wallet2.getClassicAddress(),
+      Destination: wallet2.classicAddress,
       SettleDelay: 86400,
       PublicKey: this.wallet.publicKey,
     }
@@ -34,11 +34,11 @@ describe('PaymentChannelFund', function () {
     await testTransaction(this.client, paymentChannelCreate, this.wallet)
 
     const paymentChannelFund: PaymentChannelFund = {
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       TransactionType: 'PaymentChannelFund',
       Channel: hashPaymentChannel(
-        this.wallet.getClassicAddress(),
-        wallet2.getClassicAddress(),
+        this.wallet.classicAddress,
+        wallet2.classicAddress,
         paymentChannelResponse.result.tx_json.Sequence ?? 0,
       ),
       Amount: '100',

--- a/test/integration/transactions/signerListSet.ts
+++ b/test/integration/transactions/signerListSet.ts
@@ -18,7 +18,7 @@ describe('SignerListSet', function () {
   it('base', async function () {
     const tx: SignerListSet = {
       TransactionType: 'SignerListSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       SignerEntries: [
         {
           SignerEntry: {

--- a/test/integration/transactions/trustSet.ts
+++ b/test/integration/transactions/trustSet.ts
@@ -19,10 +19,10 @@ describe('TrustSet', function () {
     const wallet2 = await generateFundedWallet(this.client)
     const tx: TrustSet = {
       TransactionType: 'TrustSet',
-      Account: this.wallet.getClassicAddress(),
+      Account: this.wallet.classicAddress,
       LimitAmount: {
         currency: 'USD',
-        issuer: wallet2.getClassicAddress(),
+        issuer: wallet2.classicAddress,
         value: '100',
       },
     }

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -26,7 +26,7 @@ export async function fundAccount(
   const payment: Payment = {
     TransactionType: 'Payment',
     Account: masterAccount,
-    Destination: wallet.getClassicAddress(),
+    Destination: wallet.classicAddress,
     // 2 times the amount needed for a new account (20 XRP)
     Amount: '400000000',
   }
@@ -108,7 +108,7 @@ export async function getXRPBalance(
 ): Promise<string> {
   const request: AccountInfoRequest = {
     command: 'account_info',
-    account: wallet.getClassicAddress(),
+    account: wallet.classicAddress,
   }
   return (await client.request(request)).result.account_data.Balance
 }


### PR DESCRIPTION
## High Level Overview of Change

We had two equivalent methods of getting the classicAddress, so I removed the .getClassicAddress since public fields are common on the Wallet object.

### Context of Change

Duplicate code.

### Type of Change

- [X] Refactor (non-breaking change that only restructures code)

## Before / After

Title says it all

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->