### PR TITLE
add derivePublicKey function

### DIFF
--- a/packages/ripple-keypairs/src/index.ts
+++ b/packages/ripple-keypairs/src/index.ts
@@ -155,6 +155,11 @@ function deriveNodeAddress(publicKey): string {
   return deriveAddressFromBytes(accountPublicBytes)
 }
 
+function derivePublicKey(privateKey): string {
+  const { publicKey } = deriveKeypair(privateKey)
+  return deriveAddress(publicKey)
+}
+
 const { decodeSeed } = addressCodec
 
 export = {
@@ -164,5 +169,6 @@ export = {
   verify,
   deriveAddress,
   deriveNodeAddress,
+  derivePublicKey,
   decodeSeed,
 }

--- a/packages/ripple-keypairs/test/api-test.js
+++ b/packages/ripple-keypairs/test/api-test.js
@@ -100,6 +100,12 @@ describe('api', () => {
     assert.strictEqual(api.deriveNodeAddress(x), y)
   })
 
+  it('derivePublicKey', () => {
+    const x = 'spjsd1w9w6gd8XViE3zKaAkph8seb'
+    const y = 'rsWUKh9woaMr4fivNq1YpbM9n2vKT14dBs'
+    assert.strictEqual(api.derivePublicKey(x), y)
+  })
+
   it('Random Address', () => {
     const seed = api.generateSeed()
     const keypair = api.deriveKeypair(seed)


### PR DESCRIPTION
## High Level Overview of Change

adds `derivePublicKey(privateKey)` to key-pairs API. 

### Context of Change

addresses https://github.com/XRPLF/xrpl.js/issues/1818. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Before it was not immediately clear how to get the accountId from a private key.  This change adds a dedicated method to the key-pairs API. 

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->