### PR TITLE
Typo fix in getBalanceChanges.ts

### DIFF
--- a/packages/xrpl/src/utils/getBalanceChanges.ts
+++ b/packages/xrpl/src/utils/getBalanceChanges.ts
@@ -34,7 +34,7 @@ interface NormalizedNode {
   FinalFields?: Fields
   PreviousFields?: Fields
   PreviousTxnID?: string
-  PreviouTxnLgrSeq?: number
+  PreviousTxnLgrSeq?: number
 }
 
 function normalizeNode(affectedNode: Node): NormalizedNode {


### PR DESCRIPTION
## High Level Overview of Change

NormalizedNode interface has miss typed key definition "PreviouTxnLgrSeq" now renamed to "PreviousTxnLgrSeq"

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

No effect.

## Test Plan

Please re-run tests before merging.

<!--
## Future Tasks
For future tasks related to PR.
-->