### PR TITLE
docs(react): Add guide for create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,66 +62,71 @@ main()
 ```
 
 For more examples, see the [documentation](#documentation).
+
 ### Using xrpl.js with `create-react-app`
-If you want to use `xrpl.js` with React using CRA you will need to install shims for core NodeJS modules.
-Starting with version 5, Webpack stopped including shims by default, so you must modify your Webpack configuration to add the shims you need. Either you can eject your config and modify it, or you can use a library such as `react-app-rewired`. The example below uses `react-app-rewired`.
+To use `xrpl.js` with React, you need to install shims for core NodeJS modules. Starting with version 5, Webpack stopped including shims by default, so you must modify your Webpack configuration to add the shims you need. Either you can eject your config and modify it, or you can use a library such as `react-app-rewired`. The example below uses `react-app-rewired`.
 
 1. Install shims (you can use `yarn` as well):
-```shell
-npm i --save-dev \
-    assert \
-    buffer \
-    crypto-browserify \
-    https-browserify \
-    os-browserify \
-    process \
-    stream-browserify \
-    stream-http \
-    url
-```
+
+   ```shell
+   npm install --save-dev \
+       assert \
+       buffer \
+       crypto-browserify \
+       https-browserify \
+       os-browserify \
+       process \
+       stream-browserify \
+       stream-http \
+       url
+   ```
 2. Modify your webpack configuration
     1. Install `react-app-rewired`
-    ````shell
-    npm install --save-dev react-app-rewired
-    ````
+   
+       ````shell
+       npm install --save-dev react-app-rewired
+       ````
+
     2. At the project root, add a file named `config-overrides.js` with the following content:
 
-    ```javascript
-    const webpack = require('webpack');
-    
-    module.exports = function override(config) {
-        const fallback = config.resolve.fallback || {};
-        Object.assign(fallback, {
-            "assert": require.resolve("assert"),
-            "crypto": require.resolve("crypto-browserify"),
-            "http": require.resolve("stream-http"),
-            "https": require.resolve("https-browserify"),
-            "os": require.resolve("os-browserify"),
-            "stream": require.resolve("stream-browserify"),
-            "url": require.resolve("url"),
-        })
-        config.resolve.fallback = fallback
-        config.plugins = (config.plugins || []).concat([
-            new webpack.ProvidePlugin({
-                process: 'process/browser',
-                Buffer: ['buffer', 'Buffer']
-            })
-        ])
-    
-        // This is deprecated in webpack 5 but alias false does not seem to work
-        config.module.rules.push({
-            test: /node_modules[\\\/]https-proxy-agent[\\\/]/,
-            use: 'null-loader',
-        })
-        return config;
-    }
-    ```
-   3. Update package.json scripts section with
-   ```
-   "start": "react-app-rewired start", 
-   "build": "react-app-rewired build",
-   "test": "react-app-rewired test",
-   ```
+       ```javascript
+       const webpack = require('webpack');
+       
+       module.exports = function override(config) {
+           const fallback = config.resolve.fallback || {};
+           Object.assign(fallback, {
+               "assert": require.resolve("assert"),
+               "crypto": require.resolve("crypto-browserify"),
+               "http": require.resolve("stream-http"),
+               "https": require.resolve("https-browserify"),
+               "os": require.resolve("os-browserify"),
+               "stream": require.resolve("stream-browserify"),
+               "url": require.resolve("url"),
+           })
+           config.resolve.fallback = fallback
+           config.plugins = (config.plugins || []).concat([
+               new webpack.ProvidePlugin({
+                   process: 'process/browser',
+                   Buffer: ['buffer', 'Buffer']
+               })
+           ])
+       
+           // This is deprecated in webpack 5 but alias false does not seem to work
+           config.module.rules.push({
+               test: /node_modules[\\\/]https-proxy-agent[\\\/]/,
+               use: 'null-loader',
+           })
+           return config;
+       }
+       ```
+       
+    3. Update package.json scripts section with
+
+        ```
+        "start": "react-app-rewired start", 
+        "build": "react-app-rewired build",
+        "test": "react-app-rewired test",
+        ```
 
 ### Using xrpl.js with React Native
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ npm i --save-dev \
     ````shell
     npm install --save-dev react-app-rewired
     ````
-    2. Add `config-overrides.js` to project root
+    2. At the project root, add a file named `config-overrides.js` with the following content:
+
     ```javascript
     const webpack = require('webpack');
     

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ main()
 For more examples, see the [documentation](#documentation).
 ### Using xrpl.js with `create-react-app`
 If you want to use `xrpl.js` with React using CRA you will need to install shims for core NodeJS modules.
-In `webpack@5` shims stopped in included by default, so you will need to modify your webpack configuration this can be done by ejecting your config and modifying it or using another library such as `react-app-rewired` 
+Starting with version 5, Webpack stopped including shims by default, so you must modify your Webpack configuration to add the shims you need. Either you can eject your config and modify it, or you can use a library such as `react-app-rewired`. The example below uses `react-app-rewired`.
 
 1. Install shims (you can use `yarn` as well):
 ```shell

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ main()
 
 For more examples, see the [documentation](#documentation).
 ### Using xrpl.js with `create-react-app`
-If you want to use `xrpl.js` with React Native you will need to install shims for core NodeJS modules.
+If you want to use `xrpl.js` with React using CRA you will need to install shims for core NodeJS modules.
 In `webpack@5` shims stopped in included by default, so you will need to modify your webpack configuration this can be done by ejecting your config and modifying it or using another library such as `react-app-rewired` 
 
 1. Install shims (you can use `yarn` as well):
@@ -99,6 +99,7 @@ npm i --save-dev \
             "stream": require.resolve("stream-browserify"),
             "url": require.resolve("url"),
         })
+        config.resolve.fallback = fallback
         config.plugins = (config.plugins || []).concat([
             new webpack.ProvidePlugin({
                 process: 'process/browser',

--- a/README.md
+++ b/README.md
@@ -62,6 +62,64 @@ main()
 ```
 
 For more examples, see the [documentation](#documentation).
+### Using xrpl.js with `create-react-app`
+If you want to use `xrpl.js` with React Native you will need to install shims for core NodeJS modules.
+In `webpack@5` shims stopped in included by default, so you will need to modify your webpack configuration this can be done by ejecting your config and modifying it or using another library such as `react-app-rewired` 
+
+1. Install shims (you can use `yarn` as well):
+```shell
+npm i --save-dev \
+    assert \
+    buffer \
+    crypto-browserify \
+    https-browserify \
+    os-browserify \
+    process \
+    stream-browserify \
+    stream-http \
+    url
+```
+2. Modify your webpack configuration
+    1. Install `react-app-rewired`
+    ````shell
+    npm install --save-dev react-app-rewired
+    ````
+    2. Add `config-overrides.js` to project root
+    ```javascript
+    const webpack = require('webpack');
+    
+    module.exports = function override(config) {
+        const fallback = config.resolve.fallback || {};
+        Object.assign(fallback, {
+            "assert": require.resolve("assert"),
+            "crypto": require.resolve("crypto-browserify"),
+            "http": require.resolve("stream-http"),
+            "https": require.resolve("https-browserify"),
+            "os": require.resolve("os-browserify"),
+            "stream": require.resolve("stream-browserify"),
+            "url": require.resolve("url"),
+        })
+        config.plugins = (config.plugins || []).concat([
+            new webpack.ProvidePlugin({
+                process: 'process/browser',
+                Buffer: ['buffer', 'Buffer']
+            })
+        ])
+    
+        // This is deprecated in webpack 5 but alias false does not seem to work
+        config.module.rules.push({
+            test: /node_modules[\\\/]https-proxy-agent[\\\/]/,
+            use: 'null-loader',
+        })
+        return config;
+    }
+    ```
+   3. Update package.json scripts section with
+   ```
+   "start": "react-app-rewired start", 
+   "build": "react-app-rewired build",
+   "test": "react-app-rewired test",
+   ```
 
 ### Using xrpl.js with React Native
 


### PR DESCRIPTION
## High Level Overview of Change

A guide for using React with xrpl.js.  Specifically this guide covers using `react-app-rewire` alongside `create-react-app`.  

### Context of Change

Webpack 5 broke how polyfills are applied.  This guide details a workaround

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

## Future Tasks

Additional guides may need to be created based on feedback about which build tools the community is using.