### PR TITLE
Remove casting linting error from xrpl package

### DIFF
--- a/packages/xrpl/.eslintrc.js
+++ b/packages/xrpl/.eslintrc.js
@@ -62,6 +62,12 @@ module.exports = {
 
     'tsdoc/syntax': 'off',
     'jsdoc/require-description-complete-sentence': 'off',
+
+    // Type assertions are occassionally necessary when dealing with very complex types
+    '@typescript-eslint/consistent-type-assertions': [
+      'warn',
+      { assertionStyle: 'as' },
+    ],
   },
   overrides: [
     {

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -466,7 +466,6 @@ class Wallet {
       txCopy.URI = txCopy.URI.toUpperCase()
     }
 
-    /* eslint-disable @typescript-eslint/consistent-type-assertions -- We check at runtime that this is safe */
     Object.keys(txCopy).forEach((key) => {
       const standard_currency_code_len = 3
       if (txCopy[key] && isIssuedCurrency(txCopy[key])) {
@@ -496,7 +495,6 @@ class Wallet {
         }
       }
     })
-    /* eslint-enable @typescript-eslint/consistent-type-assertions -- Done with dynamic checking */
 
     if (!isEqual(decoded, txCopy)) {
       const data = {

--- a/packages/xrpl/src/Wallet/rfc1751.ts
+++ b/packages/xrpl/src/Wallet/rfc1751.ts
@@ -166,7 +166,6 @@ function getSubKey(
 }
 
 function bufferToArray(buf: Buffer): number[] {
-  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We know the end type */
   return Array.prototype.slice.call(buf) as number[]
 }
 

--- a/packages/xrpl/src/Wallet/signer.ts
+++ b/packages/xrpl/src/Wallet/signer.ts
@@ -38,7 +38,6 @@ function multisign(transactions: Array<Transaction | string>): string {
     /*
      * This will throw a more clear error for JS users if any of the supplied transactions has incorrect formatting
      */
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validate does not accept Transaction type
     validate(tx as unknown as Record<string, unknown>)
     if (tx.Signers == null || tx.Signers.length === 0) {
       throw new ValidationError(
@@ -163,11 +162,9 @@ function addressToBigNumber(address: string): BigNumber {
 function getDecodedTransaction(txOrBlob: Transaction | string): Transaction {
   if (typeof txOrBlob === 'object') {
     // We need this to handle X-addresses in multisigning
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We are casting here to get strong typing
     return decode(encode(txOrBlob)) as unknown as Transaction
   }
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We are casting here to get strong typing
   return decode(txOrBlob) as unknown as Transaction
 }
 

--- a/packages/xrpl/src/client/RequestManager.ts
+++ b/packages/xrpl/src/client/RequestManager.ts
@@ -115,11 +115,10 @@ export default class RequestManager {
      */
     // The following type assertions are required to get this code to pass in browser environments
     // where setTimeout has a different type
-    // eslint-disable-next-line max-len -- Necessary to disable both rules.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Reason above.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Reason above.
     if ((timer as unknown as any).unref) {
-      // eslint-disable-next-line max-len -- Necessary to disable both rules.
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- Reason above.
+      // eslint-disable-next-line max-len -- Necessary to disable all rules.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- Reason above.
       ;(timer as unknown as any).unref()
     }
     if (this.promisesAwaitingResponse.has(newId)) {
@@ -160,7 +159,6 @@ export default class RequestManager {
       this.reject(response.id, error)
     }
     if (response.status === 'error') {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We know this must be true
       const errorResponse = response as Partial<ErrorResponse>
       const error = new RippledError(
         errorResponse.error_message ?? errorResponse.error,
@@ -179,7 +177,6 @@ export default class RequestManager {
     }
     // status no longer needed because error is thrown if status is not "success"
     delete response.status
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Must be a valid Response here
     this.resolve(response.id, response as unknown as Response)
   }
 

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -411,7 +411,6 @@ export class Connection extends EventEmitter {
       return
     }
     if (data.type) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Should be true
       this.emit(data.type as string, data)
     }
     if (data.type === 'response') {

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -349,12 +349,10 @@ class Client extends EventEmitter {
   public async request<R extends Request, T extends Response>(
     req: R,
   ): Promise<T> {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Necessary for overloading
     const response = (await this.connection.request({
       ...req,
       account: req.account
-        ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Must be string
-          ensureClassicAddress(req.account as string)
+        ? ensureClassicAddress(req.account as string)
         : undefined,
     })) as T
 
@@ -408,7 +406,6 @@ class Client extends EventEmitter {
       )
     }
     const nextPageRequest = { ...req, marker: resp.result.marker }
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Necessary for overloading
     return this.request(nextPageRequest) as unknown as U
   }
 
@@ -540,7 +537,6 @@ class Client extends EventEmitter {
       }
       // eslint-disable-next-line no-await-in-loop -- Necessary for this, it really has to wait
       const singleResponse = await this.connection.request(repeatProps)
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Should be true
       const singleResult = (singleResponse as U).result
       if (!(collectKey in singleResult)) {
         throw new XrplError(`${collectKey} not in result`)
@@ -548,7 +544,6 @@ class Client extends EventEmitter {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Should be true
       const collectedData = singleResult[collectKey]
       marker = singleResult.marker
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Should be true
       results.push(singleResponse as U)
       // Make sure we handle when no data (not even an empty array) is returned.
       if (Array.isArray(collectedData)) {

--- a/packages/xrpl/src/client/partialPayment.ts
+++ b/packages/xrpl/src/client/partialPayment.ts
@@ -48,7 +48,6 @@ function isPartialPayment(
       return false
     }
 
-    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- binary-codec typing */
     meta = decode(meta) as unknown as TransactionMetadata
   }
 
@@ -86,7 +85,6 @@ function accountTxHasPartialPayment(response: AccountTxResponse): boolean {
 }
 
 function hasPartialPayment(command: string, response: Response): boolean {
-  /* eslint-disable @typescript-eslint/consistent-type-assertions -- Request type is known at runtime from command */
   switch (command) {
     case 'tx':
       return txHasPartialPayment(response as TxResponse)
@@ -97,7 +95,6 @@ function hasPartialPayment(command: string, response: Response): boolean {
     default:
       return false
   }
-  /* eslint-enable @typescript-eslint/consistent-type-assertions */
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/checkCreate.ts
+++ b/packages/xrpl/src/models/transactions/checkCreate.ts
@@ -63,7 +63,6 @@ export function validateCheckCreate(tx: Record<string, unknown>): void {
 
   if (
     typeof tx.SendMax !== 'string' &&
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
     !isIssuedCurrency(tx.SendMax as Record<string, unknown>)
   ) {
     throw new ValidationError('CheckCreate: invalid SendMax')

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -13,7 +13,6 @@ function isMemo(obj: { Memo?: unknown }): boolean {
   if (obj.Memo == null) {
     return false
   }
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
   const memo = obj.Memo as Record<string, unknown>
   const size = Object.keys(memo).length
   const validData = memo.MemoData == null || typeof memo.MemoData === 'string'
@@ -34,13 +33,11 @@ function isMemo(obj: { Memo?: unknown }): boolean {
 const SIGNER_SIZE = 3
 
 function isSigner(obj: unknown): boolean {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
   const signerWrapper = obj as Record<string, unknown>
 
   if (signerWrapper.Signer == null) {
     return false
   }
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS and Signer is previously unknown
   const signer = signerWrapper.Signer as Record<string, unknown>
   return (
     Object.keys(signer).length === SIGNER_SIZE &&
@@ -212,13 +209,11 @@ export function validateBaseTransaction(common: Record<string, unknown>): void {
     throw new ValidationError('BaseTransaction: invalid LastLedgerSequence')
   }
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
   const memos = common.Memos as Array<{ Memo?: unknown }> | undefined
   if (memos !== undefined && !memos.every(isMemo)) {
     throw new ValidationError('BaseTransaction: invalid Memos')
   }
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
   const signers = common.Signers as Array<Record<string, unknown>> | undefined
 
   if (

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -184,7 +184,6 @@ export function validatePayment(tx: Record<string, unknown>): void {
 
   if (
     tx.Paths !== undefined &&
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
     !isPaths(tx.Paths as Array<Array<Record<string, unknown>>>)
   ) {
     throw new ValidationError('PaymentTransaction: invalid Paths')
@@ -205,7 +204,6 @@ function checkPartialPayment(tx: Record<string, unknown>): void {
       )
     }
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
     const flags = tx.Flags as number | PaymentFlagsInterface
     const isTfPartialPayment =
       typeof flags === 'number'

--- a/packages/xrpl/src/models/transactions/signerListSet.ts
+++ b/packages/xrpl/src/models/transactions/signerListSet.ts
@@ -68,7 +68,6 @@ export function validateSignerListSet(tx: Record<string, unknown>): void {
   }
 
   for (const entry of tx.SignerEntries) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Should be a SignerEntry
     const signerEntry = entry as SignerEntry
     const { WalletLocator } = signerEntry.SignerEntry
     if (

--- a/packages/xrpl/src/models/transactions/transaction.ts
+++ b/packages/xrpl/src/models/transactions/transaction.ts
@@ -105,7 +105,6 @@ export function validate(transaction: Record<string, unknown>): void {
   if (typeof tx.TransactionType !== 'string') {
     throw new ValidationError("Object's `TransactionType` is not a string")
   }
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- okay here
   setTransactionFlagsToNumber(tx as unknown as Transaction)
   switch (tx.TransactionType) {
     case 'AccountDelete':

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -147,7 +147,7 @@ async function waitForFinalTransactionOutcome(
     })
     .catch(async (error) => {
       // error is of an unknown type and hence we assert type to extract the value we need.
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-member-access -- ^
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- ^
       const message = error?.data?.error as string
       if (message === 'txnNotFound') {
         return waitForFinalTransactionOutcome(
@@ -213,8 +213,7 @@ async function getSignedTx(
 
   let tx =
     typeof transaction === 'string'
-      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- converts JsonObject to correct Transaction type
-        (decode(transaction) as unknown as Transaction)
+      ? (decode(transaction) as unknown as Transaction)
       : transaction
 
   if (autofill) {
@@ -229,7 +228,6 @@ function getLastLedgerSequence(
   transaction: Transaction | string,
 ): number | null {
   const tx = typeof transaction === 'string' ? decode(transaction) : transaction
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- converts LastLedgSeq to number if present.
   return tx.LastLedgerSequence as number | null
 }
 

--- a/packages/xrpl/src/utils/getBalanceChanges.ts
+++ b/packages/xrpl/src/utils/getBalanceChanges.ts
@@ -40,7 +40,7 @@ interface NormalizedNode {
 
 function normalizeNode(affectedNode: Node): NormalizedNode {
   const diffType = Object.keys(affectedNode)[0]
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- not quite right, but close enough
+  // Not quite right, but close enough
   const node = affectedNode[diffType] as NormalizedNode
   return {
     ...node,
@@ -102,7 +102,6 @@ function getXRPQuantity(
   }
 
   return {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- okay here
     account: (node.FinalFields?.Account ?? node.NewFields?.Account) as string,
     balance: {
       currency: 'XRP',
@@ -114,7 +113,6 @@ function getXRPQuantity(
 function flipTrustlinePerspective(balanceChange: BalanceChange): BalanceChange {
   const negatedBalance = new BigNumber(balanceChange.balance.value).negated()
   return {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- we know this is true
     account: balanceChange.balance.issuer as string,
     balance: {
       issuer: balanceChange.account,
@@ -140,11 +138,9 @@ function getTrustlineQuantity(node: NormalizedNode): BalanceChange[] | null {
 
   // the balance is always from low node's perspective
   const result = {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- we know that this is true
     account: fields?.LowLimit?.issuer as string,
     balance: {
       issuer: fields?.HighLimit?.issuer,
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- we know that this is true
       currency: (fields?.Balance as IssuedCurrencyAmount).currency,
       value: value.toString(),
     },

--- a/packages/xrpl/src/utils/hashes/hashLedger.ts
+++ b/packages/xrpl/src/utils/hashes/hashLedger.ts
@@ -76,7 +76,6 @@ export function hashSignedTx(tx: Transaction | string): string {
   let txObject: Transaction
   if (typeof tx === 'string') {
     txBlob = tx
-    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Required until updated in binary codec. */
     txObject = decode(tx) as unknown as Transaction
   } else {
     txBlob = encode(tx)


### PR DESCRIPTION
## High Level Overview of Change

This linting error seemed extraneous more than it was useful.

### Context of Change

Part of #2205's discussion to make it more readable. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Refactor (non-breaking change that only restructures code)

## Before / After

* Removed the @typescript-eslint/consistent-type-assertions rule from the xrpl package since type casting is a normal operation there, especially when dealing with `unknown` types like `PreviousFields`. 
* Also one nit rewording from "both" -> "All" since it was talking about 3 rules instead of 2.

## Test Plan

Linter passes

<!--
## Future Tasks
For future tasks related to PR.
-->