### PR TITLE
Fix Wallet.fromMnemonic 

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,6 +3,9 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
+### Fixed
+* fromMnemonic now allows lowercase for RFC1751 mnemnoics
+* fromMnemonic has better error handling if an invalid encoding is provided
 
 ## 2.3.1 (2022-06-27)
 ### Fixed

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,7 +4,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 ### Fixed
-* fromMnemonic now allows lowercase for RFC1751 mnemnoics
+* `Wallet.fromMnemonic` now allows lowercase for RFC1751 mnemonics (#2046)
 * `Wallet.fromMnemonic` detects when an invalid encoding is provided, and throws an error
 
 ## 2.3.1 (2022-06-27)

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,7 +5,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 ### Fixed
 * fromMnemonic now allows lowercase for RFC1751 mnemnoics
-* fromMnemonic has better error handling if an invalid encoding is provided
+* `Wallet.fromMnemonic` detects when an invalid encoding is provided, and throws an error
 
 ## 2.3.1 (2022-06-27)
 ### Fixed

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- There are lots of equivalent constructors which make sense to have here. */
 import BigNumber from 'bignumber.js'
 import { fromSeed } from 'bip32'
-import { mnemonicToSeedSync } from 'bip39'
+import { mnemonicToSeedSync, validateMnemonic } from 'bip39'
 import _ from 'lodash'
 import {
   classicAddressToXAddress,
@@ -229,12 +229,18 @@ class Wallet {
       })
     }
     // Otherwise decode using bip39's mnemonic standard
+    if (!validateMnemonic(mnemonic)) {
+      throw new ValidationError(
+        'Unable to parse the given mnemonic using bip39 encoding',
+      )
+    }
+
     const seed = mnemonicToSeedSync(mnemonic)
     const masterNode = fromSeed(seed)
     const node = masterNode.derivePath(
       opts.derivationPath ?? DEFAULT_DERIVATION_PATH,
     )
-    if (node.privateKey === undefined) {
+    if (node?.privateKey === undefined) {
       throw new ValidationError(
         'Unable to derive privateKey from mnemonic input',
       )

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -240,7 +240,7 @@ class Wallet {
     const node = masterNode.derivePath(
       opts.derivationPath ?? DEFAULT_DERIVATION_PATH,
     )
-    if (node?.privateKey === undefined) {
+    if (node.privateKey === undefined) {
       throw new ValidationError(
         'Unable to derive privateKey from mnemonic input',
       )

--- a/packages/xrpl/src/Wallet/rfc1751.ts
+++ b/packages/xrpl/src/Wallet/rfc1751.ts
@@ -177,10 +177,14 @@ function bufferToArray(buf: Buffer): number[] {
  * @returns A buffer containing the same data with reversed endianness
  */
 function swap128(buf: Buffer): Buffer {
-  const result = Buffer.alloc(16)
-  result.writeBigUInt64LE(buf.readBigUInt64BE(0), 8)
-  result.writeBigUInt64LE(buf.readBigUInt64BE(8), 0)
-  return result
+  // Interprets buffer as an array of (two, in this case) 64-bit numbers and swaps byte order in-place.
+  const reversedBytes = buf.swap64()
+
+  // Swap the two 64-bit numbers since our buffer is 128 bits.
+  return Buffer.concat(
+    [reversedBytes.slice(8, 16), reversedBytes.slice(0, 8)],
+    16,
+  )
 }
 
 export { rfc1751MnemonicToKey, keyToRFC1751Mnemonic }

--- a/packages/xrpl/src/Wallet/rfc1751.ts
+++ b/packages/xrpl/src/Wallet/rfc1751.ts
@@ -138,7 +138,7 @@ function getSubKey(
   for (word of sublist) {
     const idx = rfc1751WordList.indexOf(word.toUpperCase())
     if (idx === -1) {
-      throw TypeError(
+      throw new TypeError(
         `Expected an RFC1751 word, but received '${word}'. ` +
           `For the full list of words in the RFC1751 encoding see https://datatracker.ietf.org/doc/html/rfc1751`,
       )

--- a/packages/xrpl/src/Wallet/rfc1751.ts
+++ b/packages/xrpl/src/Wallet/rfc1751.ts
@@ -136,7 +136,13 @@ function getSubKey(
   const ch = [0, 0, 0, 0, 0, 0, 0, 0, 0]
   let word = ''
   for (word of sublist) {
-    const idx = rfc1751WordList.indexOf(word)
+    const idx = rfc1751WordList.indexOf(word.toUpperCase())
+    if (idx === -1) {
+      throw TypeError(
+        `Expected an RFC1751 word, but received '${word}'. ` +
+          `For the full list of words in the RFC1751 encoding see https://datatracker.ietf.org/doc/html/rfc1751`,
+      )
+    }
     const shift = (8 - ((bits + 11) % 8)) % 8
     const y = idx << shift
     const cl = y >> 16

--- a/packages/xrpl/test/wallet/index.ts
+++ b/packages/xrpl/test/wallet/index.ts
@@ -143,6 +143,41 @@ describe('Wallet', function () {
       assert.equal(wallet.seed, expectedSeed)
     })
 
+    it('throws an error when using an RFC1751 mnemonic for bip39', function () {
+      const algorithm = ECDSA.ed25519
+      const mnemonic =
+        'CAB BETH HANK BIRD MEND SIGN GILD ANY KERN HYDE CHAT STUB'
+      assert.throws(() => {
+        Wallet.fromMnemonic(mnemonic, {
+          mnemonicEncoding: 'bip39',
+          algorithm,
+        })
+      }, /^Unable to parse the given mnemonic using bip39 encoding$/u)
+    })
+
+    it('throws an error when using an bip39 mnemonic for RFC1751', function () {
+      const mnemonic =
+        'draw attack antique swing base employ blur above palace lucky glide clap pen use illegal'
+      assert.throws(() => {
+        Wallet.fromMnemonic(mnemonic, {
+          mnemonicEncoding: 'rfc1751',
+        })
+      }, /^Expected an RFC1751 word, but received 'attack'\. For the full list of words in the RFC1751 encoding see https:\/\/datatracker\.ietf\.org\/doc\/html\/rfc1/u)
+    })
+
+    it('derives a wallet using rfc1751 mnemonic with lowercase words', function () {
+      const algorithm = ECDSA.ed25519
+      const mnemonic =
+        'cab beth hank bird mend sign gild any kern hyde chat stub'
+      const expectedSeed = 'sEdVaw4m9W3H3ou3VnyvDwvPAP5BEz1'
+      const wallet = Wallet.fromMnemonic(mnemonic, {
+        mnemonicEncoding: 'rfc1751',
+        algorithm,
+      })
+
+      assert.equal(wallet.seed, expectedSeed)
+    })
+
     it('derives a wallet using a Regular Key Pair', function () {
       const masterAddress = 'rUAi7pipxGpYfPNg3LtPcf2ApiS8aw9A93'
       const regularKeyPair = {
@@ -211,11 +246,11 @@ describe('Wallet', function () {
 
   describe('fromMnemonic', function () {
     const mnemonic =
-      'try milk link drift aware pass obtain again music stick pluck fold'
+      'assault rare scout seed design extend noble drink talk control guitar quote'
     const publicKey =
-      '0257B550BA2FDCCF0ADDA3DEB2A5411700F3ADFDCC7C68E1DCD1E2B63E6B0C63E6'
+      '035953FCD81D001CF634EB44A87940F3F98ADF2483D09C914BAED0539BE50F385D'
     const privateKey =
-      '008F942B6E229C0E9CEE47E7A94253DABB6A9855F4BA2D8A741FA31851A1D423C3'
+      '0013FC461CA5799F1357C8130AF703CBA7E9C28E072C6CA8F7DEF8601CDE98F394'
 
     it('derives a wallet using default derivation path', function () {
       const wallet = Wallet.fromMnemonic(mnemonic)
@@ -235,15 +270,16 @@ describe('Wallet', function () {
     it('derives a wallet using a Regular Key Pair', function () {
       const masterAddress = 'rUAi7pipxGpYfPNg3LtPcf2ApiS8aw9A93'
       const regularKeyPair = {
-        mnemonic: 'KNEW BENT LYNN LED GAD BEN KENT SHAM HOBO RINK WALT ALLY',
+        mnemonic: 'I IRE BOND BOW TRIO LAID SEAT GOAL HEN IBIS IBIS DARE',
         publicKey:
-          '02FBC77338A52D9733641437A77369ACB0D89D52642740A008509F7A3A7450C841',
+          '0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020',
         privateKey:
-          '007A10DF756751129060DD29C9BB6733ADB92507B7DD83BB0795CAA09FB815BE22',
+          '001ACAAEDECE405B2A958212629E16F2EB46B153EEE94CDD350FDEFF52795525B7',
       }
 
       const wallet = Wallet.fromMnemonic(regularKeyPair.mnemonic, {
         masterAddress,
+        mnemonicEncoding: 'rfc1751',
       })
 
       assert.equal(wallet.publicKey, regularKeyPair.publicKey)
@@ -253,7 +289,7 @@ describe('Wallet', function () {
   })
 
   describe('fromEntropy', function () {
-    let entropy
+    let entropy: number[]
     const publicKey =
       '0390A196799EE412284A5D80BF78C3E84CBB80E1437A0AECD9ADF94D7FEAAFA284'
     const privateKey =


### PR DESCRIPTION
## High Level Overview of Change

Updates Wallet.fromMnemonic to have better validation checks, work with react-native on android, and 

### Context of Change

In response to a couple issues raised surrounding the function #2042 and #2044. (Exact changes made as a result are listed below)


### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After

* There are now validation checks on whether an encoding is valid in BOTH bip39 and rfc1751 encodings (So should not be possible to end up in a situation like #2042)
* Lowercase words now work with rfc1751 encoding (Fixes #2042) 
* It wasn't working in react-native for Android (Fixes #2044) 
* Added more tests for common mistakes people could make (And ensured that they properly error)

## Test Plan

CI Passes