### PR TITLE
Update packages post-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16607,7 +16607,7 @@
       }
     },
     "packages/ripple-address-codec": {
-      "version": "4.2.1-beta.0",
+      "version": "4.2.1",
       "integrity": "sha512-9QhBNDiWjwj7l+WQ7H7klXF/VwxVj2Q0HRhd4vLCueTPoxUtaNQyfvUZFiXJrqxg0heM3/iWxupkq4TwrXgSuQ==",
       "license": "ISC",
       "dependencies": {
@@ -16619,7 +16619,7 @@
       }
     },
     "packages/ripple-binary-codec": {
-      "version": "1.2.1-beta.0",
+      "version": "1.2.1",
       "integrity": "sha512-XMRCbFXyG+dGp3x7tMs9IwA+FVWPPaGjdHYW2+g4Q/WQJqFp5MRED+jjOBOUafmrW4TUsOn1PEEdbB4ozWbDBw==",
       "license": "ISC",
       "dependencies": {
@@ -16628,7 +16628,7 @@
         "buffer": "5.6.0",
         "create-hash": "^1.2.0",
         "decimal.js": "^10.2.0",
-        "ripple-address-codec": "^4.2.1-beta.0"
+        "ripple-address-codec": "^4.2.1"
       },
       "engines": {
         "node": ">=10.22.0"
@@ -16643,7 +16643,7 @@
       }
     },
     "packages/ripple-keypairs": {
-      "version": "1.1.1-beta.0",
+      "version": "1.1.1",
       "integrity": "sha512-Zlmbtn2YUpW4uKlLm2/tpkY5RC/EXQlkJwIIKp0AoF9D23pJ43/EuipNW2F6qURdbkUezDwB0bMV7uRXip3x2w==",
       "license": "ISC",
       "dependencies": {
@@ -16651,14 +16651,14 @@
         "brorand": "^1.0.5",
         "elliptic": "^6.5.4",
         "hash.js": "^1.0.3",
-        "ripple-address-codec": "^4.2.1-beta.0"
+        "ripple-address-codec": "^4.2.1"
       },
       "engines": {
         "node": ">= 10"
       }
     },
     "packages/xrpl": {
-      "version": "2.0.3-beta.0",
+      "version": "2.0.3",
       "integrity": "sha512-NmrSYpXym7NzGABeXU1H8g4ZtCxRhr/3wu0lguxzcIYpcKPgWLYimg+s9NLLNbPWTZdxXu9SeSWu5zh4gyqAeA==",
       "license": "ISC",
       "dependencies": {
@@ -16667,9 +16667,9 @@
         "bip39": "^3.0.4",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.4",
-        "ripple-address-codec": "^4.2.1-beta.0",
-        "ripple-binary-codec": "^1.2.1-beta.0",
-        "ripple-keypairs": "^1.1.1-beta.0",
+        "ripple-address-codec": "^4.2.1",
+        "ripple-binary-codec": "^1.2.1",
+        "ripple-keypairs": "^1.1.1",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -27095,7 +27095,7 @@
         "buffer": "5.6.0",
         "create-hash": "^1.2.0",
         "decimal.js": "^10.2.0",
-        "ripple-address-codec": "^4.2.1-beta.0"
+        "ripple-address-codec": "^4.2.1"
       },
       "dependencies": {
         "buffer": {
@@ -27115,7 +27115,7 @@
         "brorand": "^1.0.5",
         "elliptic": "^6.5.4",
         "hash.js": "^1.0.3",
-        "ripple-address-codec": "^4.2.1-beta.0"
+        "ripple-address-codec": "^4.2.1"
       }
     },
     "rsvp": {
@@ -29252,9 +29252,9 @@
         "bip39": "^3.0.4",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.4",
-        "ripple-address-codec": "^4.2.1-beta.0",
-        "ripple-binary-codec": "^1.2.1-beta.0",
-        "ripple-keypairs": "^1.1.1-beta.0",
+        "ripple-address-codec": "^4.2.1",
+        "ripple-binary-codec": "^1.2.1",
+        "ripple-keypairs": "^1.1.1",
         "ws": "^8.2.2",
         "xrpl-local": "file:src"
       },

--- a/packages/ripple-address-codec/package.json
+++ b/packages/ripple-address-codec/package.json
@@ -28,5 +28,6 @@
   "prettier": "@xrplf/prettier-config",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "gitHead": "7c6230b18ec2ed031c7e379ffb94e34b940b6542"
 }

--- a/packages/ripple-binary-codec/package.json
+++ b/packages/ripple-binary-codec/package.json
@@ -41,5 +41,6 @@
   "prettier": "@xrplf/prettier-config",
   "engines": {
     "node": ">=10.22.0"
-  }
+  },
+  "gitHead": "7c6230b18ec2ed031c7e379ffb94e34b940b6542"
 }

--- a/packages/ripple-keypairs/package.json
+++ b/packages/ripple-keypairs/package.json
@@ -31,5 +31,6 @@
   "prettier": "@xrplf/prettier-config",
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "gitHead": "7c6230b18ec2ed031c7e379ffb94e34b940b6542"
 }

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -65,5 +65,6 @@
   "readmeFilename": "README.md",
   "engines": {
     "node": ">=10.13.0"
-  }
+  },
+  "gitHead": "7c6230b18ec2ed031c7e379ffb94e34b940b6542"
 }


### PR DESCRIPTION
## High Level Overview of Change

Lerna added gitHeads to packages and we ran `npm i` which updated the package-lock post release.

