### PR TITLE
remove getFee from Client

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -89,7 +89,6 @@ import {
   ensureClassicAddress,
   getLedgerIndex,
   getOrderbook,
-  getFeeXrp,
   getBalances,
   getXrpBalance,
   submit,
@@ -583,11 +582,6 @@ class Client extends EventEmitter {
    * @category Core
    */
   public autofill = autofill
-
-  /**
-   * @category Fee
-   */
-  public getFeeXrp = getFeeXrp
 
   /**
    * @category Core

--- a/src/sugar/autofill.ts
+++ b/src/sugar/autofill.ts
@@ -8,6 +8,8 @@ import { Transaction } from '../models/transactions'
 import setTransactionFlagsToNumber from '../models/utils/flags'
 import { xrpToDrops } from '../utils'
 
+import getFeeXrp from './fee'
+
 // Expire unconfirmed transactions after 20 ledger versions, approximately 1 minute, by default
 const LEDGER_OFFSET = 20
 interface ClassicAccountAndTag {
@@ -151,7 +153,7 @@ async function calculateFeePerTransactionType(
   signersCount = 0,
 ): Promise<void> {
   // netFee is usually 0.00001 XRP (10 drops)
-  const netFeeXRP = await client.getFeeXrp()
+  const netFeeXRP = await getFeeXrp(client)
   const netFeeDrops = xrpToDrops(netFeeXRP)
   let baseFee = new BigNumber(netFeeDrops)
 

--- a/src/sugar/fee.ts
+++ b/src/sugar/fee.ts
@@ -10,17 +10,17 @@ const BASE_10 = 10
  * Calculates the current transaction fee for the ledger.
  * Note: This is a public API that can be called directly.
  *
- * @param this - The Client used to connect to the ledger.
+ * @param client - The Client used to connect to the ledger.
  * @param cushion - The fee cushion to use.
  * @returns The transaction fee.
  */
 export default async function getFeeXrp(
-  this: Client,
+  client: Client,
   cushion?: number,
 ): Promise<string> {
-  const feeCushion = cushion ?? this.feeCushion
+  const feeCushion = cushion ?? client.feeCushion
 
-  const serverInfo = (await this.request({ command: 'server_info' })).result
+  const serverInfo = (await client.request({ command: 'server_info' })).result
     .info
 
   const baseFee = serverInfo.validated_ledger?.base_fee_xrp
@@ -39,7 +39,7 @@ export default async function getFeeXrp(
   let fee = baseFeeXrp.times(serverInfo.load_factor).times(feeCushion)
 
   // Cap fee to `client.maxFeeXRP`
-  fee = BigNumber.min(fee, this.maxFeeXRP)
+  fee = BigNumber.min(fee, client.maxFeeXRP)
   // Round fee to 6 decimal places
   return new BigNumber(fee.toFixed(NUM_DECIMAL_PLACES)).toString(BASE_10)
 }

--- a/src/sugar/index.ts
+++ b/src/sugar/index.ts
@@ -2,8 +2,6 @@ export { default as autofill } from './autofill'
 
 export { getBalances, getXrpBalance } from './balances'
 
-export { default as getFeeXrp } from './fee'
-
 export { default as getLedgerIndex } from './ledgerIndex'
 
 export { default as getOrderbook } from './orderbook'

--- a/test/client/getFeeXrp.ts
+++ b/test/client/getFeeXrp.ts
@@ -1,15 +1,16 @@
 import { assert } from 'chai'
 
+import getFeeXrp from '../../src/sugar/fee'
 import rippled from '../fixtures/rippled'
 import { setupClient, teardownClient } from '../setupClient'
 
-describe('client.getFeeXrp', function () {
+describe('getFeeXrp', function () {
   beforeEach(setupClient)
   afterEach(teardownClient)
 
   it('getFeeXrp', async function () {
     this.mockRippled.addResponse('server_info', rippled.server_info.normal)
-    const fee = await this.client.getFeeXrp()
+    const fee = await getFeeXrp(this.client)
     assert.strictEqual(fee, '0.000012')
   })
 
@@ -18,7 +19,7 @@ describe('client.getFeeXrp', function () {
       'server_info',
       rippled.server_info.highLoadFactor,
     )
-    const fee = await this.client.getFeeXrp()
+    const fee = await getFeeXrp(this.client)
     assert.strictEqual(fee, '2')
   })
 
@@ -33,14 +34,14 @@ describe('client.getFeeXrp', function () {
      * (fee will actually be 51539.607552)
      */
     this.client.maxFeeXRP = '51540'
-    const fee = await this.client.getFeeXrp()
+    const fee = await getFeeXrp(this.client)
     assert.strictEqual(fee, '51539.607552')
   })
 
   it('getFeeXrp custom cushion', async function () {
     this.mockRippled.addResponse('server_info', rippled.server_info.normal)
     this.client.feeCushion = 1.4
-    const fee = await this.client.getFeeXrp()
+    const fee = await getFeeXrp(this.client)
     assert.strictEqual(fee, '0.000014')
   })
 
@@ -51,13 +52,13 @@ describe('client.getFeeXrp', function () {
   it('getFeeXrp cushion less than 1.0', async function () {
     this.mockRippled.addResponse('server_info', rippled.server_info.normal)
     this.client.feeCushion = 0.9
-    const fee = await this.client.getFeeXrp()
+    const fee = await getFeeXrp(this.client)
     assert.strictEqual(fee, '0.000009')
   })
 
   it('getFeeXrp reporting', async function () {
     this.mockRippled.addResponse('server_info', rippled.server_info.normal)
-    const fee = await this.client.getFeeXrp()
+    const fee = await getFeeXrp(this.client)
     assert.strictEqual(fee, '0.000012')
   })
 })


### PR DESCRIPTION
## High Level Overview of Change
Removes `getFee()` from client

### Context of Change
Removes `getFee` in favor of the `fee` RPC. getFee is still used in autofill.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
