### PR TITLE
refactor: Incorrect converge_time for ServerState

### DIFF
--- a/packages/xrpl/src/models/methods/serverState.ts
+++ b/packages/xrpl/src/models/methods/serverState.ts
@@ -35,7 +35,7 @@ export interface ServerStateResponse extends BaseResponse {
       io_latency_ms: number
       jq_trans_overflow: string
       last_close: {
-        converge_time_s: number
+        converge_time: number
         proposers: number
       }
       load?: {


### PR DESCRIPTION
## High Level Overview of Change

Fix an incorrect typescript def based on both the code and docs for `ServerState` response:

https://github.com/XRPLF/rippled/blob/83faf43140e27e5d6d6779eaa0ffb75c33d98029/src/ripple/app/misc/NetworkOPs.cpp#L2463

https://xrpl.org/server_state.html

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
