### PR TITLE
fix: order webpack plugins

### DIFF
--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -34,12 +34,6 @@ function webpackForTest(testFileName) {
       filename: match[1] + '.js',
     },
     plugins: [
-      new webpack.ProvidePlugin({ process: 'process/browser' }),
-      new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
-      new webpack.IgnorePlugin({
-        resourceRegExp: /^\.\/wordlists\/(?!english)/,
-        contextRegExp: /bip39\/src$/,
-      }),
       // this is a bit of a hack to prevent 'bn.js' from being installed 6 times
       // TODO: any package that is updated to use bn.js 5.x needs to be removed from `bnJsReplaces` above
       // https://github.com/webpack/webpack/issues/5593#issuecomment-390356276
@@ -51,6 +45,12 @@ function webpackForTest(testFileName) {
         ) {
           resource.request = 'diffie-hellman/node_modules/bn.js'
         }
+      }),
+      new webpack.ProvidePlugin({ process: 'process/browser' }),
+      new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^\.\/wordlists\/(?!english)/,
+        contextRegExp: /bip39\/src$/,
       }),
     ],
     module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,13 +24,6 @@ function getDefaultConfiguration() {
       filename: `xrpl.default.js`,
     },
     plugins: [
-      new webpack.NormalModuleReplacementPlugin(/^ws$/, './WSWrapper'),
-      new webpack.ProvidePlugin({ process: 'process/browser' }),
-      new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
-      new webpack.IgnorePlugin({
-        resourceRegExp: /^\.\/wordlists\/(?!english)/,
-        contextRegExp: /bip39\/src$/,
-      }),
       // this is a bit of a hack to prevent 'bn.js' from being installed 6 times
       // TODO: any package that is updated to use bn.js 5.x needs to be removed from `bnJsReplaces` above
       // https://github.com/webpack/webpack/issues/5593#issuecomment-390356276
@@ -42,6 +35,13 @@ function getDefaultConfiguration() {
         ) {
           resource.request = 'diffie-hellman/node_modules/bn.js'
         }
+      }),
+      new webpack.NormalModuleReplacementPlugin(/^ws$/, './WSWrapper'),
+      new webpack.ProvidePlugin({ process: 'process/browser' }),
+      new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^\.\/wordlists\/(?!english)/,
+        contextRegExp: /bip39\/src$/,
       }),
     ],
     module: {


### PR DESCRIPTION
## High Level Overview of Change
Fixes ordering of webpack plugins. This is a potential fix for #1763. We wont know if this is a fix until we can repro the issue.

### Context of Change
The use of the `process/browser` polyfill before the `bn.js` polyfill meant that in some places NodeJS code from `node_modules` was being introduced. Did a quick search of the built files before and after, and before the change `process.env.NODE_DEBUG` is present, and after it is not.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release