### PR TITLE
Add tx info which is only available in requests

### DIFF
--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -67,6 +67,26 @@ export interface SignerEntry {
 }
 
 /**
+ * This information is added to Transactions in request responses, but is not part
+ * of the canonical Transaction information on ledger. These fields are denoted with
+ * lowercase letters to indicate this in the rippled responses.
+ */
+export interface ResponseOnlyTxInfo {
+  /**
+   * The date/time when this transaction was included in a validated ledger.
+   */
+  date?: number
+  /**
+   * An identifying hash value unique to this transaction, as a hex string.
+   */
+  hash?: string
+  /**
+   * The sequence number of the ledger that included this transaction.
+   */
+  ledger_index?: number
+}
+
+/**
  * One offer that might be returned from either an {@link NFTBuyOffersRequest}
  * or an {@link NFTSellOffersRequest}.
  *

--- a/packages/xrpl/src/models/methods/accountTx.ts
+++ b/packages/xrpl/src/models/methods/accountTx.ts
@@ -1,7 +1,7 @@
-import { LedgerIndex } from '../common'
+import { LedgerIndex, ResponseOnlyTxInfo } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 
-import { ResponseOnlyTxInfo, BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse } from './baseMethod'
 
 /**
  * The account_tx method retrieves a list of transactions that involved the

--- a/packages/xrpl/src/models/methods/accountTx.ts
+++ b/packages/xrpl/src/models/methods/accountTx.ts
@@ -70,14 +70,6 @@ interface AccountTransaction {
    * transaction not yet in a validated ledger is subject to change.
    */
   validated: boolean
-  /**
-   * The date/time when this transaction was included in a validated ledger.
-   */
-  date?: number
-  /**
-   * An identifying hash value unique to this transaction, as a hex string.
-   */
-  hash?: string
 }
 
 /**

--- a/packages/xrpl/src/models/methods/accountTx.ts
+++ b/packages/xrpl/src/models/methods/accountTx.ts
@@ -1,7 +1,7 @@
 import { LedgerIndex } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { ResponseOnlyTxInfo, BaseRequest, BaseResponse } from './baseMethod'
 
 /**
  * The account_tx method retrieves a list of transactions that involved the
@@ -62,7 +62,7 @@ interface AccountTransaction {
    */
   meta: string | TransactionMetadata
   /** JSON object defining the transaction. */
-  tx?: Transaction
+  tx?: Transaction & ResponseOnlyTxInfo
   /** Unique hashed String representing the transaction. */
   tx_blob?: string
   /**
@@ -70,6 +70,14 @@ interface AccountTransaction {
    * transaction not yet in a validated ledger is subject to change.
    */
   validated: boolean
+  /**
+   * The date/time when this transaction was included in a validated ledger.
+   */
+  date?: number
+  /**
+   * An identifying hash value unique to this transaction, as a hex string.
+   */
+  hash?: string
 }
 
 /**

--- a/packages/xrpl/src/models/methods/baseMethod.ts
+++ b/packages/xrpl/src/models/methods/baseMethod.ts
@@ -20,6 +20,26 @@ interface Warning {
   details?: { [key: string]: string }
 }
 
+/**
+ * This information is added to Transactions in request responses, but is not part
+ * of the canonical Transaction information on ledger. These fields are denoted with
+ * lowercase letters to indicate this in the rippled responses.
+ */
+export interface ResponseOnlyTxInfo {
+  /**
+   * The date/time when this transaction was included in a validated ledger.
+   */
+  date?: number
+  /**
+   * An identifying hash value unique to this transaction, as a hex string.
+   */
+  hash?: string
+  /**
+   * The sequence number of the ledger that included this transaction.
+   */
+  ledger_index?: number
+}
+
 export interface BaseResponse {
   id: number | string
   status?: 'success' | string

--- a/packages/xrpl/src/models/methods/baseMethod.ts
+++ b/packages/xrpl/src/models/methods/baseMethod.ts
@@ -20,26 +20,6 @@ interface Warning {
   details?: { [key: string]: string }
 }
 
-/**
- * This information is added to Transactions in request responses, but is not part
- * of the canonical Transaction information on ledger. These fields are denoted with
- * lowercase letters to indicate this in the rippled responses.
- */
-export interface ResponseOnlyTxInfo {
-  /**
-   * The date/time when this transaction was included in a validated ledger.
-   */
-  date?: number
-  /**
-   * An identifying hash value unique to this transaction, as a hex string.
-   */
-  hash?: string
-  /**
-   * The sequence number of the ledger that included this transaction.
-   */
-  ledger_index?: number
-}
-
 export interface BaseResponse {
   id: number | string
   status?: 'success' | string

--- a/packages/xrpl/src/models/methods/norippleCheck.ts
+++ b/packages/xrpl/src/models/methods/norippleCheck.ts
@@ -1,7 +1,7 @@
 import { LedgerIndex } from '../common'
 import { Transaction } from '../transactions'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { ResponseOnlyTxInfo, BaseRequest, BaseResponse } from './baseMethod'
 
 /**
  * The `noripple_check` command provides a quick way to check the status of th
@@ -77,6 +77,6 @@ export interface NoRippleCheckResponse extends BaseResponse {
      * the problems array, and each entry is intended to fix the problem
      * described at the same index into that array.
      */
-    transactions: Transaction[]
+    transactions: (Transaction & ResponseOnlyTxInfo)[]
   }
 }

--- a/packages/xrpl/src/models/methods/norippleCheck.ts
+++ b/packages/xrpl/src/models/methods/norippleCheck.ts
@@ -77,6 +77,6 @@ export interface NoRippleCheckResponse extends BaseResponse {
      * the problems array, and each entry is intended to fix the problem
      * described at the same index into that array.
      */
-    transactions: (Transaction & ResponseOnlyTxInfo)[]
+    transactions: Array<Transaction & ResponseOnlyTxInfo>
   }
 }

--- a/packages/xrpl/src/models/methods/norippleCheck.ts
+++ b/packages/xrpl/src/models/methods/norippleCheck.ts
@@ -1,7 +1,7 @@
-import { LedgerIndex } from '../common'
+import { LedgerIndex, ResponseOnlyTxInfo } from '../common'
 import { Transaction } from '../transactions'
 
-import { ResponseOnlyTxInfo, BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse } from './baseMethod'
 
 /**
  * The `noripple_check` command provides a quick way to check the status of th

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -3,7 +3,11 @@ import { Offer } from '../ledger'
 import { OfferCreate, Transaction } from '../transactions'
 import { TransactionMetadata } from '../transactions/metadata'
 
-import type { BaseRequest, BaseResponse } from './baseMethod'
+import type {
+  ResponseOnlyTxInfo,
+  BaseRequest,
+  BaseResponse,
+} from './baseMethod'
 
 interface Book {
   /**
@@ -268,17 +272,7 @@ export interface TransactionStream extends BaseStream {
    */
   meta?: TransactionMetadata
   /** The definition of the transaction in JSON format. */
-  transaction: Transaction & {
-    /**
-     * This number measures the number of seconds since the "Ripple Epoch" of January 1, 2000 (00:00 UTC)
-     */
-    date?: number
-    /**
-     * Every signed transaction has a unique "hash" that identifies it.
-     * The transaction hash can be used to look up its final status, which may serve as a "proof of payment"
-     */
-    hash?: string
-  }
+  transaction: Transaction & ResponseOnlyTxInfo
   /**
    * If true, this transaction is included in a validated ledger and its
    * outcome is final. Responses from the transaction stream should always be

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -1,13 +1,15 @@
-import type { Amount, Currency, Path, StreamType } from '../common'
+import type {
+  Amount,
+  Currency,
+  Path,
+  StreamType,
+  ResponseOnlyTxInfo,
+} from '../common'
 import { Offer } from '../ledger'
 import { OfferCreate, Transaction } from '../transactions'
 import { TransactionMetadata } from '../transactions/metadata'
 
-import type {
-  ResponseOnlyTxInfo,
-  BaseRequest,
-  BaseResponse,
-} from './baseMethod'
+import type { BaseRequest, BaseResponse } from './baseMethod'
 
 interface Book {
   /**

--- a/packages/xrpl/src/models/methods/transactionEntry.ts
+++ b/packages/xrpl/src/models/methods/transactionEntry.ts
@@ -1,7 +1,7 @@
 import { LedgerIndex } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { ResponseOnlyTxInfo, BaseRequest, BaseResponse } from './baseMethod'
 
 /**
  * The `transaction_entry` method retrieves information on a single transaction
@@ -46,6 +46,6 @@ export interface TransactionEntryResponse extends BaseResponse {
      */
     metadata: TransactionMetadata
     /** JSON representation of the Transaction object. */
-    tx_json: Transaction
+    tx_json: Transaction & ResponseOnlyTxInfo
   }
 }

--- a/packages/xrpl/src/models/methods/transactionEntry.ts
+++ b/packages/xrpl/src/models/methods/transactionEntry.ts
@@ -1,7 +1,7 @@
-import { LedgerIndex } from '../common'
+import { LedgerIndex, ResponseOnlyTxInfo } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 
-import { ResponseOnlyTxInfo, BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse } from './baseMethod'
 
 /**
  * The `transaction_entry` method retrieves information on a single transaction


### PR DESCRIPTION
## High Level Overview of Change

This allows you to access the date, hash, and ledger_index fields on tx responses.

### Context of Change
Follow up to #1768.

These fields are available when retrieving transactions from a validated ledger, e.g. with the 'account_tx' command.

The returned txs have date, hash, and ledger_index fields.

Without this fix, TypeScript users need to apply workarounds such as type assertion on the returned objects (e.g. `as any`)

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)