### PR TITLE
Add missing fields to TxSubscription and Tx requests

### DIFF
--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -275,7 +275,7 @@ export interface TransactionStream extends BaseStream {
     date?: number
     /**
      * Every signed transaction has a unique "hash" that identifies it.
-     * The transaction hash can be used as a "proof of payment" to verify the final status.
+     * The transaction hash can be used to look up its final status, which may serve as a "proof of payment"
      */
     hash?: string
   }

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -269,7 +269,14 @@ export interface TransactionStream extends BaseStream {
   meta?: TransactionMetadata
   /** The definition of the transaction in JSON format. */
   transaction: Transaction & {
-    date?: number
+    /**
+     * A unix timestamp (in seconds) marking the time of the transaction
+     */
+    date?: Number
+    /**
+     * Every signed transaction has a unique "hash" that identifies it.
+     * The transaction hash can be used as a "proof of payment" to verify the final status.
+     */
     hash?: string
   }
   /**
@@ -340,7 +347,14 @@ export interface OrderBookStream extends BaseStream {
   ledger_index?: number
   meta: TransactionMetadata
   transaction: (Transaction | ModifiedOfferCreateTransaction) & {
-    date?: number
+    /**
+     * A unix timestamp (in seconds) marking the time of the transaction
+     */
+    date?: Number
+    /**
+     * Every signed transaction has a unique "hash" that identifies it.
+     * The transaction hash can be used as a "proof of payment" to verify the final status.
+     */
     hash?: string
   }
   validated: boolean

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -272,7 +272,7 @@ export interface TransactionStream extends BaseStream {
     /**
      * A unix timestamp (in seconds) marking the time of the transaction
      */
-    date?: Number
+    date?: number
     /**
      * Every signed transaction has a unique "hash" that identifies it.
      * The transaction hash can be used as a "proof of payment" to verify the final status.
@@ -350,7 +350,7 @@ export interface OrderBookStream extends BaseStream {
     /**
      * A unix timestamp (in seconds) marking the time of the transaction
      */
-    date?: Number
+    date?: number
     /**
      * Every signed transaction has a unique "hash" that identifies it.
      * The transaction hash can be used as a "proof of payment" to verify the final status.

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -270,7 +270,7 @@ export interface TransactionStream extends BaseStream {
   /** The definition of the transaction in JSON format. */
   transaction: Transaction & {
     /**
-     * A unix timestamp (in seconds) marking the time of the transaction
+     * This number measures the number of seconds since the "Ripple Epoch" of January 1, 2000 (00:00 UTC)
      */
     date?: number
     /**
@@ -348,7 +348,7 @@ export interface OrderBookStream extends BaseStream {
   meta: TransactionMetadata
   transaction: (Transaction | ModifiedOfferCreateTransaction) & {
     /**
-     * A unix timestamp (in seconds) marking the time of the transaction
+     * This number measures the number of seconds since the "Ripple Epoch" of January 1, 2000 (00:00 UTC)
      */
     date?: number
     /**

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -268,7 +268,10 @@ export interface TransactionStream extends BaseStream {
    */
   meta?: TransactionMetadata
   /** The definition of the transaction in JSON format. */
-  transaction: Transaction
+  transaction: Transaction & {
+    date?: number
+    hash?: string
+  }
   /**
    * If true, this transaction is included in a validated ledger and its
    * outcome is final. Responses from the transaction stream should always be
@@ -336,7 +339,10 @@ export interface OrderBookStream extends BaseStream {
   ledger_hash?: string
   ledger_index?: number
   meta: TransactionMetadata
-  transaction: Transaction | ModifiedOfferCreateTransaction
+  transaction: (Transaction | ModifiedOfferCreateTransaction) & {
+    date?: number
+    hash?: string
+  }
   validated: boolean
 }
 

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -353,7 +353,7 @@ export interface OrderBookStream extends BaseStream {
     date?: number
     /**
      * Every signed transaction has a unique "hash" that identifies it.
-     * The transaction hash can be used as a "proof of payment" to verify the final status.
+     * The transaction hash can be used to look up its final status, which may serve as a "proof of payment"
      */
     hash?: string
   }

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -52,7 +52,7 @@ export interface TxResponse extends BaseResponse {
      */
     validated?: boolean
     /**
-     * A unix timestamp (in seconds) marking the time of the transaction
+     * This number measures the number of seconds since the "Ripple Epoch" of January 1, 2000 (00:00 UTC)
      */
     date?: number
   } & Transaction

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -51,6 +51,10 @@ export interface TxResponse extends BaseResponse {
      * Set to false, this data is not final.
      */
     validated?: boolean
+    /**
+     * A unix timestamp (in seconds) marking the time of the transaction
+     */
+    date?: number
   } & Transaction
   /**
    * If true, the server was able to search all of the specified ledger

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -160,6 +160,10 @@ export interface BaseTransaction {
    */
   TxnSignature?: string
   /**
+   * A unix timestamp (in seconds) marking the time of the transaction
+   */
+  date?: Number
+  /**
    * Every signed transaction has a unique "hash" that identifies it. 
    * The transaction hash can be used as a "proof of payment" to verify the final status.
    */

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -163,7 +163,7 @@ export interface BaseTransaction {
    * Every signed transaction has a unique "hash" that identifies it. 
    * The transaction hash can be used as a "proof of payment" to verify the final status.
    */
-     hash?: string
+  hash?: string
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -159,6 +159,11 @@ export interface BaseTransaction {
    * account it says it is from.
    */
   TxnSignature?: string
+  /**
+   * Every signed transaction has a unique "hash" that identifies it. 
+   * The transaction hash can be used as a "proof of payment" to verify the final status.
+   */
+     hash?: string
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -159,15 +159,6 @@ export interface BaseTransaction {
    * account it says it is from.
    */
   TxnSignature?: string
-  /**
-   * A unix timestamp (in seconds) marking the time of the transaction
-   */
-  date?: Number
-  /**
-   * Every signed transaction has a unique "hash" that identifies it. 
-   * The transaction hash can be used as a "proof of payment" to verify the final status.
-   */
-  hash?: string
 }
 
 /**


### PR DESCRIPTION
## High Level Overview of Change

Adds non-canonical fields which are returned on requests, but are not normally part of transactions on the ledger.

### Context of Change

See #1892 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After

* Before `date` and `hash` were missing from these models even though the requests/subscriptions returned them.

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->