### PR TITLE
fix: corrected snippet to show regular key works

### DIFF
--- a/packages/xrpl/snippets/src/setRegularKey.ts
+++ b/packages/xrpl/snippets/src/setRegularKey.ts
@@ -41,7 +41,7 @@ async function setRegularKey(): Promise<void> {
   }
 
   const submitTx = await client.submit(payment, {
-    wallet: wallet1,
+    wallet: regularKeyWallet,
   })
   console.log('Response for tx signed using Regular Key:')
   console.log(submitTx)


### PR DESCRIPTION
## High Level Overview of Change

Code snippet for regular wallet did not do as intended. Fixed one liner to make it so tx was signed by regular key wallet and not original wallet as a normal tx would.

### Context of Change

Snippet was misleading (comments stated one thing, code did another)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation Updates


## Before / After

Edited one line in snippet to sign with reg key rather than wallet

## Test Plan

Ran snippet in separate window