### PR TITLE
[ripple-binary-codec] fix ISO when parsing currency code

### DIFF
--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 ### Added
-- Exported `TRANSACTION_TYPES` value 
+- Exported `TRANSACTION_TYPES` value
 ### Fixed
 - Adds missing fields from XLS-20 NFT implementation
+
+## 1.2.3 (2022-2-2)
+- Fix issue where ISO is invalid when parsing currency code
 
 ## 1.2.2 (2021-12-2)
 - Fix issue where unsupported currency codes weren't being correctly processed

--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -87,12 +87,13 @@ class Currency extends Hash160 {
     super(byteBuf ?? Currency.XRP.bytes)
     const code = this.bytes.slice(12, 15)
 
-    if (this.bytes[0] !== 0) {
-      this._iso = null
-    } else if (/^0*$/.test(this.bytes.toString('hex'))) {
+    if (/^0*$/.test(this.bytes.toString('hex'))) {
       this._iso = 'XRP'
-    } else {
+      // eslint-disable-next-line no-control-regex
+    } else if (/0{24}[\x00-\x7F]{6}0{10}/gm.test(this.bytes.toString('hex'))) {
       this._iso = isoCodeFromHex(code)
+    } else {
+      this._iso = null
     }
   }
 

--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -1,10 +1,11 @@
 import { Hash160 } from './hash-160'
 import { Buffer } from 'buffer/'
 
+const XRP_REGEX = /^0{40}$/
 const ISO_REGEX = /^[A-Z0-9]{3}$/
 const HEX_REGEX = /^[A-F0-9]{40}$/
 // eslint-disable-next-line no-control-regex
-const STANDARD_FORMAT_HEX_REGEX = /0{24}[\x00-\x7F]{6}0{10}/
+const STANDARD_FORMAT_HEX_REGEX = /^0{24}[\x00-\x7F]{6}0{10}$/
 
 /**
  * Convert an ISO code to a currency bytes representation
@@ -89,7 +90,7 @@ class Currency extends Hash160 {
     super(byteBuf ?? Currency.XRP.bytes)
     const hex = this.bytes.toString('hex')
 
-    if (/^0*$/.test(hex)) {
+    if (XRP_REGEX.test(hex)) {
       this._iso = 'XRP'
     } else if (STANDARD_FORMAT_HEX_REGEX.test(hex)) {
       this._iso = isoCodeFromHex(this.bytes.slice(12, 15))

--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -88,10 +88,11 @@ class Currency extends Hash160 {
   constructor(byteBuf: Buffer) {
     super(byteBuf ?? Currency.XRP.bytes)
     const code = this.bytes.slice(12, 15)
+    const hex = this.bytes.toString('hex')
 
-    if (/^0*$/.test(this.bytes.toString('hex'))) {
+    if (/^0*$/.test(hex)) {
       this._iso = 'XRP'
-    } else if (STANDARD_FORMAT_HEX_REGEX.test(this.bytes.toString('hex'))) {
+    } else if (STANDARD_FORMAT_HEX_REGEX.test(hex)) {
       this._iso = isoCodeFromHex(code)
     } else {
       this._iso = null

--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -87,13 +87,12 @@ class Currency extends Hash160 {
 
   constructor(byteBuf: Buffer) {
     super(byteBuf ?? Currency.XRP.bytes)
-    const code = this.bytes.slice(12, 15)
     const hex = this.bytes.toString('hex')
 
     if (/^0*$/.test(hex)) {
       this._iso = 'XRP'
     } else if (STANDARD_FORMAT_HEX_REGEX.test(hex)) {
-      this._iso = isoCodeFromHex(code)
+      this._iso = isoCodeFromHex(this.bytes.slice(12, 15))
     } else {
       this._iso = null
     }

--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -1,7 +1,7 @@
 import { Hash160 } from './hash-160'
 import { Buffer } from 'buffer/'
 
-const XRP_REGEX = /^0{40}$/
+const XRP_HEX_REGEX = /^0{40}$/
 const ISO_REGEX = /^[A-Z0-9]{3}$/
 const HEX_REGEX = /^[A-F0-9]{40}$/
 // eslint-disable-next-line no-control-regex
@@ -90,7 +90,7 @@ class Currency extends Hash160 {
     super(byteBuf ?? Currency.XRP.bytes)
     const hex = this.bytes.toString('hex')
 
-    if (XRP_REGEX.test(hex)) {
+    if (XRP_HEX_REGEX.test(hex)) {
       this._iso = 'XRP'
     } else if (STANDARD_FORMAT_HEX_REGEX.test(hex)) {
       this._iso = isoCodeFromHex(this.bytes.slice(12, 15))

--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -3,6 +3,8 @@ import { Buffer } from 'buffer/'
 
 const ISO_REGEX = /^[A-Z0-9]{3}$/
 const HEX_REGEX = /^[A-F0-9]{40}$/
+// eslint-disable-next-line no-control-regex
+const STANDARD_FORMAT_HEX_REGEX = /0{24}[\x00-\x7F]{6}0{10}/
 
 /**
  * Convert an ISO code to a currency bytes representation
@@ -89,8 +91,7 @@ class Currency extends Hash160 {
 
     if (/^0*$/.test(this.bytes.toString('hex'))) {
       this._iso = 'XRP'
-      // eslint-disable-next-line no-control-regex
-    } else if (/0{24}[\x00-\x7F]{6}0{10}/gm.test(this.bytes.toString('hex'))) {
+    } else if (STANDARD_FORMAT_HEX_REGEX.test(this.bytes.toString('hex'))) {
       this._iso = isoCodeFromHex(code)
     } else {
       this._iso = null

--- a/packages/ripple-binary-codec/test/hash.test.js
+++ b/packages/ripple-binary-codec/test/hash.test.js
@@ -50,7 +50,7 @@ describe('Hash256', function () {
 })
 
 describe('Currency', function () {
-  test('Will throw an error for dodgy XRP ', function () {
+  test('Will throw an error for dodgy XRP', function () {
     expect(() =>
       Currency.from('0000000000000000000000005852500000000000'),
     ).toThrow()
@@ -68,6 +68,18 @@ describe('Currency', function () {
   test('Currency codes with uppercase and 0-9 decode to ISO codes', () => {
     expect(Currency.from('X8P').toJSON()).toBe('X8P')
     expect(Currency.from('USD').toJSON()).toBe('USD')
+  })
+
+  test('Currency codes with no contiguous zeroes in first 96 type code & reserved bits', function () {
+    expect(
+      Currency.from('0000000023410000000000005852520000000000').iso(),
+    ).toBe(null)
+  })
+
+  test('Currency codes with no contiguous zeroes in last 40 reserved bits', function () {
+    expect(
+      Currency.from('0000000000000000000000005852527570656500').iso(),
+    ).toBe(null)
   })
 
   test('can be constructed from a Buffer', function () {


### PR DESCRIPTION
## High Level Overview of Change

Fixes ISO when parsing currency code.

### Context of Change

Storm importer reported a bug where ripple-binary-codec encode/decode wasn't properly working.

Root cause is the parsing logic inside Currency constructor doesn't set ISO field correctly.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

Added tests to verify the bug is resolved.