### PR TITLE
docs(react): Add guide for create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,71 @@ main()
 
 For more examples, see the [documentation](#documentation).
 
+### Using xrpl.js with `create-react-app`
+To use `xrpl.js` with React, you need to install shims for core NodeJS modules. Starting with version 5, Webpack stopped including shims by default, so you must modify your Webpack configuration to add the shims you need. Either you can eject your config and modify it, or you can use a library such as `react-app-rewired`. The example below uses `react-app-rewired`.
+
+1. Install shims (you can use `yarn` as well):
+
+   ```shell
+   npm install --save-dev \
+       assert \
+       buffer \
+       crypto-browserify \
+       https-browserify \
+       os-browserify \
+       process \
+       stream-browserify \
+       stream-http \
+       url
+   ```
+2. Modify your webpack configuration
+    1. Install `react-app-rewired`
+   
+       ````shell
+       npm install --save-dev react-app-rewired
+       ````
+
+    2. At the project root, add a file named `config-overrides.js` with the following content:
+
+       ```javascript
+       const webpack = require('webpack');
+       
+       module.exports = function override(config) {
+           const fallback = config.resolve.fallback || {};
+           Object.assign(fallback, {
+               "assert": require.resolve("assert"),
+               "crypto": require.resolve("crypto-browserify"),
+               "http": require.resolve("stream-http"),
+               "https": require.resolve("https-browserify"),
+               "os": require.resolve("os-browserify"),
+               "stream": require.resolve("stream-browserify"),
+               "url": require.resolve("url"),
+           })
+           config.resolve.fallback = fallback
+           config.plugins = (config.plugins || []).concat([
+               new webpack.ProvidePlugin({
+                   process: 'process/browser',
+                   Buffer: ['buffer', 'Buffer']
+               })
+           ])
+       
+           // This is deprecated in webpack 5 but alias false does not seem to work
+           config.module.rules.push({
+               test: /node_modules[\\\/]https-proxy-agent[\\\/]/,
+               use: 'null-loader',
+           })
+           return config;
+       }
+       ```
+       
+    3. Update package.json scripts section with
+
+        ```
+        "start": "react-app-rewired start", 
+        "build": "react-app-rewired build",
+        "test": "react-app-rewired test",
+        ```
+
 ### Using xrpl.js with React Native
 
 If you want to use `xrpl.js` with React Native you will need to install shims for core NodeJS modules. To help with this you can use a module like [rn-nodeify](https://github.com/tradle/rn-nodeify).

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To use `xrpl.js` with React, you need to install shims for core NodeJS modules. 
                "os": require.resolve("os-browserify"),
                "stream": require.resolve("stream-browserify"),
                "url": require.resolve("url"),
+               "ws": require.resolve('xrpl/dist/npm/client/WSWrapper'),
            })
            config.resolve.fallback = fallback
            config.plugins = (config.plugins || []).concat([


### PR DESCRIPTION
This was previously merged into `develop` via #2087

## High Level Overview of Change

A guide for using React with xrpl.js.  Specifically this guide covers using `react-app-rewire` alongside `create-react-app`.  

### Context of Change

Webpack 5 broke how polyfills are applied.  This guide details a workaround.

### Type of Change

- [x] Documentation Updates

## Future Tasks

Additional guides may need to be created based on feedback about which build tools the community is using.