### PR TITLE
fix(ripple-keypairs): hexToBytes should produce [] for empty input, not [0]

### DIFF
--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -1,5 +1,8 @@
 # ripple-keypairs Release History
 
+## Unreleased
+- `hexToBytes` now produces empty output for empty input, rather than `[0]`.
+
 ## 1.1.1 (2021-12-1)
 - Fix issue where npm < 7 was not allowed to install the library
 

--- a/packages/ripple-keypairs/src/utils.ts
+++ b/packages/ripple-keypairs/src/utils.ts
@@ -13,7 +13,10 @@ function bytesToHex(a): string {
 
 function hexToBytes(a): number[] {
   assert.ok(a.length % 2 === 0)
-  return new BN(a, 16).toArray(null, a.length / 2)
+  // Special-case length zero to return [].
+  // BN.toArray intentionally returns [0] rather than [] for length zero,
+  // which may make sense for BigNum data, but not for byte strings.
+  return a.length === 0 ? [] : new BN(a, 16).toArray(null, a.length / 2)
 }
 
 function computePublicKeyHash(publicKeyBytes: Buffer): Buffer {

--- a/packages/ripple-keypairs/test/utils-test.js
+++ b/packages/ripple-keypairs/test/utils-test.js
@@ -4,6 +4,10 @@ const assert = require('assert')
 const utils = require('../dist/utils')
 
 describe('utils', () => {
+  it('hexToBytes - empty', () => {
+    assert.deepEqual(utils.hexToBytes(''), [])
+  })
+
   it('hexToBytes - zero', () => {
     assert.deepEqual(utils.hexToBytes('000000'), [0, 0, 0])
   })


### PR DESCRIPTION
## High Level Overview of Change

`hexToBytes` uses the `BN` library, but `BN.toArray` intentionally produces `[0]` rather than `[]` for a zero buffer, even when requesting output of zero length. This may make sense for BigNum buffers, but not for byte strings.

This change fixes that by special-casing zero-length input to `[]`.

### Context of Change

- Related to https://github.com/XRPLF/xrpl.js/pull/1975

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

- Before: `hexToBytes('')` produced `[0]`
- After: `hexToBytes('')` produces `[]`

## Test Plan

I added a unit test case.

<!--
## Future Tasks
For future tasks related to PR.
-->