### PR TITLE
feat: Export verify

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,7 +5,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 ### Added
 
-- Export `verify` from ripple-keypairs for use in web-apps.
+- Export `verify` from ripple-keypairs as `verifySignature` for use in web-apps.
 
 ### Fixed
 * `Wallet.fromMnemonic` now allows lowercase for RFC1751 mnemonics (#2046)

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,7 +3,6 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
-
 ### Added
 
 - Export `verify` from ripple-keypairs for use in web-apps.

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,6 +3,11 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
+
+### Added
+
+- Export `verify` from ripple-keypairs for use in web-apps.
+
 ### Fixed
 * `Wallet.fromMnemonic` now allows lowercase for RFC1751 mnemonics (#2046)
 * `Wallet.fromMnemonic` detects when an invalid encoding is provided, and throws an error

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,7 +5,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 ### Added
 
-- Export `verify` from ripple-keypairs as `verifySignature` for use in web-apps.
+- Export `verify` from ripple-keypairs as `verifyKeypairSignature` for use in web-apps.
 
 ### Fixed
 * `Wallet.fromMnemonic` now allows lowercase for RFC1751 mnemonics (#2046)

--- a/packages/xrpl/src/utils/index.ts
+++ b/packages/xrpl/src/utils/index.ts
@@ -15,7 +15,7 @@ import {
   xAddressToClassicAddress,
 } from 'ripple-address-codec'
 import * as rbc from 'ripple-binary-codec'
-import { verify as verifySignature } from 'ripple-keypairs'
+import { verify as verifyKeypairSignature } from 'ripple-keypairs'
 
 import { LedgerEntry } from '../models/ledger'
 import { Response } from '../models/methods'
@@ -195,7 +195,7 @@ export {
   deriveAddress,
   deriveXAddress,
   signPaymentChannelClaim,
-  verifySignature,
+  verifyKeypairSignature,
   verifyPaymentChannelClaim,
   convertStringToHex,
   convertHexToString,

--- a/packages/xrpl/src/utils/index.ts
+++ b/packages/xrpl/src/utils/index.ts
@@ -15,6 +15,7 @@ import {
   xAddressToClassicAddress,
 } from 'ripple-address-codec'
 import * as rbc from 'ripple-binary-codec'
+import { verify } from 'ripple-keypairs'
 
 import { LedgerEntry } from '../models/ledger'
 import { Response } from '../models/methods'
@@ -194,6 +195,7 @@ export {
   deriveAddress,
   deriveXAddress,
   signPaymentChannelClaim,
+  verify,
   verifyPaymentChannelClaim,
   convertStringToHex,
   convertHexToString,

--- a/packages/xrpl/src/utils/index.ts
+++ b/packages/xrpl/src/utils/index.ts
@@ -15,7 +15,7 @@ import {
   xAddressToClassicAddress,
 } from 'ripple-address-codec'
 import * as rbc from 'ripple-binary-codec'
-import { verify } from 'ripple-keypairs'
+import { verify as verifySignature } from 'ripple-keypairs'
 
 import { LedgerEntry } from '../models/ledger'
 import { Response } from '../models/methods'
@@ -195,7 +195,7 @@ export {
   deriveAddress,
   deriveXAddress,
   signPaymentChannelClaim,
-  verify,
+  verifySignature,
   verifyPaymentChannelClaim,
   convertStringToHex,
   convertHexToString,


### PR DESCRIPTION
## High Level Overview of Change

Exports the `verify` function from `ripple-binary-codec` so it can be used in web apps.

### Context of Change

Trying to use the function in a webapp, but ripple-keypairs doesn't have webpacking.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

## Test Plan

CI Passes
