### PR TITLE
[ripple-binary-codec] package.json - fix homepage link

### DIFF
--- a/packages/ripple-binary-codec/package.json
+++ b/packages/ripple-binary-codec/package.json
@@ -35,7 +35,7 @@
   "bugs": {
     "url": "https://github.com/XRPLF/xrpl.js/issues"
   },
-  "homepage": "https://github.com/XRPLF/xrpl.js/packages/ripple-binary-codec#readme",
+  "homepage": "https://github.com/XRPLF/xrpl.js/tree/main/packages/ripple-binary-codec#readme",
   "license": "ISC",
   "readmeFilename": "README.md",
   "prettier": "@xrplf/prettier-config",


### PR DESCRIPTION
## High Level Overview of Change

On the [ripple-binary-codec npm package page](https://www.npmjs.com/package/ripple-binary-codec), the the second GitHub link was broken. This fixes it.

### Context of Change

Reported via @mvadari 

### Type of Change

- [x] Documentation Updates
