### PR TITLE
fix: rename DisallowIncoming flag for NFTs

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -9,6 +9,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Fix timeout error in request manager
 * Improved typescript typing
 * Fixed empty value condition for NFTokenMinter field in AccountSet transaction
+* Renamed `lsfDisallowIncomingNFTOffer` and `asfDisallowIncomingNFTOffer` to `lsfDisallowIncomingNFTokenOffer` and `asfDisallowIncomingNFTokenOffer`
 
 ### Added
 - `getNFTokenID` lets you get the NFTokenID after minting an NFT

--- a/packages/xrpl/src/models/ledger/AccountRoot.ts
+++ b/packages/xrpl/src/models/ledger/AccountRoot.ts
@@ -119,7 +119,7 @@ export interface AccountRootFlagsInterface {
   /**
    * Disallow incoming NFTOffers from other accounts.
    */
-  lsfDisallowIncomingNFTOffer?: boolean
+  lsfDisallowIncomingNFTokenOffer?: boolean
   /**
    * Disallow incoming Checks from other accounts.
    */
@@ -175,7 +175,7 @@ export enum AccountRootFlags {
   /**
    * Disallow incoming NFTOffers from other accounts.
    */
-  lsfDisallowIncomingNFTOffer = 0x04000000,
+  lsfDisallowIncomingNFTokenOffer = 0x04000000,
   /**
    * Disallow incoming Checks from other accounts.
    */

--- a/packages/xrpl/src/models/transactions/accountSet.ts
+++ b/packages/xrpl/src/models/transactions/accountSet.ts
@@ -49,7 +49,7 @@ export enum AccountSetAsfFlags {
   asfAuthorizedNFTokenMinter = 10,
   /** asf 11 is reserved for Hooks amendment */
   /** Disallow other accounts from creating incoming NFTOffers */
-  asfDisallowIncomingNFTOffer = 12,
+  asfDisallowIncomingNFTokenOffer = 12,
   /** Disallow other accounts from creating incoming Checks */
   asfDisallowIncomingCheck = 13,
   /** Disallow other accounts from creating incoming PayChannels */

--- a/packages/xrpl/test/models/utils.test.ts
+++ b/packages/xrpl/test/models/utils.test.ts
@@ -163,7 +163,7 @@ describe('Models Utils', function () {
         AccountRootFlags.lsfPasswordSpent |
         AccountRootFlags.lsfRequireAuth |
         AccountRootFlags.lsfRequireDestTag |
-        AccountRootFlags.lsfDisallowIncomingNFTOffer |
+        AccountRootFlags.lsfDisallowIncomingNFTokenOffer |
         AccountRootFlags.lsfDisallowIncomingCheck |
         AccountRootFlags.lsfDisallowIncomingPayChan |
         AccountRootFlags.lsfDisallowIncomingTrustline
@@ -180,7 +180,7 @@ describe('Models Utils', function () {
           parsed.lsfPasswordSpent &&
           parsed.lsfRequireAuth &&
           parsed.lsfRequireDestTag &&
-          parsed.lsfDisallowIncomingNFTOffer &&
+          parsed.lsfDisallowIncomingNFTokenOffer &&
           parsed.lsfDisallowIncomingCheck &&
           parsed.lsfDisallowIncomingPayChan &&
           parsed.lsfDisallowIncomingTrustline,
@@ -199,7 +199,7 @@ describe('Models Utils', function () {
       assert.isUndefined(parsed.lsfPasswordSpent)
       assert.isUndefined(parsed.lsfRequireAuth)
       assert.isUndefined(parsed.lsfRequireDestTag)
-      assert.isUndefined(parsed.lsfDisallowIncomingNFTOffer)
+      assert.isUndefined(parsed.lsfDisallowIncomingNFTokenOffer)
       assert.isUndefined(parsed.lsfDisallowIncomingCheck)
       assert.isUndefined(parsed.lsfDisallowIncomingPayChan)
       assert.isUndefined(parsed.lsfDisallowIncomingTrustline)


### PR DESCRIPTION
## High Level Overview of Change

`lsfDisallowIncomingNFTOffer` to `lsfDisallowIncomingNFTokenOffer`
`asfDisallowIncomingNFTOffer` to `asfDisallowIncomingNFTokenOffer`

Related to XRPLF/rippled#4442

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)