### PR TITLE
Fix browser infinite disconnect if exception raised during 'connected'

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,6 +5,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 ### Fixed
 * Client.disconnect() now stops the heartbeat health check as well
+* Infinite error/reconnect in browser if an exception was raised during the initial websocket connection event.
 
 ## 2.2.3 (2022-05-04)
 ### Fixed
@@ -19,7 +20,6 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Added missing `Owner` field to NFTokenBurn type definition
 * Changed `tfSellToken` to `tfSellNFToken` to match the 1.9.0 naming for NFTokenSellOffers
 * Add missing filter types in AccountObjectType
-* Infinite error/reconnect in browser if an exception was raised during the initial websocket connection event.
 
 ## 2.2.1 (2022-04-21)
 ### Fixed

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -19,6 +19,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Added missing `Owner` field to NFTokenBurn type definition
 * Changed `tfSellToken` to `tfSellNFToken` to match the 1.9.0 naming for NFTokenSellOffers
 * Add missing filter types in AccountObjectType
+* Infinite error/reconnect in browser if an exception was raised during the initial websocket connection event.
 
 ## 2.2.1 (2022-04-21)
 ### Fixed

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -463,7 +463,7 @@ export class Connection extends EventEmitter {
          * Error code 1011 represents an Internal Error according to
          * https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
          */
-        const internalErrorCode = 1011
+        const internalErrorCode = 1012
         this.emit('disconnected', internalErrorCode)
       } else {
         this.emit('disconnected', code)

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -452,9 +452,10 @@ export class Connection extends EventEmitter {
 
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
       if (code === undefined) {
+        const reasonText = reason ? reason.toString() : "undefined";
         // eslint-disable-next-line no-console -- The error is helpful for debugging.
         console.error(
-          `Disconnected but the disconnect code was undefined (The given reason was ${reason.toString()}).` +
+          `Disconnected but the disconnect code was undefined (The given reason was ${reasonText}).` +
             `This could be caused by an exception being thrown during a 'connect' callback. ` +
             `Disconnecting with code 1011 to indicate an internal error has occurred.`,
         )
@@ -463,7 +464,7 @@ export class Connection extends EventEmitter {
          * Error code 1011 represents an Internal Error according to
          * https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
          */
-        const internalErrorCode = 1012
+        const internalErrorCode = 1011
         this.emit('disconnected', internalErrorCode)
       } else {
         this.emit('disconnected', code)

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -436,7 +436,7 @@ export class Connection extends EventEmitter {
       this.emit('error', 'websocket', error.message, error),
     )
     // Handle a closed connection: reconnect if it was unexpected
-    this.ws.once('close', (code, reason) => {
+    this.ws.once('close', (code?: number, reason?: Buffer) => {
       if (this.ws == null) {
         throw new XrplError('onceClose: ws is null')
       }
@@ -450,9 +450,7 @@ export class Connection extends EventEmitter {
       this.ws.removeAllListeners()
       this.ws = null
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
       if (code === undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
         const reasonText = reason ? reason.toString() : 'undefined'
         // eslint-disable-next-line no-console -- The error is helpful for debugging.
         console.error(
@@ -475,7 +473,6 @@ export class Connection extends EventEmitter {
        * If this wasn't a manual disconnect, then lets reconnect ASAP.
        * Code can be undefined if there's an exception while connecting.
        */
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
       if (code !== INTENTIONAL_DISCONNECT_CODE && code !== undefined) {
         this.intentionalDisconnect()
       }

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -452,7 +452,8 @@ export class Connection extends EventEmitter {
 
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
       if (code === undefined) {
-        const reasonText = reason ? reason.toString() : "undefined";
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
+        const reasonText = reason ? reason.toString() : 'undefined'
         // eslint-disable-next-line no-console -- The error is helpful for debugging.
         console.error(
           `Disconnected but the disconnect code was undefined (The given reason was ${reasonText}).` +

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -448,9 +448,22 @@ export class Connection extends EventEmitter {
       )
       this.ws.removeAllListeners()
       this.ws = null
-      this.emit('disconnected', code)
+
+      if(code === undefined) {
+        console.error(`Disconnected but the disconnect code was undefined (The given reason was ${reason}).` +
+        `This could be caused by an exception being thrown during a 'connect' callback. ` +
+        `Disconnecting with code 1011 to indicate an internal error has occurred.`)
+
+        // Error code 1011 represents an Internal Error according to
+        // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
+        this.emit('disconnected', 1011)
+      } else {
+        this.emit('disconnected', code)
+      }
+
       // If this wasn't a manual disconnect, then lets reconnect ASAP.
-      if (code !== INTENTIONAL_DISCONNECT_CODE) {
+      // Code can be undefined if there's an exception while connecting.
+      if (code !== INTENTIONAL_DISCONNECT_CODE && code !== undefined) {
         this.intentionalDisconnect()
       }
     })

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -421,6 +421,7 @@ export class Connection extends EventEmitter {
    * @returns A promise that resolves to void when the connection is fully established.
    * @throws Error if the websocket initialized is somehow null.
    */
+  // eslint-disable-next-line max-lines-per-function -- Many error code conditionals to check.
   private async onceOpen(connectionTimeoutID: NodeJS.Timeout): Promise<void> {
     if (this.ws == null) {
       throw new XrplError('onceOpen: ws is null')
@@ -449,20 +450,30 @@ export class Connection extends EventEmitter {
       this.ws.removeAllListeners()
       this.ws = null
 
-      if(code === undefined) {
-        console.error(`Disconnected but the disconnect code was undefined (The given reason was ${reason}).` +
-        `This could be caused by an exception being thrown during a 'connect' callback. ` +
-        `Disconnecting with code 1011 to indicate an internal error has occurred.`)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
+      if (code === undefined) {
+        // eslint-disable-next-line no-console -- The error is helpful for debugging.
+        console.error(
+          `Disconnected but the disconnect code was undefined (The given reason was ${reason.toString()}).` +
+            `This could be caused by an exception being thrown during a 'connect' callback. ` +
+            `Disconnecting with code 1011 to indicate an internal error has occurred.`,
+        )
 
-        // Error code 1011 represents an Internal Error according to
-        // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
-        this.emit('disconnected', 1011)
+        /*
+         * Error code 1011 represents an Internal Error according to
+         * https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
+         */
+        const internalErrorCode = 1011
+        this.emit('disconnected', internalErrorCode)
       } else {
         this.emit('disconnected', code)
       }
 
-      // If this wasn't a manual disconnect, then lets reconnect ASAP.
-      // Code can be undefined if there's an exception while connecting.
+      /*
+       * If this wasn't a manual disconnect, then lets reconnect ASAP.
+       * Code can be undefined if there's an exception while connecting.
+       */
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined can be passed in.
       if (code !== INTENTIONAL_DISCONNECT_CODE && code !== undefined) {
         this.intentionalDisconnect()
       }


### PR DESCRIPTION
## High Level Overview of Change

When an exception is raised during the websocket connection, it can cause a disconnect with no error code, which can then cause an infinite series of reconnect + errors.

### Context of Change

In response to #1825 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After
Before:
(Errors keep repeating infinitely)
<img width="512" alt="image" src="https://user-images.githubusercontent.com/19694186/166083647-e7185734-8c5b-4b75-8a85-6e36936b9e18.png">

After:
(Error happens once with a more descriptive error message)
<img width="512" alt="image" src="https://user-images.githubusercontent.com/19694186/166083534-2fe048c7-4750-4ffc-aef7-b0950d1077ce.png">

## Test Plan

Manually reproduced using @mDuo13's steps to reproduce and verified it only disconnected once after the changes.