### PR TITLE
fix: Add `nft_offer` to available account objects

### DIFF
--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -4,6 +4,7 @@ export type AccountObjectType =
   | 'check'
   | 'deposit_preauth'
   | 'escrow'
+  | 'nft_offer'
   | 'offer'
   | 'payment_channel'
   | 'signer_list'


### PR DESCRIPTION
## High Level Overview of Change

The account_objects call allows you to specify `nft_offer` but that option was missing from our types defintion.

Fix #2099

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release