### PR TITLE
Fix deriveXAddress null behavior

### DIFF
--- a/packages/ripple-address-codec/HISTORY.md
+++ b/packages/ripple-address-codec/HISTORY.md
@@ -1,5 +1,8 @@
 # ripple-address-codec
 
+## Unreleased
+- Fixed `encodeXAddress` to handle `null` equivalently to `false`.
+
 ## 4.2.1 (2021-12-1)
 - Fix issue where npm < 7 could not install the library
 - Initial pass at linting this codebase with new rules

--- a/packages/ripple-address-codec/src/index.ts
+++ b/packages/ripple-address-codec/src/index.ts
@@ -43,8 +43,10 @@ function encodeXAddress(
   if (tag > MAX_32_BIT_UNSIGNED_INT) {
     throw new Error('Invalid tag')
   }
-  const theTag = tag === false ? 0 : tag
-  const flag = tag === false ? 0 : 1
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Passing null is a common js mistake
+  const theTag = tag === false || tag === null ? 0 : tag
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Passing null is a common js mistake
+  const flag = tag === false || tag === null ? 0 : 1
   /* eslint-disable no-bitwise ---
    * need to use bitwise operations here */
   const bytes = Buffer.concat([

--- a/packages/ripple-address-codec/src/index.ts
+++ b/packages/ripple-address-codec/src/index.ts
@@ -43,8 +43,7 @@ function encodeXAddress(
   if (tag > MAX_32_BIT_UNSIGNED_INT) {
     throw new Error('Invalid tag')
   }
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Passing null is a common js mistake
-  const theTag = tag === false || tag == null ? 0 : tag
+  const theTag = tag || 0
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Passing null is a common js mistake
   const flag = tag === false || tag == null ? 0 : 1
   /* eslint-disable no-bitwise ---

--- a/packages/ripple-address-codec/src/index.ts
+++ b/packages/ripple-address-codec/src/index.ts
@@ -44,9 +44,9 @@ function encodeXAddress(
     throw new Error('Invalid tag')
   }
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Passing null is a common js mistake
-  const theTag = tag === false || tag === null ? 0 : tag
+  const theTag = tag === false || tag == null ? 0 : tag
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Passing null is a common js mistake
-  const flag = tag === false || tag === null ? 0 : 1
+  const flag = tag === false || tag == null ? 0 : 1
   /* eslint-disable no-bitwise ---
    * need to use bitwise operations here */
   const bytes = Buffer.concat([

--- a/packages/xrpl/test/utils/deriveXAddress.ts
+++ b/packages/xrpl/test/utils/deriveXAddress.ts
@@ -22,4 +22,17 @@ describe('deriveXAddress', function () {
       'TVVrSWtmQQssgVcmoMBcFQZKKf56QscyWLKnUyiuZW8ALU4',
     )
   })
+
+  it('does not include tag when null', function () {
+    assert.equal(
+      deriveXAddress({
+        publicKey:
+          'ED02C98225BD1C79E9A4F95C6978026D300AFB7CA2A34358920BCFBCEBE6AFCD6A',
+        // @ts-expect-error -- Assessing null behavior
+        tag: null,
+        test: false,
+      }),
+      'X7FbrqVEqdTNoX5qq94rTdarGjeVYmkxi8A1TKAJUnyLL9g',
+    )
+  })
 })

--- a/packages/xrpl/test/utils/deriveXAddress.ts
+++ b/packages/xrpl/test/utils/deriveXAddress.ts
@@ -28,8 +28,21 @@ describe('deriveXAddress', function () {
       deriveXAddress({
         publicKey:
           'ED02C98225BD1C79E9A4F95C6978026D300AFB7CA2A34358920BCFBCEBE6AFCD6A',
-        // @ts-expect-error -- Assessing null behavior
+        // @ts-expect-error -- Assessing null behavior (Common js mistake)
         tag: null,
+        test: false,
+      }),
+      'X7FbrqVEqdTNoX5qq94rTdarGjeVYmkxi8A1TKAJUnyLL9g',
+    )
+  })
+
+  it('does not include tag when undefined', function () {
+    assert.equal(
+      deriveXAddress({
+        publicKey:
+          'ED02C98225BD1C79E9A4F95C6978026D300AFB7CA2A34358920BCFBCEBE6AFCD6A',
+        // @ts-expect-error -- Assessing undefined behavior
+        tag: undefined,
         test: false,
       }),
       'X7FbrqVEqdTNoX5qq94rTdarGjeVYmkxi8A1TKAJUnyLL9g',


### PR DESCRIPTION
## High Level Overview of Change

`deriveXAddress` should have the same behavior for `null` as it does for `false`. 

### Context of Change

In response to #1872 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Added a unit test for it.

<!--
## Future Tasks
For future tasks related to PR.
-->