### PR TITLE
[WIP] Fature: add custom definitions.json import

### DIFF
--- a/packages/ripple-binary-codec/README.md
+++ b/packages/ripple-binary-codec/README.md
@@ -105,3 +105,20 @@ Use `--coverage` to generate and display code coverage information:
     npm test --coverage
 
 This tells jest to output code coverage info in the `./coverage` directory, in addition to showing it on the command line.
+
+## Custom definitions
+If you want to use this lib. on e.g. a side chain, where different (new) transaction
+types, fields, etc. are supported, you can load a
+[custom `definitions.json`](https://github.com/RichardAH/xrpl-codec-gen).
+
+Loading a custom `definitions.json` file with the `setDefinitions` method needs
+to happen **before** any of the other methods of this lib. are called.
+
+```js
+// First only import the definitions methods
+const { encode, decode, setDefinitions } = require('ripple-binary-codec')
+setDefinitions(require('./my-custom-definitions.json'))
+
+// Now enjoy your custom definitions:
+const encoded = encode({ TransactionType: 'SomeNewTxtype' })
+```

--- a/packages/ripple-binary-codec/README.md
+++ b/packages/ripple-binary-codec/README.md
@@ -116,9 +116,13 @@ to happen **before** any of the other methods of this lib. are called.
 
 ```js
 // First only import the definitions methods
-const { encode, decode, setDefinitions } = require('ripple-binary-codec')
+const { setDefinitions } = require('ripple-binary-codec/dist/enums/definitions')
 setDefinitions(require('./my-custom-definitions.json'))
+
+const { encode, decode } = require('ripple-binary-codec')
 
 // Now enjoy your custom definitions:
 const encoded = encode({ TransactionType: 'SomeNewTxtype' })
+
+console.log(encoded)
 ```

--- a/packages/ripple-binary-codec/src/enums/definitions.ts
+++ b/packages/ripple-binary-codec/src/enums/definitions.ts
@@ -1,0 +1,19 @@
+import * as definitions from './definitions.json'
+
+let enums = definitions
+
+/*
+ * @brief: Set custom definitions (for e.g. custom tranasction types)
+ */
+function setDefinitions(customDefinitions: typeof definitions): void {
+  enums = customDefinitions
+}
+
+/*
+ * @brief: Get latest definitions the lib is wokring with
+ */
+function getDefinitions(): typeof definitions {
+  return enums
+}
+
+export { getDefinitions, setDefinitions }

--- a/packages/ripple-binary-codec/src/enums/index.ts
+++ b/packages/ripple-binary-codec/src/enums/index.ts
@@ -1,7 +1,9 @@
-import * as enums from './definitions.json'
+import { getDefinitions } from './definitions'
 import { SerializedType } from '../types/serialized-type'
 import { Buffer } from 'buffer/'
 import { BytesList } from '../binary'
+
+const enums = getDefinitions()
 
 /*
  * @brief: All valid transaction types

--- a/packages/ripple-binary-codec/src/index.ts
+++ b/packages/ripple-binary-codec/src/index.ts
@@ -4,6 +4,7 @@ import { decodeLedgerData } from './ledger-hashes'
 import { ClaimObject } from './binary'
 import { JsonObject } from './types/serialized-type'
 import { TRANSACTION_TYPES } from './enums'
+import { getDefinitions, setDefinitions } from './enums/definitions'
 
 const {
   signingData,
@@ -111,5 +112,7 @@ export = {
   encodeQuality,
   decodeQuality,
   decodeLedgerData,
+  getDefinitions,
+  setDefinitions,
   TRANSACTION_TYPES,
 }

--- a/packages/ripple-binary-codec/test/dynamic-definitions.test.js
+++ b/packages/ripple-binary-codec/test/dynamic-definitions.test.js
@@ -1,0 +1,15 @@
+const stockDefinitions = require('../dist/enums/definitions.json')
+const alternativeDefinitions = Object.assign({}, stockDefinitions)
+alternativeDefinitions.TRANSACTION_TYPES.FakePayment = 200
+
+const { encode, decode, setDefinitions } = require('../dist')
+setDefinitions(alternativeDefinitions)
+
+describe('encoding and decoding with custom definitions', function () {
+  test('encode non-existing stock tx type with custom definitions', function () {
+    const tx_json = { TransactionType: 'FakePayment' }
+    const encoded = encode(tx_json)
+    const decoded = decode(encoded)
+    expect(tx_json).toEqual(decoded)
+  })
+})


### PR DESCRIPTION
If you want to use this lib. on e.g. a side chain, where different (new) transaction types, fields, etc. are supported, you can load a [custom definitions.json](https://github.com/RichardAH/xrpl-codec-gen).

Loading a custom definitions.json file with the setDefinitions method needs to happen before any of the other methods of this lib. are called.

```js
// First only import the definitions methods
const { setDefinitions } = require('ripple-binary-codec/dist/enums/definitions')
setDefinitions(require('./my-custom-definitions.json'))

const { encode, decode } = require('ripple-binary-codec')

// Now enjoy your custom definitions:
const encoded = encode({ TransactionType: 'SomeNewTxtype' })

console.log(encoded)
```

This implementation relies on the fact that imports (require, ...) are only loading & executing imported code once. An object for that import is created, and this object will now be referenced whenever data/methods are referred to by other routines. If overwriting a var in the method scope, all calls relying on the data in that scope will point to the new data.

So: by setting (overwriting) the definitions object before other methods are called, the moment other methods are called basing const output on the overwritten object, the const output will be generated with the new, imported data.

### Warning

This works when using `require`. In modern js 'import' this approach doesn't work. A better solution would be to natively allow for a custom definitions import, results in breaking changes.