### PR TITLE
add Memos hex value check in Wallet.sign

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,7 +4,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 ### Added
 * Support for ExpandedSignerList amendment that expands the maximum signer list to 32 entries.
-
+* Addtional check for memos field format, provide more detailed error messages.
 ## 2.4.0 (2022-09-01)
 ### Added
 * Export `verify` from ripple-keypairs as `verifyKeypairSignature` for use in web-apps.

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -31,7 +31,6 @@ import { isIssuedCurrency } from '../models/transactions/common'
 import { isHex } from '../models/utils'
 import { ensureClassicAddress } from '../sugar/utils'
 import { hashSignedTx } from '../utils/hashes/hashLedger'
-
 import { rfc1751MnemonicToKey } from './rfc1751'
 
 const DEFAULT_ALGORITHM: ECDSA = ECDSA.ed25519
@@ -439,14 +438,23 @@ class Wallet {
     txCopy.Memos?.map((memo) => {
       const memoCopy = { ...memo }
       if (memo.Memo.MemoData) {
+        if (!isHex(memo.Memo.MemoData)) {
+          throw new ValidationError('MemoData field must be a hex value')
+        }
         memoCopy.Memo.MemoData = memo.Memo.MemoData.toUpperCase()
       }
 
       if (memo.Memo.MemoType) {
+        if (!isHex(memo.Memo.MemoType)) {
+          throw new ValidationError('MemoType field must be a hex value')
+        }
         memoCopy.Memo.MemoType = memo.Memo.MemoType.toUpperCase()
       }
 
       if (memo.Memo.MemoFormat) {
+        if (!isHex(memo.Memo.MemoFormat)) {
+          throw new ValidationError('MemoFormat field must be a hex value')
+        }
         memoCopy.Memo.MemoFormat = memo.Memo.MemoFormat.toUpperCase()
       }
 

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -31,6 +31,7 @@ import { isIssuedCurrency } from '../models/transactions/common'
 import { isHex } from '../models/utils'
 import { ensureClassicAddress } from '../sugar/utils'
 import { hashSignedTx } from '../utils/hashes/hashLedger'
+
 import { rfc1751MnemonicToKey } from './rfc1751'
 
 const DEFAULT_ALGORITHM: ECDSA = ECDSA.ed25519

--- a/packages/xrpl/test/wallet/index.ts
+++ b/packages/xrpl/test/wallet/index.ts
@@ -385,6 +385,83 @@ describe('Wallet', function () {
       })
     })
 
+    it('sign throws when MemoType is not a hex value', async function () {
+      const secret = 'shd2nxpFD6iBRKWsRss2P4tKMWyy9'
+      const lowercaseMemoTx: Transaction = {
+        TransactionType: 'Payment',
+        Flags: 2147483648,
+        Account: 'rwiZ3q3D3QuG4Ga2HyGdq3kPKJRGctVG8a',
+        Amount: '10000000',
+        LastLedgerSequence: 14000999,
+        Destination: 'rUeEBYXHo8vF86Rqir3zWGRQ84W9efdAQd',
+        Fee: '12',
+        Sequence: 12,
+        SourceTag: 8888,
+        DestinationTag: 9999,
+        Memos: [
+          {
+            Memo: {
+              MemoType: 'not hex value',
+              MemoData: '72656e74',
+            },
+          },
+        ],
+      }
+      assert.throws(() => {
+        Wallet.fromSeed(secret).sign(lowercaseMemoTx)
+      }, /MemoType field must be a hex value/u)
+    })
+    it('sign throws when MemoData is not a hex value', async function () {
+      const secret = 'shd2nxpFD6iBRKWsRss2P4tKMWyy9'
+      const lowercaseMemoTx: Transaction = {
+        TransactionType: 'Payment',
+        Flags: 2147483648,
+        Account: 'rwiZ3q3D3QuG4Ga2HyGdq3kPKJRGctVG8a',
+        Amount: '10000000',
+        LastLedgerSequence: 14000999,
+        Destination: 'rUeEBYXHo8vF86Rqir3zWGRQ84W9efdAQd',
+        Fee: '12',
+        Sequence: 12,
+        SourceTag: 8888,
+        DestinationTag: 9999,
+        Memos: [
+          {
+            Memo: {
+              MemoData: 'not hex value',
+            },
+          },
+        ],
+      }
+      assert.throws(() => {
+        Wallet.fromSeed(secret).sign(lowercaseMemoTx)
+      }, /MemoData field must be a hex value/u)
+    })
+    it('sign throws when MemoFormat is not a hex value', async function () {
+      const secret = 'shd2nxpFD6iBRKWsRss2P4tKMWyy9'
+      const lowercaseMemoTx: Transaction = {
+        TransactionType: 'Payment',
+        Flags: 2147483648,
+        Account: 'rwiZ3q3D3QuG4Ga2HyGdq3kPKJRGctVG8a',
+        Amount: '10000000',
+        LastLedgerSequence: 14000999,
+        Destination: 'rUeEBYXHo8vF86Rqir3zWGRQ84W9efdAQd',
+        Fee: '12',
+        Sequence: 12,
+        SourceTag: 8888,
+        DestinationTag: 9999,
+        Memos: [
+          {
+            Memo: {
+              MemoFormat: 'not hex value',
+            },
+          },
+        ],
+      }
+      assert.throws(() => {
+        Wallet.fromSeed(secret).sign(lowercaseMemoTx)
+      }, /MemoFormat field must be a hex value/u)
+    })
+
     it('sign with EscrowFinish', async function () {
       const result = wallet.sign(REQUEST_FIXTURES.escrow as Transaction)
       assert.deepEqual(result, {


### PR DESCRIPTION
## High Level Overview of Change
add a check in `wallet.sign()` to see if fields in Memos are hex values, if not, throw a specific error message like "MemoType field must be a hex value". 


### Context of Change
link to issue https://github.com/XRPLF/xrpl.js/issues/1790

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->
- [ X] Bug fix (non-breaking change which fixes an issue)

## Test Plan
added three unit tests case