### PR TITLE
feat: add missing fields to Transaction type

### DIFF
--- a/src/models/transactions/common.ts
+++ b/src/models/transactions/common.ts
@@ -176,6 +176,18 @@ export interface BaseTransaction {
    * account it says it is from.
    */
   TxnSignature?: string
+  /**
+   * The date/time when this transaction was included in a validated ledger.
+   */
+  date?: number
+  /**
+   * An identifying hash value unique to this transaction, as a hex string.
+   */
+  hash?: string
+  /**
+   * The sequence number of the ledger that included this transaction.
+   */
+  ledger_index?: number
 }
 
 /**


### PR DESCRIPTION
## High Level Overview of Change

This allows you to access the date, hash, and ledger_index fields.

### Context of Change

These fields are available when retrieving transactions from a validated ledger, e.g. with the 'account_tx' command.

The returned txs have date, hash, and ledger_index fields.

Without this fix, TypeScript users need to apply workarounds such as type assertion on the returned objects (e.g. `as any`)

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Before / After

Before:
`xrpl.rippleTimeToISOTime((transaction.tx as any).date)`

After:
`xrpl.rippleTimeToISOTime(transaction.tx.date)`