### PR TITLE
Make the unknown submitAndWait error more verbose

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,6 +3,9 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
+### Added
+* Made unexpected errors in `submitAndWait` more verbose to make them easier to debug.
+
 ### Fixed
 * `Wallet.fromMnemonic` now allows lowercase for RFC1751 mnemonics (#2046)
 * `Wallet.fromMnemonic` detects when an invalid encoding is provided, and throws an error

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,12 +3,10 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
-### Added
-* Made unexpected errors in `submitAndWait` more verbose to make them easier to debug.
-
 ### Fixed
 * `Wallet.fromMnemonic` now allows lowercase for RFC1751 mnemonics (#2046)
 * `Wallet.fromMnemonic` detects when an invalid encoding is provided, and throws an error
+* Made unexpected errors in `submitAndWait` more verbose to make them easier to debug.
 
 ## 2.3.1 (2022-06-27)
 ### Fixed

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -157,7 +157,9 @@ async function waitForFinalTransactionOutcome(
           submissionResult,
         )
       }
-      throw new Error(`${message} \n Preliminary result: ${submissionResult}.`)
+      throw new Error(
+        `${message} \n Preliminary result: ${submissionResult}.\nFull error details: ${error}`,
+      )
     })
 
   if (txResponse.result.validated) {

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -158,7 +158,9 @@ async function waitForFinalTransactionOutcome(
         )
       }
       throw new Error(
-        `${message} \n Preliminary result: ${submissionResult}.\nFull error details: ${error}`,
+        `${message} \n Preliminary result: ${submissionResult}.\nFull error details: ${String(
+          error,
+        )}`,
       )
     })
 


### PR DESCRIPTION
## High Level Overview of Change

Provides more context when an unknown error happens during the submitAndWait function

### Context of Change

The integration test for `submitAndWait` is being flaky and giving this error, but it's not possible to debug because the message is undefined. This should allow us to debug it if it happens in the future, in addition to providing a better experience for folks running into unexpected exceptions using `submitAndWait`.

### Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Before / After

Added more information to the exception message.

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->