### PR TITLE
Update dependabot.yml to ignore bip32

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     interval: monthly
     time: "15:00"
   open-pull-requests-limit: 10
+  ignore:
+    # See https://github.com/XRPLF/xrpl.js/pull/1839 for context
+    - dependency-name: bip32


### PR DESCRIPTION
## High Level Overview of Change

We want dependabot to stop recommending to upgrade bip32

### Context of Change

It's currently not worth updating bip32 for reasons explained in this issue: #1839 
 
### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After

Just setting dependabot to ignore bip32 since we don't want to update it automatically going forward.

## Test Plan

N/A

<!--
## Future Tasks
For future tasks related to PR.
-->