### PR TITLE
Move UNLModify fix to proper History.md file

### DIFF
--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## 1.2.2 (2021-12-2)
 - Fix issue where unsupported currency codes weren't being correctly processed
+- Added a workaround for rippled UNLModify encoding bug (#1830)
 
 ## 1.2.1 (2021-12-1)
 - Fix issue where npm < 7 could not install the library

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,7 +4,6 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## 2.0.3 (2021-12-1)
 * Removes requirement for npm version > 7 for non-contributors
-* Added a workaround for rippled UNLModify encoding bug (#1830)
 * For contributors -
   * Renamed the master branch to main, and now just have one main branch
   * Fixed issues which made Windows contributors unable to build the library


### PR DESCRIPTION
## High Level Overview of Change

Move the release notes for the UNLModify fix into ripple-binary-codec since that's where the code changed. 

### Context of Change

Accidentally put this fix into the xrpl HISTORY.md, but it belongs in the ripple-binary-codec HISTORY.md.

### Type of Change

- [X] Documentation Updates

## Before / After

Title says it all

## Test Plan

Manually checked where the corresponding code change was, and it was in ripple-binary-codec

<!--
## Future Tasks
For future tasks related to PR.
-->