### PR TITLE
Add support for disallowIncoming flags

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -26,6 +26,7 @@ Wallet.fromMmnemonic()
 
 ### Added
 * Optional custom amount field to `fundWallet`.
+* Support for `disallowIncoming` account set flags (e.g. `asfDisallowIncomingTrustline`)
 
 ### Changed
 * Add support for Transaction objects in `verifyTransaction`

--- a/packages/xrpl/src/models/ledger/AccountRoot.ts
+++ b/packages/xrpl/src/models/ledger/AccountRoot.ts
@@ -124,7 +124,6 @@ export interface AccountRootFlagsInterface {
    * Disallow incoming Checks from other accounts.
    */
   lsfDisallowIncomingCheck?: boolean
-
   /**
    * Disallow incoming PayChannels from other accounts.
    */

--- a/packages/xrpl/src/models/ledger/AccountRoot.ts
+++ b/packages/xrpl/src/models/ledger/AccountRoot.ts
@@ -116,6 +116,23 @@ export interface AccountRootFlagsInterface {
    * (It has DepositAuth enabled.)
    */
   lsfDepositAuth?: boolean
+  /**
+   * Disallow incoming NFTOffers from other accounts.
+   */
+  lsfDisallowIncomingNFTOffer?: boolean
+  /**
+   * Disallow incoming Checks from other accounts.
+   */
+  lsfDisallowIncomingCheck?: boolean
+
+  /**
+   * Disallow incoming PayChannels from other accounts.
+   */
+  lsfDisallowIncomingPayChan?: boolean
+  /**
+   * Disallow incoming Trustlines from other accounts.
+   */
+  lsfDisallowIncomingTrustline?: boolean
 }
 
 export enum AccountRootFlags {
@@ -156,4 +173,21 @@ export enum AccountRootFlags {
    * (It has DepositAuth enabled.)
    */
   lsfDepositAuth = 0x01000000,
+  /**
+   * Disallow incoming NFTOffers from other accounts.
+   */
+  lsfDisallowIncomingNFTOffer = 0x04000000,
+  /**
+   * Disallow incoming Checks from other accounts.
+   */
+  lsfDisallowIncomingCheck = 0x08000000,
+
+  /**
+   * Disallow incoming PayChannels from other accounts.
+   */
+  lsfDisallowIncomingPayChan = 0x10000000,
+  /**
+   * Disallow incoming Trustlines from other accounts.
+   */
+  lsfDisallowIncomingTrustline = 0x20000000,
 }

--- a/packages/xrpl/src/models/ledger/AccountRoot.ts
+++ b/packages/xrpl/src/models/ledger/AccountRoot.ts
@@ -180,7 +180,6 @@ export enum AccountRootFlags {
    * Disallow incoming Checks from other accounts.
    */
   lsfDisallowIncomingCheck = 0x08000000,
-
   /**
    * Disallow incoming PayChannels from other accounts.
    */

--- a/packages/xrpl/src/models/transactions/accountSet.ts
+++ b/packages/xrpl/src/models/transactions/accountSet.ts
@@ -44,6 +44,15 @@ export enum AccountSetAsfFlags {
    * Allow another account to mint and burn tokens on behalf of this account.
    */
   asfAuthorizedNFTokenMinter = 10,
+  /** asf 11 is reserved for Hooks amendment */
+  /** Disallow other accounts from creating incoming NFTOffers */
+  asfDisallowIncomingNFTOffer = 12,
+  /** Disallow other accounts from creating incoming Checks */
+  asfDisallowIncomingCheck = 13,
+  /** Disallow other accounts from creating incoming PayChannels */
+  asfDisallowIncomingPayChan = 14,
+  /** Disallow other accounts from creating incoming Trustlines */
+  asfDisallowIncomingTrustline = 15,
 }
 
 /**

--- a/packages/xrpl/test/models/accountSet.test.ts
+++ b/packages/xrpl/test/models/accountSet.test.ts
@@ -30,7 +30,7 @@ describe('AccountSet', function () {
   })
 
   it(`throws w/ invalid SetFlag (out of range)`, function () {
-    account.SetFlag = 12
+    account.SetFlag = 20
 
     assert.throws(
       () => validateAccountSet(account),
@@ -60,7 +60,7 @@ describe('AccountSet', function () {
   })
 
   it(`throws w/ invalid ClearFlag`, function () {
-    account.ClearFlag = 12
+    account.ClearFlag = 20
 
     assert.throws(
       () => validateAccountSet(account),

--- a/packages/xrpl/test/models/utils.test.ts
+++ b/packages/xrpl/test/models/utils.test.ts
@@ -151,6 +151,7 @@ describe('Models Utils', function () {
       assert.strictEqual(tx.Flags, 0)
     })
 
+    // eslint-disable-next-line complexity -- Simpler to list them all out at once.
     it('parseAccountRootFlags all enabled', function () {
       const accountRootFlags =
         AccountRootFlags.lsfDefaultRipple |
@@ -161,7 +162,11 @@ describe('Models Utils', function () {
         AccountRootFlags.lsfNoFreeze |
         AccountRootFlags.lsfPasswordSpent |
         AccountRootFlags.lsfRequireAuth |
-        AccountRootFlags.lsfRequireDestTag
+        AccountRootFlags.lsfRequireDestTag |
+        AccountRootFlags.lsfDisallowIncomingNFTOffer |
+        AccountRootFlags.lsfDisallowIncomingCheck |
+        AccountRootFlags.lsfDisallowIncomingPayChan |
+        AccountRootFlags.lsfDisallowIncomingTrustline
 
       const parsed = parseAccountRootFlags(accountRootFlags)
 
@@ -174,7 +179,11 @@ describe('Models Utils', function () {
           parsed.lsfNoFreeze &&
           parsed.lsfPasswordSpent &&
           parsed.lsfRequireAuth &&
-          parsed.lsfRequireDestTag,
+          parsed.lsfRequireDestTag &&
+          parsed.lsfDisallowIncomingNFTOffer &&
+          parsed.lsfDisallowIncomingCheck &&
+          parsed.lsfDisallowIncomingPayChan &&
+          parsed.lsfDisallowIncomingTrustline,
       )
     })
 
@@ -190,6 +199,10 @@ describe('Models Utils', function () {
       assert.isUndefined(parsed.lsfPasswordSpent)
       assert.isUndefined(parsed.lsfRequireAuth)
       assert.isUndefined(parsed.lsfRequireDestTag)
+      assert.isUndefined(parsed.lsfDisallowIncomingNFTOffer)
+      assert.isUndefined(parsed.lsfDisallowIncomingCheck)
+      assert.isUndefined(parsed.lsfDisallowIncomingPayChan)
+      assert.isUndefined(parsed.lsfDisallowIncomingTrustline)
     })
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Adding client library support for the `disallowIncoming` amendment being proposed soon: https://github.com/XRPLF/rippled/pull/4336

### Context of Change

Adds 4 more account flags for disallowing incoming objects on the ledger.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

## Before / After

* Adds `lsfDisallowIncomingNFTokenOffer

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->