### PR TITLE
Update xrpl.js to use the definition.json changes in ripple-binary-codec

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -10,6 +10,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Improved typescript typing
 
 ### Added
+* Allow custom type definitions to be used for encoding/decoding transactions at runtime (e.g. for sidechains/new amendments)
 
 
 ### Changed


### PR DESCRIPTION
## High Level Overview of Change

Splitting up the [original PR here](https://github.com/XRPLF/xrpl.js/pull/2127) into two sections, this one focused on the xrpl.js interface for using the updated definitions.

### Context of Change

The changes to the codec are simpler, whereas the interface is still up for debate, so wanted to separate the concerns.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

## Before / After

Added the ability to specify the types desired for `encode` and `decode` when serializing transactions using high level functions like `submitAndWait` in xrpl.js

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->