### PR TITLE
Add detail and visibility to fundWallet documentation

### DIFF
--- a/packages/xrpl/src/Wallet/fundWallet.ts
+++ b/packages/xrpl/src/Wallet/fundWallet.ts
@@ -94,10 +94,7 @@ async function fundWallet(
 
   if (
     options?.faucetHost != null &&
-    (options.faucetHost.startsWith('ws://') ||
-      options.faucetHost.startsWith('wss://') ||
-      options.faucetHost.startsWith('http://') ||
-      options.faucetHost.startsWith('https://'))
+    /^(http|https|ws|wss):\/\//.test(options.faucetHost)
   ) {
     throw new XRPLFaucetError(
       `Invalid format for faucetHost. Should not include ws(s)/http(s) prefix. Received '${options.faucetHost}'.`,

--- a/packages/xrpl/src/Wallet/fundWallet.ts
+++ b/packages/xrpl/src/Wallet/fundWallet.ts
@@ -45,7 +45,8 @@ const MAX_ATTEMPTS = 20
  * @param options.faucetHost - A custom host for a faucet server. `fundWallet` will automatically
  * determine the correct server for devnet and testnet as long as `faucetHost` is null or undefined.
  * In other environments, you should provide the host using this option.
- * Here's an example of how to format `faucetHost`: `faucet.devnet.rippletest.net`
+ * Ex. Passing in faucetHost = `faucet.devnet.rippletest.net` will send a request
+ * to https://faucet.devnet.rippletest.net/accounts:443
  * @returns A Wallet on a test network that contains some amount of XRP,
  * and that wallet's balance in XRP.
  * @throws When the Client isn't connected, when it is unable to fund the wallet address,

--- a/packages/xrpl/src/Wallet/fundWallet.ts
+++ b/packages/xrpl/src/Wallet/fundWallet.ts
@@ -29,7 +29,8 @@ const INTERVAL_SECONDS = 1
 const MAX_ATTEMPTS = 20
 
 /**
- * Generates a random wallet with some amount of XRP (usually 1000 XRP).
+ * Only usable on test networks.
+ * Fills this wallet with some amount of XRP (usually 1000 XRP).
  *
  * @example
  * ```typescript
@@ -41,14 +42,14 @@ const MAX_ATTEMPTS = 20
  * @param this - Client.
  * @param wallet - An existing XRPL Wallet to fund. If undefined or null, a new Wallet will be created.
  * @param options - See below.
- * @param options.faucetHost - A custom host for a faucet server. On devnet and
- * testnet, `fundWallet` will attempt to determine the correct server
- * automatically. In other environments, or if you would like to customize the
- * faucet host in devnet or testnet, you should provide the host using this
- * option.
- * @returns A Wallet on the Testnet or Devnet that contains some amount of XRP,
+ * @param options.faucetHost - A custom host for a faucet server. `fundWallet` will automatically
+ * determine the correct server for devnet and testnet as long as `faucetHost` is null or undefined.
+ * In other environments, you should provide the host using this option.
+ * Here's an example of how to format `faucetHost`: `faucet.devnet.rippletest.net`
+ * @returns A Wallet on a test network that contains some amount of XRP,
  * and that wallet's balance in XRP.
- * @throws When either Client isn't connected or unable to fund wallet address.
+ * @throws When the Client isn't connected, when it is unable to fund the wallet address,
+ * or if `faucetHost` is incorrectly formatted.
  */
 async function fundWallet(
   this: Client,
@@ -88,6 +89,17 @@ async function fundWallet(
     /* startingBalance remains '0' */
   }
 
+  if (
+    options?.faucetHost != null &&
+    (options.faucetHost.startsWith('ws://') ||
+      options.faucetHost.startsWith('wss://') ||
+      options.faucetHost.startsWith('http://') ||
+      options.faucetHost.startsWith('https://'))
+  ) {
+    throw new XRPLFaucetError(
+      `Invalid format for faucetHost. Should not include ws(s)/http(s) prefix. Received '${options.faucetHost}'.`,
+    )
+  }
   // Options to pass to https.request
   const httpOptions = getHTTPOptions(this, postBody, options?.faucetHost)
 

--- a/packages/xrpl/src/Wallet/fundWallet.ts
+++ b/packages/xrpl/src/Wallet/fundWallet.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Relatively simple logic, but verbose */
 import { IncomingMessage } from 'http'
 import { request as httpsRequest, RequestOptions } from 'https'
 
@@ -52,6 +53,7 @@ const MAX_ATTEMPTS = 20
  * @throws When the Client isn't connected, when it is unable to fund the wallet address,
  * or if `faucetHost` is incorrectly formatted.
  */
+// eslint-disable-next-line max-lines-per-function -- Error checking makes for a better user experience.
 async function fundWallet(
   this: Client,
   wallet?: Wallet | null,

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -23,7 +23,7 @@ import {
   sign,
 } from 'ripple-keypairs'
 
-import { Client } from '../client'
+import type { Client } from '../client'
 import ECDSA from '../ECDSA'
 import { ValidationError } from '../errors'
 import { Transaction } from '../models/transactions'

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -23,6 +23,7 @@ import {
   sign,
 } from 'ripple-keypairs'
 
+import { Client } from '../client'
 import ECDSA from '../ECDSA'
 import { ValidationError } from '../errors'
 import { Transaction } from '../models/transactions'
@@ -380,6 +381,34 @@ class Wallet {
    */
   public getXAddress(tag: number | false = false, isTestnet = false): string {
     return classicAddressToXAddress(this.classicAddress, tag, isTestnet)
+  }
+
+  /**
+   * Only usable on test networks.
+   * Funds an existing wallet using a faucet.
+   * This is an alias for Client.fundWallet()
+   *
+   * @param this - An existing XRPL Wallet to fund.
+   * @param client - An XRPL client.
+   * @param options - See below.
+   * @param options.faucetHost - A custom host for a faucet server. `fundWallet` will automatically
+   * determine the correct server for devnet and testnet as long as `faucetHost` is null or undefined.
+   * In other environments, you should provide the host using this option.
+   * Here's an example of how to format `faucetHost`: `faucet.devnet.rippletest.net`
+   * @returns This wallet and that its new balance in XRP.
+   * @throws When either Client isn't connected or unable to fund wallet address.
+   */
+  public async fundWallet(
+    this: Wallet,
+    client: Client,
+    options?: {
+      faucetHost?: string
+    },
+  ): Promise<{
+    wallet: Wallet
+    balance: number
+  }> {
+    return client.fundWallet(this, options)
   }
 
   /**

--- a/packages/xrpl/test/integration/fundWallet.ts
+++ b/packages/xrpl/test/integration/fundWallet.ts
@@ -6,6 +6,7 @@ import {
   isValidClassicAddress,
   isValidXAddress,
   dropsToXrp,
+  XRPLFaucetError,
 } from 'xrpl-local'
 // how long before each test case times out
 const TIMEOUT = 60000
@@ -96,17 +97,23 @@ describe('fundWallet', function () {
 
     await api.disconnect()
   })
-
   it('throws when given an incorrectly formatted faucetHost', async function () {
     const api = new Client('ws://xls20-sandbox.rippletest.net:51233')
 
+    let errorHappened = false
     await api.connect()
-    assert.throws(async () =>
-      api.fundWallet(null, {
-        faucetHost: 'https://faucet-nft.ripple.com/',
-      }),
-    )
 
+    // Using try/catch instead of assert.throws because 'await' has to be top-level
+    try {
+      await api.fundWallet(null, {
+        faucetHost: 'https://faucet-nft.ripple.com/',
+      })
+    } catch (error) {
+      assert.ok(error instanceof XRPLFaucetError)
+      errorHappened = true
+    }
+
+    assert.ok(errorHappened)
     await api.disconnect()
   })
 


### PR DESCRIPTION
## High Level Overview of Change

Adds detail to the `fundWallet` function, and adds an alias to Wallet.fundWallet to increase the discoverability of the function.

### Context of Change

In response to some issues debugging how fundWallet works after the update to allow for custom faucet urls.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation Updates

## Before / After

* Adds a fundWallet alias to Wallet because that's a common spot to search for wallet functions
* Adds an error messages if `faucetHost` has `https://` or `wss://` as that's not the expected format for the function.
* Adds an example to the description of the function for how to use `faucetHost`
* Adds tests

## Test Plan

CI passes

<!--
## Future Tasks
For future tasks related to PR.
-->