### PR TITLE
[DO NOT MERGE] Allow default param for coreTypes with cost of circular import

### DIFF
--- a/packages/ripple-binary-codec/src/enums/index.ts
+++ b/packages/ripple-binary-codec/src/enums/index.ts
@@ -3,7 +3,7 @@ import { XrplDefinitions, FieldInstance, Bytes } from './xrpl-definitions'
 /**
  * By default, coreTypes from the `types` folder is where known type definitions are initialized to avoid import cycles.
  */
-const DEFAULT_DEFINITIONS = new XrplDefinitions(enums, {})
+const DEFAULT_DEFINITIONS = new XrplDefinitions(enums)
 
 const Type = DEFAULT_DEFINITIONS.type
 const LedgerEntryType = DEFAULT_DEFINITIONS.ledgerEntryType

--- a/packages/ripple-binary-codec/src/enums/xrpl-definitions.ts
+++ b/packages/ripple-binary-codec/src/enums/xrpl-definitions.ts
@@ -7,6 +7,7 @@ import {
   TRANSACTION_TYPE_WIDTH,
   TRANSACTION_RESULT_WIDTH,
 } from './constants'
+import { coreTypes } from '../types'
 
 interface DefinitionsData {
   TYPES: Record<string, number>
@@ -42,16 +43,8 @@ class XrplDefinitions {
    */
   constructor(
     enums: DefinitionsData,
-    types: Record<string, typeof SerializedType>,
+    types: Record<string, typeof SerializedType> = coreTypes,
   ) {
-    // Helps catch errors early in JavaScript code.
-    if (types == undefined) {
-      throw new TypeError(
-        'You passed in an undefined `types` parameter, but `types` must be defined since it contains logic for encoding/decoding transaction data.' +
-          ' If you have NOT added/modified any data types, you can import and use `coreTypes` from the types folder.',
-      )
-    }
-
     this.type = new BytesLookup(enums.TYPES, TYPE_WIDTH)
     this.ledgerEntryType = new BytesLookup(
       enums.LEDGER_ENTRY_TYPES,

--- a/packages/ripple-binary-codec/src/types/index.ts
+++ b/packages/ripple-binary-codec/src/types/index.ts
@@ -37,7 +37,7 @@ const coreTypes: Record<string, typeof SerializedType> = {
 // Ensures that the DEFAULT_DEFINITIONS object connects these types to fields for serializing/deserializing
 // This is done here instead of in enums/index.ts to avoid a circular dependency
 // because some of the above types depend on BinarySerailizer which depends on enums/index.ts.
-DEFAULT_DEFINITIONS.associateTypes(coreTypes)
+DEFAULT_DEFINITIONS?.associateTypes(coreTypes)
 
 export {
   coreTypes,

--- a/packages/ripple-binary-codec/test/definitions.test.js
+++ b/packages/ripple-binary-codec/test/definitions.test.js
@@ -24,7 +24,7 @@ describe('encode and decode using new types as a parameter', function () {
     // Before updating the types, this should not be encodable
     expect(() => encode(tx)).toThrow()
 
-    const newDefs = new XrplDefinitions(newTransactionDefs, coreTypes)
+    const newDefs = new XrplDefinitions(newTransactionDefs)
 
     const encoded = encode(tx, newDefs)
     expect(() => decode(encoded)).toThrow()
@@ -40,7 +40,7 @@ describe('encode and decode using new types as a parameter', function () {
     // Before updating the types, undefined fields will be ignored on encode
     expect(decode(encode(tx))).not.toStrictEqual(tx)
 
-    const newDefs = new XrplDefinitions(newFieldDefs, coreTypes)
+    const newDefs = new XrplDefinitions(newFieldDefs)
 
     const encoded = encode(tx, newDefs)
     expect(() => decode(encoded)).toThrow()

--- a/packages/ripple-binary-codec/test/signing-data-encoding.test.js
+++ b/packages/ripple-binary-codec/test/signing-data-encoding.test.js
@@ -5,7 +5,6 @@ const {
   encodeForMultisigning,
 } = require('../dist')
 const { XrplDefinitions } = require('../dist/enums')
-const { coreTypes } = require('../dist/types')
 
 // This changes the Payment TransactionType from being 0 to being 30 (aka 0x001F when encoded)
 const definitions = require('./fixtures/definitions-with-diff-payment.json')
@@ -73,7 +72,7 @@ describe('Signing data', function () {
   })
 
   test('can create single signing blobs with modified type', function () {
-    const newDefs = new XrplDefinitions(definitions, coreTypes)
+    const newDefs = new XrplDefinitions(definitions)
     const actual = encodeForSigning(tx_json, newDefs)
     expect(actual).toBe(
       [
@@ -169,7 +168,7 @@ describe('Signing data', function () {
   })
 
   test('can create multi signing blobs with custom definitions', function () {
-    const newDefs = new XrplDefinitions(definitions, coreTypes)
+    const newDefs = new XrplDefinitions(definitions)
     const signingAccount = 'rJZdUusLDtY9NEsGea7ijqhVrXv98rYBYN'
     const signingJson = Object.assign({}, tx_json, { SigningPubKey: '' })
     const actual = encodeForMultisigning(signingJson, signingAccount, newDefs)
@@ -233,7 +232,7 @@ describe('Signing data', function () {
   })
 
   test('can create claim blob with unrelated type changes', function () {
-    const newDefs = new XrplDefinitions(definitions, coreTypes)
+    const newDefs = new XrplDefinitions(definitions)
 
     const channel =
       '43904CBFCDCEC530B4037871F86EE90BF799DF8D2E0EA564BC8A3F332E4F5FB1'

--- a/packages/xrpl/test/integration/integration.ts
+++ b/packages/xrpl/test/integration/integration.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
 
 import _ from 'lodash'
-import { XrplDefinitions, coreTypes } from 'ripple-binary-codec'
+import { XrplDefinitions } from 'ripple-binary-codec'
 import { Amount, Client, RippledError } from 'xrpl-local'
 import {
   AccountSet,
@@ -93,7 +93,7 @@ describe('integration tests', function () {
       Fee: '12',
     }
 
-    const newDefs = new XrplDefinitions(newPaymentDefinitions, coreTypes)
+    const newDefs = new XrplDefinitions(newPaymentDefinitions)
 
     // It should successfully submit, but fail once rippled sees it since the new type definition is not on-ledger.
     await assertRejects(
@@ -117,7 +117,7 @@ describe('integration tests', function () {
   })
 
   it('Defining a new TransactionType should compile and run', async function () {
-    const newDefs = new XrplDefinitions(newTxDefinitions, coreTypes)
+    const newDefs = new XrplDefinitions(newTxDefinitions)
 
     const client: Client = this.client
     const wallet1 = await generateFundedWallet(client)

--- a/packages/xrpl/test/wallet/signer.ts
+++ b/packages/xrpl/test/wallet/signer.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { decode, encode, XrplDefinitions, coreTypes } from 'ripple-binary-codec'
+import { decode, encode, XrplDefinitions } from 'ripple-binary-codec'
 import { Transaction, ValidationError } from 'xrpl-local'
 import Wallet from 'xrpl-local/Wallet'
 import {
@@ -212,7 +212,7 @@ describe('Signer', function () {
   })
 
   it('authorizeChannel succeeds with unrelated custom definitions', function () {
-    const newDefs = new XrplDefinitions(definitions, coreTypes)
+    const newDefs = new XrplDefinitions(definitions)
     const secpWallet = Wallet.fromSeed('snGHNrPbHrdUcszeuDEigMdC1Lyyd')
     const channelId =
       '5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3'
@@ -251,7 +251,7 @@ describe('Signer', function () {
   })
 
   it('should validly sign a transaction with custom defs', async function () {
-    const newDefs = new XrplDefinitions(definitions, coreTypes)
+    const newDefs = new XrplDefinitions(definitions)
     const signedTx = verifyWallet.sign(tx, false, newDefs)
 
     const decodedTx = decode(
@@ -267,7 +267,7 @@ describe('Signer', function () {
   })
 
   it('should be able to multisign a transaction with custom defs', async function () {
-    const newDefs = new XrplDefinitions(definitions, coreTypes)
+    const newDefs = new XrplDefinitions(definitions)
     const wallet1 = Wallet.fromSeed('sEdTqWgUWAqvrL3AZyJDhVVa4V6LX3E')
     const wallet2 = Wallet.fromSeed('sEdTco3Gx6dQzzdPovjGAMjU3v5SJ4S')
 


### PR DESCRIPTION
## High Level Overview of Change

Showing a way to allow the default parameter which passes tests, but includes a circular dependency. 
