### PR TITLE
Fix ripple-keypair HISTORY.md version

### DIFF
--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.1.2 (2022-05-02)
+## 1.1.4 (2022-05-02)
 - `hexToBytes` now produces empty output for empty input, rather than `[0]`.
 - Extend `bytesToHex` to work correctly with any input type accepted by `Array.from`.
   In particular, it now produces correct output for typed arrays such as `UInt8Array`.


### PR DESCRIPTION
## High Level Overview of Change

We were accidentally releasing changed versions without any changes, so our HISTORY was out of date. This corrects that.