### PR TITLE
fix: don't run ripple-binary-codec tests on install

### DIFF
--- a/packages/ripple-binary-codec/package.json
+++ b/packages/ripple-binary-codec/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "build": "tsc -b && copyfiles ./src/enums/definitions.json ./dist/enums/",
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
-    "prepare": "npm run build && npm test",
-    "test": "jest --verbose false --silent=false ./test/*.test.js",
+    "prepublishOnly": "npm test",
+    "test": "npm run build && jest --verbose false --silent=false ./test/*.test.js",
     "lint": "eslint . --ext .ts --ext .test.js"
   },
   "repository": {

--- a/packages/ripple-binary-codec/src/types/index.ts
+++ b/packages/ripple-binary-codec/src/types/index.ts
@@ -36,7 +36,7 @@ const coreTypes: Record<string, typeof SerializedType> = {
 
 // Ensures that the DEFAULT_DEFINITIONS object connects these types to fields for serializing/deserializing
 // This is done here instead of in enums/index.ts to avoid a circular dependency
-// because some of the above types depend on BinarySerailizer which depends on enums/index.ts.
+// because some of the above types depend on BinarySerializer which depends on enums/index.ts.
 DEFAULT_DEFINITIONS.associateTypes(coreTypes)
 
 export {


### PR DESCRIPTION
## High Level Overview of Change

This PR changes the `prepare` script in `ripple-binary-codec` to be `prepublishOnly`, so that it only runs before publish, not on every `npm install`. It also runs `npm build`.

### Context of Change

ripple-binary-codec tests were failing on a commit in a separate PR, and the fact that it couldn't even install the packages made it more difficult to figure out what was going wrong.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After


## Test Plan

Works as expected in CI.