### PR TITLE
Add NFT Devnet as an inferable faucet 

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,6 +3,8 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
+### Added
+* When connected to nft-devnet, Client.fundWallet now defaults to using the nft-devnet faucet instead of requiring specification.
 
 ## 2.3.0 (2022-06-02)
 ### Added

--- a/packages/xrpl/src/Wallet/fundWallet.ts
+++ b/packages/xrpl/src/Wallet/fundWallet.ts
@@ -21,6 +21,7 @@ interface FaucetWallet {
 enum FaucetNetwork {
   Testnet = 'faucet.altnet.rippletest.net',
   Devnet = 'faucet.devnet.rippletest.net',
+  NFTDevnet = 'faucet-nft.ripple.com',
 }
 
 // Interval to check an account balance
@@ -310,6 +311,10 @@ function getFaucetHost(client: Client): FaucetNetwork | undefined {
 
   if (connectionUrl.includes('devnet')) {
     return FaucetNetwork.Devnet
+  }
+
+  if (connectionUrl.includes('xls20-sandbox')) {
+    return FaucetNetwork.NFTDevnet
   }
 
   throw new XRPLFaucetError('Faucet URL is not defined or inferrable.')

--- a/packages/xrpl/test/integration/fundWallet.ts
+++ b/packages/xrpl/test/integration/fundWallet.ts
@@ -69,6 +69,35 @@ describe('fundWallet', function () {
     await api.disconnect()
   })
 
+  it('can generate and fund wallets on nft-devnet', async function () {
+    const api = new Client('ws://xls20-sandbox.rippletest.net:51233')
+
+    await api.connect()
+    const { wallet, balance } = await api.fundWallet()
+    assert.notEqual(wallet, undefined)
+    assert(isValidClassicAddress(wallet.classicAddress))
+    assert(isValidXAddress(wallet.getXAddress()))
+
+    const info = await api.request({
+      command: 'account_info',
+      account: wallet.classicAddress,
+    })
+
+    assert.equal(dropsToXrp(info.result.account_data.Balance), balance)
+
+    const { balance: newBalance } = await api.fundWallet(wallet, {
+      faucetHost: 'faucet-nft.ripple.com',
+    })
+
+    const afterSent = await api.request({
+      command: 'account_info',
+      account: wallet.classicAddress,
+    })
+    assert.equal(dropsToXrp(afterSent.result.account_data.Balance), newBalance)
+
+    await api.disconnect()
+  })
+
   it('can generate and fund wallets using a custom host', async function () {
     const api = new Client('ws://xls20-sandbox.rippletest.net:51233')
 


### PR DESCRIPTION
## High Level Overview of Change

Lets fundWallet infer the NFT Devnet faucet when the client is connected to NFT Devnet.

### Context of Change

It's not easy to find the url for the NFT Devnet, and it's really common to want to generate a new wallet for testing purposes on the NFT Devnet, so this seems like a nice quality of life change. (If NFT Devnet turns off, their client won't be pointed to it anyway, and we can then remove this at any point)

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->