### PR TITLE
fix: change eslint-plugin-jsdoc version constraint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3385,7 +3385,7 @@
         "eslint-plugin-consistent-default-export-name": ">= 0.0.13",
         "eslint-plugin-eslint-comments": ">= 3.2.0 < 4",
         "eslint-plugin-import": ">= 2.22.0 < 3",
-        "eslint-plugin-jsdoc": ">= 36.0.8 < 37",
+        "eslint-plugin-jsdoc": ">= 36.0.8 < 38",
         "eslint-plugin-node": ">= 11.1.0 < 12",
         "eslint-plugin-prettier": "~4.0",
         "eslint-plugin-tsdoc": ">= 0.2.5",


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
We are using eslint-plugin-jsdoc version 37.1.0 (dependabot update), but the constraint in package-lock.json is `"eslint-plugin-jsdoc": ">= 36.0.8 < 37"`, causing `npm install` to fail at some node version. This PR fixes the issue.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->
Node 18 runs `npm install` successfully without error.
