### PR TITLE
Remove xls20-sandbox tests

### DIFF
--- a/packages/xrpl/src/Wallet/defaultFaucets.ts
+++ b/packages/xrpl/src/Wallet/defaultFaucets.ts
@@ -54,6 +54,7 @@ export function getFaucetHost(client: Client): FaucetNetwork | undefined {
     return FaucetNetwork.Devnet
   }
 
+  // TODO: Remove this once the sandbox is fully decomissioned.
   if (connectionUrl.includes('xls20-sandbox')) {
     return FaucetNetwork.NFTDevnet
   }

--- a/packages/xrpl/test/integration/fundWallet.test.ts
+++ b/packages/xrpl/test/integration/fundWallet.test.ts
@@ -26,16 +26,10 @@ describe('fundWallet', function () {
     )
   })
 
-  it('can generate and fund wallets on nft-devnet', async function () {
-    await generate_faucet_wallet_and_fund_again(
-      'ws://xls20-sandbox.rippletest.net:51233',
-    )
-  })
-
   it('can generate and fund wallets using a custom host and path', async function () {
     await generate_faucet_wallet_and_fund_again(
-      'ws://xls20-sandbox.rippletest.net:51233',
-      'faucet-nft.ripple.com',
+      'wss://s.devnet.rippletest.net:51233/',
+      'faucet.devnet.rippletest.net',
       '/accounts',
     )
   })

--- a/packages/xrpl/test/wallet/fundWallet.test.ts
+++ b/packages/xrpl/test/wallet/fundWallet.test.ts
@@ -33,13 +33,6 @@ describe('Get Faucet host ', function () {
     assert.strictEqual(getFaucetHost(this.client), expectedFaucet)
   })
 
-  it('returns the NFT-Devnet host with the XLS-20 Sandbox server', function () {
-    const expectedFaucet = FaucetNetwork.NFTDevnet
-    this.client.connection.url = 'ws://xls20-sandbox.rippletest.net:51233'
-
-    assert.strictEqual(getFaucetHost(this.client), expectedFaucet)
-  })
-
   it('returns the Hooks V2 Testnet host', function () {
     const expectedFaucet = FaucetNetwork.HooksV2Testnet
     this.client.connection.url = FaucetNetwork.HooksV2Testnet


### PR DESCRIPTION
## High Level Overview of Change

XLS20-sandbox (NFT Devnet) is no longer needed since mainnet has the amendment enabled.

### Context of Change

Tests are failing because it's not up.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->
* Add a TODO where it's still in the codebase
* Remove it entirely from tests.

<!--
## Future Tasks
For future tasks related to PR.
-->
Remove it from the codebase once it's fully decomissioned.