### PR TITLE
Update currency code parsing: lower case chars & some special chars

### DIFF
--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -2,7 +2,7 @@ import { Hash160 } from './hash-160'
 import { Buffer } from 'buffer/'
 
 const XRP_HEX_REGEX = /^0{40}$/
-const ISO_REGEX = /^[A-Z0-9]{3}$/
+const ISO_REGEX = /^[A-Z0-9?!@#$%^&*<>(){}[\]|]{3}$/i
 const HEX_REGEX = /^[A-F0-9]{40}$/
 // eslint-disable-next-line no-control-regex
 const STANDARD_FORMAT_HEX_REGEX = /^0{24}[\x00-\x7F]{6}0{10}$/

--- a/packages/ripple-binary-codec/test/hash.test.js
+++ b/packages/ripple-binary-codec/test/hash.test.js
@@ -62,6 +62,11 @@ describe('Currency', function () {
   test('Currency codes with symbols not to decode to hex', () => {
     expect(Currency.from('x|p').toJSON()).toBe('x|p')
   })
+  test('Currency codes with unsupported symbols to hex', () => {
+    expect(Currency.from('A±§').toJSON()).toBe(
+      '00000000000000000000000041B1A70000000000',
+    )
+  })
   test('Currency codes with uppercase and 0-9 decode to ISO codes', () => {
     expect(Currency.from('X8P').toJSON()).toBe('X8P')
     expect(Currency.from('USD').toJSON()).toBe('USD')

--- a/packages/ripple-binary-codec/test/hash.test.js
+++ b/packages/ripple-binary-codec/test/hash.test.js
@@ -54,15 +54,13 @@ describe('Currency', function () {
     const currencyCode = '0000000000000000000000005852500000000000'
     expect(Currency.from(currencyCode).toJSON()).toBe(currencyCode)
   })
-  test('Currency with lowercase letters decode to hex', () => {
-    expect(Currency.from('xRp').toJSON()).toBe(
-      '0000000000000000000000007852700000000000',
-    )
+  // Three char currency codes allow lower case & some symbols.
+  //   https://xrpl.org/currency-formats.html#standard-currency-codes
+  test('Currency with lowercase letters not to decode to hex', () => {
+    expect(Currency.from('xRp').toJSON()).toBe('xRp')
   })
-  test('Currency codes with symbols decode to hex', () => {
-    expect(Currency.from('x|p').toJSON()).toBe(
-      '000000000000000000000000787C700000000000',
-    )
+  test('Currency codes with symbols not to decode to hex', () => {
+    expect(Currency.from('x|p').toJSON()).toBe('x|p')
   })
   test('Currency codes with uppercase and 0-9 decode to ISO codes', () => {
     expect(Currency.from('X8P').toJSON()).toBe('X8P')


### PR DESCRIPTION
`ripple-binary-codec` would turn specific three char currency codes into 40 char HEX currency format. Which is great, except the rules applied to determine if something is a valid three character currency code were off.

### Problem description

When encoding a transaction, `ripple-binary-codec` would change a currency code like `Ab!` into the HEX representation, while the token `Ab!` is a valid three char currency code, and can be issued, traded, sent, etc. just fine on the XRPL (rippled accepts this, as per docs (see below)).

### Old (incorrect) binary codec regex:
```
const ISO_REGEX = /^[A-Z0-9]{3}$/
```

This regex assumes exactly three upper case or numeric chars. 

### New (correct) binary codec regex:
```
const ISO_REGEX = /^[A-Z0-9?!@#$%^&*<>(){}[\]|]{3}$/i
```

This regex matches the docs & the behaviour of rippled:
> Currency codes must be **exactly 3 ASCII characters** in length. The following characters are permitted: **all uppercase and lowercase** letters, digits, **as well as the symbols** ?, !, @, #, $, %, ^, &, *, <, >, (, ), {, }, [, ], and |.

Source: https://xrpl.org/currency-formats.html#standard-currency-codes
