### PR TITLE
refactor: rename `ISOTimeToRippleTime` to `isoTimeToRippleTime`

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -186,7 +186,7 @@ export {
   xrpToDrops,
   hasNextPage,
   rippleTimeToISOTime,
-  isoTimeToRippleTime as ISOTimeToRippleTime,
+  isoTimeToRippleTime,
   rippleTimeToUnixTime,
   unixTimeToRippleTime,
   percentToQuality,

--- a/src/utils/timeConversion.ts
+++ b/src/utils/timeConversion.ts
@@ -40,8 +40,9 @@ function rippleTimeToISOTime(rippleTime: number): string {
  * @returns Seconds since ripple epoch (1/1/2000 GMT).
  * @category Utilities
  */
-function isoTimeToRippleTime(iso8601: string): number {
-  return unixTimeToRippleTime(Date.parse(iso8601))
+function isoTimeToRippleTime(iso8601: string | Date): number {
+  const isoDate = typeof iso8601 === 'string' ? new Date(iso8601) : iso8601
+  return unixTimeToRippleTime(isoDate.getTime())
 }
 
 export {

--- a/test/utils/timeConversion.ts
+++ b/test/utils/timeConversion.ts
@@ -1,0 +1,48 @@
+import { assert } from 'chai'
+
+import {
+  rippleTimeToISOTime,
+  isoTimeToRippleTime,
+  unixTimeToRippleTime,
+  rippleTimeToUnixTime,
+} from '../../src'
+
+describe('time conversion', function () {
+  describe('rippleTimeToISOTime', function () {
+    it('converts ripple time to ISO time', function () {
+      const rippleTime = 0
+      const isoTime = '2000-01-01T00:00:00.000Z'
+      assert.equal(rippleTimeToISOTime(rippleTime), isoTime)
+    })
+  })
+
+  describe('isoTimeToRippleTime', function () {
+    it('converts ISO time to ripple time', function () {
+      const rippleTime = 0
+      const isoTime = '2000-01-01T00:00:00.000Z'
+      assert.equal(isoTimeToRippleTime(isoTime), rippleTime)
+    })
+
+    it('converts from Date', function () {
+      const rippleTime = 0
+      const isoTime = '2000-01-01T00:00:00.000Z'
+      assert.equal(isoTimeToRippleTime(new Date(isoTime)), rippleTime)
+    })
+  })
+
+  describe('unixTimeToRippleTime', function () {
+    it('converts unix time to ripple time', function () {
+      const unixTime = 946684801000
+      const rippleTime = 1
+      assert.equal(unixTimeToRippleTime(unixTime), rippleTime)
+    })
+  })
+
+  describe('rippleTimeToUnixTime', function () {
+    it('converts ripple time to unix time', function () {
+      const unixTime = 946684801000
+      const rippleTime = 1
+      assert.equal(rippleTimeToUnixTime(rippleTime), unixTime)
+    })
+  })
+})


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* renames the util method `ISOTimeToRippleTime` to `isoTimeToRippleTime`, to follow JS paradigms
* adds tests for the time conversion methods, which weren't actually tested
* allows users to pass in a `Date` object to `isoTimeToRippleTime`
* refactors `isoTimeToRippleTime` to avoid using `Date.parse`, which is [discouraged](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse)

### Context of Change

The original name was causing linter complaints in #1729 

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.