### PR TITLE
Fix reliable submission masking legitimate error with type error

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,6 +5,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 ### Fixed
 * Client.disconnect() now stops the heartbeat health check as well
+* Errors during reliable submission with no error message now properly show the preliminary result instead of a type error
 
 ## 2.2.3 (2022-05-04)
 ### Fixed

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -148,7 +148,7 @@ async function waitForFinalTransactionOutcome(
     .catch(async (error) => {
       // error is of an unknown type and hence we assert type to extract the value we need.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- ^
-      const message = error.data.error as string
+      const message = error?.data?.error as string
       if (message === 'txnNotFound') {
         return waitForFinalTransactionOutcome(
           client,


### PR DESCRIPTION
## High Level Overview of Change

When `submitAndWait` failed with no error message it accidentally triggers a TypeError instead of displaying the preliminary result.

### Context of Change

In response to the integration test for `submitAndWait` occasionally failing for no apparent reason. (Ex. On a docs only change)

This is the error which would occur in the tests:
```
1) client.submitAndWait
xrpl:        submitAndWait an unsigned transaction:
xrpl:      TypeError: Cannot read properties of undefined (reading 'error')
xrpl:       at /home/runner/work/xrpl.js/xrpl.js/packages/xrpl/src/sugar/submit.ts:2:5564
xrpl:       at Generator.next (<anonymous>)
xrpl:       at /home/runner/work/xrpl.js/xrpl.js/packages/xrpl/src/sugar/submit.ts:2:1415
xrpl:       at new Promise (<anonymous>)
xrpl:       at __awaiter (src/sugar/submit.ts:2:586)
xrpl:       at /home/runner/work/xrpl.js/xrpl.js/packages/xrpl/src/sugar/submit.ts:2:5447
xrpl:       at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Run CI 10 times and see if the error happens again. (Otherwise keep an eye out for it on PRs because it is a flaky failure)

<!--
## Future Tasks
For future tasks related to PR.
-->