### PR TITLE
add missing filter types in AccountObjectType

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -6,6 +6,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ### Added
 * Export deriveAddress from ripple-keypairs in xrpl.js
 
+### Fixed
+* Add missing filter types in AccountObjectType
+
 ## 2.2.1 (2022-04-21)
 ### Fixed
 * Fix return field of nft offer

--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -2,10 +2,12 @@ export type LedgerIndex = number | ('validated' | 'closed' | 'current')
 
 export type AccountObjectType =
   | 'check'
+  | 'deposit_preauth'
   | 'escrow'
   | 'offer'
   | 'payment_channel'
   | 'signer_list'
+  | 'ticket'
   | 'state'
 
 interface XRP {


### PR DESCRIPTION
## High Level Overview of Change

Add missing filter types in AccountObjectType.

### Context of Change

User reported an [issue](https://github.com/XRPLF/xrpl.js/issues/1902) with missing filter types in AccountObjectTypes

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Verified all tests pass.