### PR TITLE
Ignore `https-proxy-agent` dependency in browser environments

### DIFF
--- a/packages/xrpl/.eslintrc.js
+++ b/packages/xrpl/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     // Disabled until https://github.com/import-js/eslint-plugin-import/pull/2305 is resolved to
     // accomodate this change https://github.com/XRPLF/xrpl.js/pull/2133
     'import/no-unused-modules': 'off',
+    'eslint-comments/no-unused-disable': 'off',
     // Certain rippled APIs require snake_case naming
     '@typescript-eslint/naming-convention': [
       'error',

--- a/packages/xrpl/.eslintrc.js
+++ b/packages/xrpl/.eslintrc.js
@@ -28,6 +28,9 @@ module.exports = {
   plugins: [],
   extends: ['@xrplf/eslint-config/base', 'plugin:mocha/recommended'],
   rules: {
+    // Disabled until https://github.com/import-js/eslint-plugin-import/pull/2305 is resolved to
+    // accomodate this change https://github.com/XRPLF/xrpl.js/pull/2133
+    'import/no-unused-modules': 'off',
     // Certain rippled APIs require snake_case naming
     '@typescript-eslint/naming-convention': [
       'error',

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -2,6 +2,8 @@
 
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 ## Unreleased
+### Fixed
+* Ignore `https-proxy-agent` in browsers for improved Vite integration
 
 ## 2.5.0 (2022-10-13)
 ### Added

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -18,7 +18,8 @@
     "test": "test"
   },
   "browser": {
-    "ws": "./dist/npm/client/WSWrapper.js"
+    "ws": "./dist/npm/client/WSWrapper.js",
+    "https-proxy-agent": false
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",

--- a/packages/xrpl/src/client/WSWrapper.ts
+++ b/packages/xrpl/src/client/WSWrapper.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-unused-modules -- Used by webpack */
 /* eslint-disable max-classes-per-file -- Needs to be a wrapper for ws */
 import { EventEmitter } from 'events'
 

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -136,7 +136,6 @@ export interface LedgerStream extends BaseStream {
 /**
  * This response mirrors the LedgerStream, except it does NOT include the 'type' nor 'txn_count' fields.
  */
-// eslint-disable-next-line import/no-unused-modules -- Detailed enough to be worth exporting for end users.
 export interface LedgerStreamResponse {
   /**
    * The reference transaction cost as of this ledger version, in drops of XRP.


### PR DESCRIPTION
## High Level Overview of Change

This change ignores `https-proxy-agent` from browser environments in `package.json`, mirroring the existing content in https://github.com/XRPLF/xrpl.js/blob/main/packages/xrpl/webpack.config.js#L59

### Context of Change

With some effort in our Vite.js based project, we were able to polyfill node dependencies to resolve [this known issue](https://github.com/XRPLF/xrpl.js/issues/1691#issuecomment-1202076652).

However, this fix did not extend to our Cypress test environment.  With a working Vite configuration, running Cypress tests yields:

```
Error: Build failed with 2 errors:
node_modules/https-proxy-agent/dist/agent.js:15:38: ERROR: Could not resolve "net"
node_modules/https-proxy-agent/dist/agent.js:16:38: ERROR: Could not resolve "tls"
    at failureErrorWithLog (/node_modules/esbuild/lib/main.js:1566:15)
```

To get Cypress tests running, we:
1. Utilized `@bahmutov/cypress-esbuild-preprocessor` to polyfill esbuild node dependencies to match those in our Vite configuration (including aliases) 
2. Added `"https-proxy-agent": false` to xrpl.js `package.json`'s `browser` field.

This has the effect of ignoring `http-proxy-agent` in browser environments, which clears up the error and allows Cypress tests to run. See [the spec](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module) for more information.

#### Linting changes

This change (adding a boolean value to `package.json`) triggers this bug in [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import/issues/1996), which motivated the temporary disablement of the `import/no-unused-modules` linting rule.  After the eslint-plugin-import bug is fixed, `import/no-unused-modules` can be enabled again (e.g. revert [this commit](https://github.com/XRPLF/xrpl.js/pull/2133/commits/a8c3dfa1c0ba98fdab3d11733121dd2d56b7172c) and turn back on `import/no-unused-modules`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

`https-proxy-agent` is no longer included in browser environments.
