### PR TITLE
Allow customized headers

### DIFF
--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -36,6 +36,7 @@ interface ConnectionOptions {
   // request timeout
   timeout: number
   connectionTimeout: number
+  headers?: { [key: string]: string }
 }
 
 /**
@@ -114,9 +115,15 @@ function createWebSocket(
 ): WebSocket | null {
   const options: WebSocket.ClientOptions = {}
   options.agent = getAgent(url, config)
+  if (config.headers) {
+    options.headers = config.headers
+  }
   if (config.authorization != null) {
     const base64 = Buffer.from(config.authorization).toString('base64')
-    options.headers = { Authorization: `Basic ${base64}` }
+    options.headers = {
+      ...options.headers,
+      Authorization: `Basic ${base64}`,
+    }
   }
   const optionsOverrides = _.omitBy(
     {


### PR DESCRIPTION
## High Level Overview of Change

Allow users to customize the headers field in the client connection to provide api keys.

### Context of Change

In response to #2034 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

## Before / After

You can now add a custom header if you want.

## Test Plan

CI passes

<!--
## Future Tasks
For future tasks related to PR.
-->