### PR TITLE
feat: shorten ledger close time

### DIFF
--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -7,7 +7,7 @@ import { Transaction } from '../models/transactions'
 import { hashes } from '../utils'
 
 /** Approximate time for a ledger to close, in milliseconds */
-const LEDGER_CLOSE_TIME = 4000
+const LEDGER_CLOSE_TIME = 1000
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {


### PR DESCRIPTION
## High Level Overview of Change

Changed reliable submission ledger close time from 4 to 1 to enhance transaction speed

### Context of Change

An example of where that might actually make the function run faster in a normal operation: according to [livenet.xrpl.org](http://livenet.xrpl.org/) a normal ledger on mainnet closes every 4.068 seconds right now. If the relsub method checks after 4 seconds, it would have to wait another 4 seconds before checking again, and take 8 seconds to finish, even if the transaction was validated after 4.068 seconds. If we switch to checking every 1 second, then it would take 5 seconds to finish.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

CI tests