### PR TITLE
[Small Type error Fix]TrustSet LimitAmount Type changed

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,6 +5,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 
 ### Fixed
+* Type of TrustSet transaction edited, specifically LimitAmount property type (fixed typescript issue)
 * Remove unnecessary console.warn for partial payments (#1783, #1784, #1896)
 
 ## 2.1.1 (2021-12-23)

--- a/packages/xrpl/src/models/transactions/trustSet.ts
+++ b/packages/xrpl/src/models/transactions/trustSet.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '../../errors'
-import { Amount } from '../common'
+import { IssuedCurrencyAmount } from '../common'
 
 import {
   BaseTransaction,
@@ -102,7 +102,7 @@ export interface TrustSet extends BaseTransaction {
    * Object defining the trust line to create or modify, in the format of a
    * Currency Amount.
    */
-  LimitAmount: Amount
+  LimitAmount: IssuedCurrencyAmount
   /**
    * Value incoming balances on this trust line at the ratio of this number per
    * 1,000,000,000 units. A value of 0 is shorthand for treating balances at


### PR DESCRIPTION
This PR changes Type on TrustSet interface property LimitAmount from Amount (string/object) to IssuedCurrencyAmount(object)

The reason why I made this PR is because I encountered an error while working with data from the TrustSet transaction in the TypeScript environment. 

If you tried to access data from the LimitAmount object on TrustSet transaction, like value, issuer, or currency. You would get a type error that this property does not exist on type Amount (type string). This is because TrustSet transaction was using universal Amount type and not specific type like IssuedCurrencyAmount.

According to [xrpl.org](https://xrpl.org/trustset.html#trustset) docs, TrustSet's LimitAmount property should be an Object, not string, which makes me even more sure with this change.

I tested this change locally and it fixed the type issue.