### PR TITLE
modifiedNodes bug fix

### DIFF
--- a/src/ledger/parse/settings.ts
+++ b/src/ledger/parse/settings.ts
@@ -5,9 +5,11 @@ const AccountFlags = constants.AccountFlags
 import parseFields from './fields'
 
 function getAccountRootModifiedNode(tx: any) {
-  const modifiedNodes = tx.meta.AffectedNodes.filter(
-    (node) => node.ModifiedNode.LedgerEntryType === 'AccountRoot'
-  )
+// AffectedNodes may have createNode and DeletedNode, then crash here
+//   const modifiedNodes = tx.meta.AffectedNodes.filter(
+//     (node) => node.ModifiedNode.LedgerEntryType === 'AccountRoot'
+//   )
+  const modifiedNodes = tx.meta.AffectedNodes.filter(node =>  node.ModifiedNode && node.ModifiedNode.LedgerEntryType === 'AccountRoot');
   assert.ok(modifiedNodes.length === 1)
   return modifiedNodes[0].ModifiedNode
 }


### PR DESCRIPTION
1. AffectedNodes may have not only ModifiedNode, but also createNode and DeletedNode, then crash

