### PR TITLE
Update: Add hash type to base transaction interface (common.ts)

### DIFF
--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -160,6 +160,10 @@ export interface BaseTransaction {
    */
   TxnSignature?: string
   /**
+   * A unix timestamp (in seconds) marking the time of the transaction
+   */
+  date?: Number
+  /**
    * Every signed transaction has a unique "hash" that identifies it. 
    * The transaction hash can be used as a "proof of payment" to verify the final status.
    */

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -163,7 +163,7 @@ export interface BaseTransaction {
    * Every signed transaction has a unique "hash" that identifies it. 
    * The transaction hash can be used as a "proof of payment" to verify the final status.
    */
-     hash?: string
+  hash?: string
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -159,6 +159,11 @@ export interface BaseTransaction {
    * account it says it is from.
    */
   TxnSignature?: string
+  /**
+   * Every signed transaction has a unique "hash" that identifies it. 
+   * The transaction hash can be used as a "proof of payment" to verify the final status.
+   */
+     hash?: string
 }
 
 /**


### PR DESCRIPTION
## Add hash & date type to base transaction interface (common.ts)

- Simple additions to the base transaction interface within ./packages/xrpl/src/models/transaction/common.ts

### Context of Change

All transaction types include a unique hash such that it can be identified and validated on chain. All transaction hashes are present in string type.

All transactions include a date - UNIX timestamp (in seconds). This may have been formerly known as executed_time.

https://xrpl.org/transaction-basics.html#identifying-transactions

### Type of Change

[x] Bug fix (non-breaking change which fixes an issue)
