### PR TITLE
refactor: alphabetize `ledger_entry` commands and reorganize `account_objects`

### DIFF
--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -1,16 +1,5 @@
 export type LedgerIndex = number | ('validated' | 'closed' | 'current')
 
-export type AccountObjectType =
-  | 'check'
-  | 'deposit_preauth'
-  | 'escrow'
-  | 'nft_offer'
-  | 'offer'
-  | 'payment_channel'
-  | 'signer_list'
-  | 'ticket'
-  | 'state'
-
 interface XRP {
   currency: 'XRP'
 }

--- a/packages/xrpl/src/models/methods/accountObjects.ts
+++ b/packages/xrpl/src/models/methods/accountObjects.ts
@@ -1,4 +1,4 @@
-import { AccountObjectType, LedgerIndex } from '../common'
+import { LedgerIndex } from '../common'
 import {
   Check,
   DepositPreauth,
@@ -11,6 +11,18 @@ import {
 } from '../ledger'
 
 import { BaseRequest, BaseResponse } from './baseMethod'
+
+type AccountObjectType =
+  | 'check'
+  | 'deposit_preauth'
+  | 'escrow'
+  | 'nft_offer'
+  | 'offer'
+  | 'payment_channel'
+  | 'signer_list'
+  | 'state'
+  | 'ticket'
+  | 'bridge'
 
 /**
  * The account_objects command returns the raw ledger format for all objects
@@ -65,8 +77,8 @@ type AccountObject =
   | Offer
   | PayChannel
   | SignerList
-  | Ticket
   | RippleState
+  | Ticket
 
 /**
  * Response expected from an {@link AccountObjectsRequest}.

--- a/packages/xrpl/src/models/methods/accountObjects.ts
+++ b/packages/xrpl/src/models/methods/accountObjects.ts
@@ -22,7 +22,6 @@ type AccountObjectType =
   | 'signer_list'
   | 'state'
   | 'ticket'
-  | 'bridge'
 
 /**
  * The account_objects command returns the raw ledger format for all objects

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -46,6 +46,23 @@ export interface LedgerEntryRequest extends BaseRequest {
    */
   account_root?: string
 
+  /** The object ID of a Check object to retrieve. */
+  check?: string
+
+  /**
+   * Specify a DepositPreauth object to retrieve. If a string, must be the
+   * object ID of the DepositPreauth object, as hexadecimal. If an object,
+   * requires owner and authorized sub-fields.
+   */
+  deposit_preauth?:
+    | {
+        /** The account that provided the preauthorization. */
+        owner: string
+        /** The account that received the preauthorization. */
+        authorized: string
+      }
+    | string
+
   /**
    * The DirectoryNode to retrieve. If a string, must be the object ID of the
    * directory, as hexadecimal. If an object, requires either `dir_root` o
@@ -63,6 +80,19 @@ export interface LedgerEntryRequest extends BaseRequest {
     | string
 
   /**
+   * The Escrow object to retrieve. If a string, must be the object ID of the
+   * escrow, as hexadecimal. If an object, requires owner and seq sub-fields.
+   */
+  escrow?:
+    | {
+        /** The owner (sender) of the Escrow object. */
+        owner: string
+        /** Sequence Number of the transaction that created the Escrow object. */
+        seq: number
+      }
+    | string
+
+  /**
    * The Offer object to retrieve. If a string, interpret as the unique object
    * ID to the Offer. If an object, requires the sub-fields `account` and `seq`
    * to uniquely identify the offer.
@@ -75,6 +105,9 @@ export interface LedgerEntryRequest extends BaseRequest {
         seq: number
       }
     | string
+
+  /** The object ID of a PayChannel object to retrieve. */
+  payment_channel?: string
 
   /**
    * Object specifying the RippleState (trust line) object to retrieve. The
@@ -90,39 +123,6 @@ export interface LedgerEntryRequest extends BaseRequest {
     /** Currency Code of the RippleState object to retrieve. */
     currency: string
   }
-
-  /** The object ID of a Check object to retrieve. */
-  check?: string
-
-  /**
-   * The Escrow object to retrieve. If a string, must be the object ID of the
-   * escrow, as hexadecimal. If an object, requires owner and seq sub-fields.
-   */
-  escrow?:
-    | {
-        /** The owner (sender) of the Escrow object. */
-        owner: string
-        /** Sequence Number of the transaction that created the Escrow object. */
-        seq: number
-      }
-    | string
-
-  /** The object ID of a PayChannel object to retrieve. */
-  payment_channel?: string
-
-  /**
-   * Specify a DepositPreauth object to retrieve. If a string, must be the
-   * object ID of the DepositPreauth object, as hexadecimal. If an object,
-   * requires owner and authorized sub-fields.
-   */
-  deposit_preauth?:
-    | {
-        /** The account that provided the preauthorization. */
-        owner: string
-        /** The account that received the preauthorization. */
-        authorized: string
-      }
-    | string
 
   /**
    * The Ticket object to retrieve. If a string, must be the object ID of the


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Alphabetizes the subcommands in `ledger_entry`
* Moves the subtype `AccountObjectsType` from `models/common` to `accountObjects.ts`, which is the only place it's used in the repo.

### Context of Change

Better code organization

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.