### PR TITLE
Add better error for trying to encode invalid transactions

### DIFF
--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -1,5 +1,8 @@
 # ripple-binary-codec Release History
 
+## Unreleased
+- Added a clearer error message for trying to encode an invalid transaction. (Ex. With an incorrect TransactionType)
+
 ## 1.4.0 (2022-04-18)
 - Updated NFT definitions to match 1.9.0's breaking naming changes
 

--- a/packages/ripple-binary-codec/src/types/st-object.ts
+++ b/packages/ripple-binary-codec/src/types/st-object.ts
@@ -130,11 +130,9 @@ class STObject extends SerializedType {
 
       if (associatedValue == undefined) {
         throw new TypeError(
-          'Unable to interpret "' +
-            field.name +
-            ': ' +
-            xAddressDecoded[field.name] +
-            '". There may be a typo in your transaction.',
+          `Unable to interpret "${field.name}: ${
+            xAddressDecoded[field.name]
+          }".`,
         )
       }
 

--- a/packages/ripple-binary-codec/src/types/st-object.ts
+++ b/packages/ripple-binary-codec/src/types/st-object.ts
@@ -127,6 +127,17 @@ class STObject extends SerializedType {
       const associatedValue = field.associatedType.from(
         xAddressDecoded[field.name],
       )
+
+      if (associatedValue == undefined) {
+        throw new TypeError(
+          'Unable to interpret "' +
+            field.name +
+            ': ' +
+            xAddressDecoded[field.name] +
+            '". There may be a typo in your transaction.',
+        )
+      }
+
       if ((associatedValue as unknown as Bytes).name === 'UNLModify') {
         // triggered when the TransactionType field has a value of 'UNLModify'
         isUnlModify = true

--- a/packages/ripple-binary-codec/test/signing-data-encoding.test.js
+++ b/packages/ripple-binary-codec/test/signing-data-encoding.test.js
@@ -1,3 +1,4 @@
+const { throws } = require('assert')
 const {
   encodeForSigning,
   encodeForSigningClaim,
@@ -65,6 +66,16 @@ describe('Signing data', function () {
       ].join(''),
     )
   })
+
+  test('can fail gracefully for invalid TransactionType', function () {
+    const invalidTransactionType = {
+      ...tx_json,
+      TransactionType: 'NotAPayment',
+    }
+
+    throws(() => encodeForSigning(invalidTransactionType), /NotAPayment/u)
+  })
+
   test('can create multi signing blobs', function () {
     const signingAccount = 'rJZdUusLDtY9NEsGea7ijqhVrXv98rYBYN'
     const signingJson = Object.assign({}, tx_json, { SigningPubKey: '' })


### PR DESCRIPTION
## High Level Overview of Change

Add a clear error message when trying to encode invalid transactions.

### Context of Change

The error message if you put in an incorrect TransactionType is very hard to understand/debug.

In response to https://github.com/ripple/ripple-binary-codec/issues/126
And the migrated issue: https://github.com/XRPLF/xrpl.js/issues/1808

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

## Test Plan

CI passes + added a test case for this new error.

<!--
## Future Tasks
For future tasks related to PR.
-->