### PR TITLE
Fix broken test in connection.ts for node 18 and add node 18 testing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main, 1.x ]
+    branches: [main, 1.x]
   pull_request:
   workflow_dispatch:
 
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -98,15 +98,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
 
     services:
       rippled:
         image: natenichols/rippled-standalone:latest
         ports:
-        - 6006:6006
-        options:
-          --health-cmd="wget localhost:6006 || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s
+          - 6006:6006
+        options: --health-cmd="wget localhost:6006 || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s
 
     steps:
       - uses: actions/checkout@v3
@@ -156,9 +155,8 @@ jobs:
       rippled:
         image: natenichols/rippled-standalone:latest
         ports:
-        - 6006:6006
-        options:
-          --health-cmd="wget localhost:6006 || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s
+          - 6006:6006
+        options: --health-cmd="wget localhost:6006 || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/xrpl/test/connection.test.ts
+++ b/packages/xrpl/test/connection.test.ts
@@ -136,7 +136,7 @@ describe('Connection', function () {
     createServer().then((server: net.Server) => {
       const port = (server.address() as net.AddressInfo).port
       const options = {
-        proxy: `ws://localhost:${port}`,
+        proxy: `ws://127.0.0.1:${port}`,
         authorization: 'authorization',
         trustedCertificates: ['path/to/pem'],
       }


### PR DESCRIPTION
## High Level Overview of Change

Connection.ts had a broken test `with proxy` when using node 18.

### Context of Change

The error: 
```
  1) Connection
       with proxy:
     Error: Timeout of 20000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/jacksonmills/Documents/xrpl-js-6/xrpl.js/packages/xrpl/test/connection.test.ts)
      at listOnTimeout (node:internal/timers:564:17)
      at processTimers (node:internal/timers:507:7)
```

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)


## Before / After

Changed `localhost` to `127.0.0.1` following this workaround: https://github.com/node-fetch/node-fetch/issues/1624

## Test Plan

Run tests locally & get a code reviewer to try the same with Node 18

<!--
## Future Tasks
For future tasks related to PR.
-->

Turn on Node 18 CI