### PR TITLE
fix: `txnNotFound` error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16659,7 +16659,7 @@
       }
     },
     "packages/xrpl": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "integrity": "sha512-NmrSYpXym7NzGABeXU1H8g4ZtCxRhr/3wu0lguxzcIYpcKPgWLYimg+s9NLLNbPWTZdxXu9SeSWu5zh4gyqAeA==",
       "license": "ISC",
       "dependencies": {

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -2,7 +2,13 @@
 
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
-## Unreleased 
+## Unreleased
+
+## 2.1.1 (2021-12-23)
+### Fixed
+* A bug in submitAndWait function where the transaction could still be in queue and the server returns `txnNotFound`.
+
+## 2.1.0 (2021-12-17)
 ### Added
 * Support for the [XLS-20 NFT proposal](https://github.com/XRPLF/XRPL-Standards/discussions/46)
 

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -122,7 +122,7 @@ async function submitRequest(
  * validated ledger, or the transaction's lastLedgerSequence has been surpassed by the
  * latest ledger sequence (meaning it will never be included in a validated ledger).
  */
-// eslint-disable max-params, max-lines-per-function -- waitForFinalTxOutcome needs to display and do with more information.
+// eslint-disable-next-line max-params, max-lines-per-function -- this function needs to display and do with more information.
 async function waitForFinalTransactionOutcome(
   client: Client,
   txHash: string,

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -127,20 +127,21 @@ async function waitForFinalTransactionOutcome(
       command: 'tx',
       transaction: txHash,
     })
-    .catch((error) => {
+    .catch(async (error) => {
+      // this type of error does not have its interface, type-assert and extract the value we need.
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- L131
       const castedError = error.data as { error: string }
-      if (castedError.error == 'txnNotFound') {
+      if (castedError.error === 'txnNotFound') {
         return waitForFinalTransactionOutcome(client, txHash)
-      } else {
-        throw new Error(String(castedError.error))
       }
+      throw new Error(String(castedError.error))
     })
 
-  if (txResponse?.result.validated) {
+  if (txResponse.result.validated) {
     return txResponse
   }
 
-  const txLastLedger = txResponse?.result.LastLedgerSequence
+  const txLastLedger = txResponse.result.LastLedgerSequence
   if (txLastLedger == null) {
     throw new XrplError('LastLedgerSequence cannot be null')
   }

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -136,7 +136,7 @@ async function waitForFinalTransactionOutcome(
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- L131
       const message = error.data.error as string
       if (message === 'txnNotFound') {
-        if (lastLedger > (await client.getLedgerIndex())) {
+        if (lastLedger < (await client.getLedgerIndex())) {
           throw new XrplError(
             `The latest ledger sequence ${latestLedger} is greater than the transaction's LastLedgerSequence (${lastLedger}).`,
           )

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -147,7 +147,7 @@ async function waitForFinalTransactionOutcome(
     })
     .catch(async (error) => {
       // error is of an unknown type and hence we assert type to extract the value we need.
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- L131
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- ^
       const message = error.data.error as string
       if (message === 'txnNotFound') {
         return waitForFinalTransactionOutcome(

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -130,11 +130,11 @@ async function waitForFinalTransactionOutcome(
     .catch(async (error) => {
       // this type of error does not have its interface, type-assert and extract the value we need.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- L131
-      const castedError = error.data as { error: string }
-      if (castedError.error === 'txnNotFound') {
+      const message = error.data.error as string
+      if (message === 'txnNotFound') {
         return waitForFinalTransactionOutcome(client, txHash)
       }
-      throw new Error(String(castedError.error))
+      throw new Error(message)
     })
 
   if (txResponse.result.validated) {

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -122,7 +122,7 @@ async function submitRequest(
  * validated ledger, or the transaction's lastLedgerSequence has been surpassed by the
  * latest ledger sequence (meaning it will never be included in a validated ledger).
  */
-// eslint-disable-next-line max-params, max-lines-per-function -- fn needs to display and do with more information.
+// eslint-disable max-params, max-lines-per-function -- waitForFinalTxOutcome needs to display and do with more information.
 async function waitForFinalTransactionOutcome(
   client: Client,
   txHash: string,
@@ -135,8 +135,8 @@ async function waitForFinalTransactionOutcome(
 
   if (lastLedger < latestLedger) {
     throw new XrplError(
-      `The latest ledger sequence ${latestLedger} is greater than the transaction's LastLedgerSequence (${lastLedger}).
-      Preliminary result: ${submissionResult}`,
+      `The latest ledger sequence ${latestLedger} is greater than the transaction's LastLedgerSequence (${lastLedger}).\n` +
+        `Preliminary result: ${submissionResult}`,
     )
   }
 

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-params -- waitForFinalTxOutcome needs to display and do with more information to work perfectly. */
-/* eslint-disable max-lines-per-function -- waitForFinalTxOutcome has a lot of computations to do and conditions to check. */
 import { decode, encode } from 'ripple-binary-codec'
 
 import type { Client, SubmitRequest, SubmitResponse, Wallet } from '..'
@@ -124,6 +122,7 @@ async function submitRequest(
  * validated ledger, or the transaction's lastLedgerSequence has been surpassed by the
  * latest ledger sequence (meaning it will never be included in a validated ledger).
  */
+// eslint-disable-next-line max-params, max-lines-per-function -- fn needs to display and do with more information.
 async function waitForFinalTransactionOutcome(
   client: Client,
   txHash: string,
@@ -147,7 +146,7 @@ async function waitForFinalTransactionOutcome(
       transaction: txHash,
     })
     .catch(async (error) => {
-      // this type of error does not have its interface, type-assert and extract the value we need.
+      // error is of an unknown type and hence we assert type to extract the value we need.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- L131
       const message = error.data.error as string
       if (message === 'txnNotFound') {

--- a/packages/xrpl/test/integration/requests/submit.ts
+++ b/packages/xrpl/test/integration/requests/submit.ts
@@ -7,11 +7,9 @@ import {
   SubmitResponse,
   hashes,
   Transaction,
-  RippledError,
 } from 'xrpl-local'
 import { convertStringToHex } from 'xrpl-local/utils'
 
-import { assertRejects } from '../../testUtils'
 import serverUrl from '../serverUrl'
 import { setupClient, teardownClient } from '../setup'
 import { ledgerAccept, verifySubmittedTransaction } from '../utils'
@@ -75,26 +73,5 @@ describe('submit', function () {
     }
 
     assert.deepEqual(submitResponse, expectedResponse)
-  })
-
-  // Reproduces the 'txnNotFound' case
-  it('submit & quickly check status without waiting', async function () {
-    const accountSet: AccountSet = {
-      TransactionType: 'AccountSet',
-      Account: this.wallet.classicAddress,
-      Domain: convertStringToHex('example.com'),
-    }
-    const { tx_blob: signedAccountSet } = this.wallet.sign(
-      await this.client.autofill(accountSet),
-    )
-    this.client.submit(signedAccountSet)
-
-    await assertRejects(
-      this.client.request({
-        command: 'tx',
-        transaction: hashes.hashSignedTx(signedAccountSet),
-      }),
-      RippledError,
-    )
   })
 })

--- a/packages/xrpl/test/integration/requests/submit.ts
+++ b/packages/xrpl/test/integration/requests/submit.ts
@@ -7,9 +7,11 @@ import {
   SubmitResponse,
   hashes,
   Transaction,
+  RippledError,
 } from 'xrpl-local'
 import { convertStringToHex } from 'xrpl-local/utils'
 
+import { assertRejects } from '../../testUtils'
 import serverUrl from '../serverUrl'
 import { setupClient, teardownClient } from '../setup'
 import { ledgerAccept, verifySubmittedTransaction } from '../utils'
@@ -73,5 +75,26 @@ describe('submit', function () {
     }
 
     assert.deepEqual(submitResponse, expectedResponse)
+  })
+
+  // Reproduces the 'txnNotFound' case
+  it('submit & quickly check status without waiting', async function () {
+    const accountSet: AccountSet = {
+      TransactionType: 'AccountSet',
+      Account: this.wallet.classicAddress,
+      Domain: convertStringToHex('example.com'),
+    }
+    const { tx_blob: signedAccountSet } = this.wallet.sign(
+      await this.client.autofill(accountSet),
+    )
+    this.client.submit(signedAccountSet)
+
+    await assertRejects(
+      this.client.request({
+        command: 'tx',
+        transaction: hashes.hashSignedTx(signedAccountSet),
+      }),
+      RippledError,
+    )
   })
 })


### PR DESCRIPTION
## High Level Overview of Change
Add validation for RippledError when a tx has not been validated and the lastLedgerSequence hasn't passed.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
I came across 2 transactions where the `submitAndWait` function failed to get the status of the transaction when the transaction is still in queue and tx command is not able to find it reason being it is not processed and hence doesn't reflect on rippled databases.

![image](https://user-images.githubusercontent.com/49061120/147276676-11fcf036-a8a3-406c-8853-c92395b00119.png)

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
Now, if the transaction is not found, we wait for it to show up(assuming it is going to be processed) or wait for the LastLedgerSequence to pass.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Added test to demonstrate how it is reproduced. Passes CI tests.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->