### PR TITLE
Add Code Sandbox template to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ main()
 
 For more examples, see the [documentation](#documentation).
 
+## Try it out now!
+
+If you just want to try xrpl.js, you can fork this Code Sandbox template:
+https://codesandbox.io/s/xrpl-intro-pxgdjr?file=/src/App.js
+
+It goes through:
+1. Creating a new test account
+2. Sending a payment transaction 
+3. And sending requests to see your account balance
+
 ### Using xrpl.js with `create-react-app`
 To use `xrpl.js` with React, you need to install shims for core NodeJS modules. Starting with version 5, Webpack stopped including shims by default, so you must modify your Webpack configuration to add the shims you need. Either you can eject your config and modify it, or you can use a library such as `react-app-rewired`. The example below uses `react-app-rewired`.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ To use `xrpl.js` with React, you need to install shims for core NodeJS modules. 
         "test": "react-app-rewired test",
         ```
 
+This online template uses these steps to run xrpl.js with React in the browser:
+https://codesandbox.io/s/xrpl-intro-pxgdjr?file=/src/App.js
+
 ### Using xrpl.js with React Native
 
 If you want to use `xrpl.js` with React Native you will need to install shims for core NodeJS modules. To help with this you can use a module like [rn-nodeify](https://github.com/tradle/rn-nodeify).


### PR DESCRIPTION
## High Level Overview of Change

Add a template code sandbox to the README

### Context of Change

Following up on the issue where we couldn't use xrpl.js with React, this shows how to do it, and is an easy to modify snippet for people who are new to the library.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

## Before / After

Added a link to the Code Sandbox template 

## Test Plan

Code sandbox runs successfully when I click the link.

<!--
## Future Tasks
For future tasks related to PR.
-->