### PR TITLE
fix: encoding issue with encoding non-traditional currency codes

### DIFF
--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -89,7 +89,7 @@ class Currency extends Hash160 {
 
     if (this.bytes[0] !== 0) {
       this._iso = null
-    } else if (code.toString('hex') === '000000') {
+    } else if (/^0*$/.test(this.bytes.toString('hex'))) {
       this._iso = 'XRP'
     } else {
       this._iso = isoCodeFromHex(code)

--- a/packages/ripple-binary-codec/test/hash.test.js
+++ b/packages/ripple-binary-codec/test/hash.test.js
@@ -69,6 +69,7 @@ describe('Currency', function () {
     expect(Currency.from('X8P').toJSON()).toBe('X8P')
     expect(Currency.from('USD').toJSON()).toBe('USD')
   })
+
   test('can be constructed from a Buffer', function () {
     const xrp = new Currency(Buffer.alloc(20))
     expect(xrp.iso()).toBe('XRP')
@@ -77,6 +78,12 @@ describe('Currency', function () {
     const currency = '015841551A748AD2C1F76FF6ECB0CCCD00000000'
     expect(Currency.from(currency).toJSON()).toBe(currency)
   })
+
+  test('Can handle other non-standard currency codes', () => {
+    const currency = '0000000000414C6F676F30330000000000000000'
+    expect(Currency.from(currency).toJSON()).toBe(currency)
+  })
+
   test('throws on invalid reprs', function () {
     expect(() => Currency.from(Buffer.alloc(19))).toThrow()
     expect(() => Currency.from(1)).toThrow()


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes an issue where some tokens with non-traditional currency codes weren't being encoded properly; they were being encoded as `XRP` for some reason. 

### Context of Change

Issue with data ingestion from the ledger (calculated tx hash wasn't equal to the rippled-calculated hash)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added test. CI passes.