### PR TITLE
Deprecate BroadcastClient

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,6 +5,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 ### Added
 * Export deriveAddress from ripple-keypairs in xrpl.js
+* Deprecated BroadcastClient as it does not solve the reliabile connection problem.
 
 ## 2.2.1 (2022-04-21)
 ### Fixed

--- a/packages/xrpl/src/client/BroadcastClient.ts
+++ b/packages/xrpl/src/client/BroadcastClient.ts
@@ -3,6 +3,16 @@ import { Client, ClientOptions } from '.'
 /**
  * Client that can rely on multiple different servers.
  *
+ * @deprecated since version 2.2.0.
+ * Will be deleted in version 3.0.0.
+ *
+ * Currently this implementation does not provide better reliability.
+ * To get better reliability, implement reconnect/error handling logic
+ * and choose a reliable endpoint.
+ *
+ * If you need the ability to fall-back to different endpoints, consider
+ * using [xrpl-client](https://github.com/XRPL-Labs/xrpl-client/)
+ *
  * @category Clients
  */
 export default class BroadcastClient extends Client {


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

Currently it's not functional, and we decided against building it out when xrpl-client already exists and the goal of reliability could be better implemented via reconnect logic + using a reliable endpoint like xrpl.ws. 

See issue: https://github.com/XRPLF/xrpl.js/issues/1925

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

## Test Plan

None

<!--
## Future Tasks
For future tasks related to PR.
-->