### PR TITLE
fix: remove tx serialization check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,15 @@
 {
     "editor.tabSize": 2,
     "cSpell.words": [
-        "Multisigned",
-        "Setf",
         "hostid",
+        "keypair",
+        "keypairs",
+        "multisign",
+        "multisigned",
+        "multisigning",
         "preauthorization",
-        "secp256k1"
+        "secp256k1",
+        "Setf"
     ],
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -9,6 +9,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ### Fixed
 * Fixed `ServerState.transitions` typing, it is now a string instead of a number. (Only used in return from `server_state` request)
 * Added `destination_amount` to `PathOption` which is returned as part of a `path_find` request
+* Removed the `decode(encode(tx)) == tx` check from the wallet signing process
 
 ### Removed
 * RPCs and utils related to the old sidechain design

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable max-lines -- There are lots of equivalent constructors which make sense to have here. */
 import BigNumber from 'bignumber.js'
 import { fromSeed } from 'bip32'
 import { mnemonicToSeedSync, validateMnemonic } from 'bip39'
-import isEqual from 'lodash/isEqual'
 import omitBy from 'lodash/omitBy'
 import {
   classicAddressToXAddress,
@@ -25,11 +23,8 @@ import {
 } from 'ripple-keypairs'
 
 import ECDSA from '../ECDSA'
-import { ValidationError, XrplError } from '../errors'
-import { IssuedCurrencyAmount } from '../models/common'
+import { ValidationError } from '../errors'
 import { Transaction, validate } from '../models/transactions'
-import { isIssuedCurrency } from '../models/transactions/common'
-import { isHex } from '../models/utils'
 import { ensureClassicAddress } from '../sugar/utils'
 import { hashSignedTx } from '../utils/hashes/hashLedger'
 
@@ -367,6 +362,7 @@ class Wallet {
       )
     }
 
+    const serialized = encode(txToSignAndEncode)
     return {
       tx_blob: serialized,
       hash: hashSignedTx(serialized),
@@ -399,6 +395,7 @@ class Wallet {
   public getXAddress(tag: number | false = false, isTestnet = false): string {
     return classicAddressToXAddress(this.classicAddress, tag, isTestnet)
   }
+}
 
 /**
  * Signs a transaction with the proper signing encoding.
@@ -445,21 +442,5 @@ function removeTrailingZeros(tx: Transaction): void {
     tx.Amount.value = new BigNumber(tx.Amount.value).toString()
   }
 }
-
-/**
- * Convert an ISO code to a hex string representation
- *
- * @param iso - A 3 letter standard currency code
- */
-/* eslint-disable @typescript-eslint/no-magic-numbers -- Magic numbers are from rippleds of currency code encoding */
-function isoToHex(iso: string): string {
-  const bytes = Buffer.alloc(20)
-  if (iso !== 'XRP') {
-    const isoBytes = iso.split('').map((chr) => chr.charCodeAt(0))
-    bytes.set(isoBytes, 12)
-  }
-  return bytes.toString('hex').toUpperCase()
-}
-/* eslint-enable @typescript-eslint/no-magic-numbers -- Only needed in this function */
 
 export default Wallet

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -28,7 +28,6 @@ import { ValidationError, XrplError } from '../errors'
 import { IssuedCurrencyAmount } from '../models/common'
 import { Transaction, validate } from '../models/transactions'
 import { isIssuedCurrency } from '../models/transactions/common'
-import { isHex } from '../models/utils'
 import { ensureClassicAddress } from '../sugar/utils'
 import { hashSignedTx } from '../utils/hashes/hashLedger'
 
@@ -367,7 +366,7 @@ class Wallet {
     }
 
     const serialized = encode(txToSignAndEncode)
-    this.checkTxSerialization(tx)
+    this.validateTx(tx)
     return {
       tx_blob: serialized,
       hash: hashSignedTx(serialized),
@@ -410,31 +409,7 @@ class Wallet {
    * @throws XrplError if the transaction includes an issued currency which is equivalent to XRP ignoring case.
    */
   // eslint-disable-next-line class-methods-use-this -- Helper for organization purposes
-  private checkTxSerialization(tx: Transaction): void {
-    /*
-     * - Memos have exclusively hex data which should ignore case.
-     *   Since decode goes to upper case, we set all tx memos to be uppercase for the comparison.
-     */
-    tx.Memos?.forEach((memo) => {
-      if (memo.Memo.MemoData) {
-        if (!isHex(memo.Memo.MemoData)) {
-          throw new ValidationError('MemoData field must be a hex value')
-        }
-      }
-
-      if (memo.Memo.MemoType) {
-        if (!isHex(memo.Memo.MemoType)) {
-          throw new ValidationError('MemoType field must be a hex value')
-        }
-      }
-
-      if (memo.Memo.MemoFormat) {
-        if (!isHex(memo.Memo.MemoFormat)) {
-          throw new ValidationError('MemoFormat field must be a hex value')
-        }
-      }
-    })
-
+  private validateTx(tx: Transaction): void {
     /* eslint-disable @typescript-eslint/consistent-type-assertions -- We check at runtime that this is safe */
     Object.keys(tx).forEach((key) => {
       const standard_currency_code_len = 3

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -367,8 +367,6 @@ class Wallet {
       )
     }
 
-    const serialized = encode(txToSignAndEncode)
-    this.checkTxSerialization(serialized, tx)
     return {
       tx_blob: serialized,
       hash: hashSignedTx(serialized),
@@ -401,125 +399,6 @@ class Wallet {
   public getXAddress(tag: number | false = false, isTestnet = false): string {
     return classicAddressToXAddress(this.classicAddress, tag, isTestnet)
   }
-
-  /**
-   *  Decode a serialized transaction, remove the fields that are added during the signing process,
-   *  and verify that it matches the transaction prior to signing. This gives the user a sanity check
-   *  to ensure that what they try to encode matches the message that will be recieved by rippled.
-   *
-   * @param serialized - A signed and serialized transaction.
-   * @param tx - The transaction prior to signing.
-   * @throws A ValidationError if the transaction does not have a TxnSignature/Signers property, or if
-   * the serialized Transaction desn't match the original transaction.
-   * @throws XrplError if the transaction includes an issued currency which is equivalent to XRP ignoring case.
-   */
-  // eslint-disable-next-line class-methods-use-this, max-lines-per-function -- Helper for organization purposes
-  private checkTxSerialization(serialized: string, tx: Transaction): void {
-    // Decode the serialized transaction:
-    const decoded = decode(serialized)
-    const txCopy = { ...tx }
-
-    /*
-     * And ensure it is equal to the original tx, except:
-     * - It must have a TxnSignature or Signers (multisign).
-     */
-    if (!decoded.TxnSignature && !decoded.Signers) {
-      throw new ValidationError(
-        'Serialized transaction must have a TxnSignature or Signers property',
-      )
-    }
-    // - We know that the original tx did not have TxnSignature, so we should delete it:
-    delete decoded.TxnSignature
-    // - We know that the original tx did not have Signers, so if it exists, we should delete it:
-    delete decoded.Signers
-
-    /*
-     * - If SigningPubKey was not in the original tx, then we should delete it.
-     *   But if it was in the original tx, then we should ensure that it has not been changed.
-     */
-    if (!tx.SigningPubKey) {
-      delete decoded.SigningPubKey
-    }
-
-    /*
-     * - Memos have exclusively hex data which should ignore case.
-     *   Since decode goes to upper case, we set all tx memos to be uppercase for the comparison.
-     */
-    txCopy.Memos?.map((memo) => {
-      const memoCopy = { ...memo }
-      if (memo.Memo.MemoData) {
-        if (!isHex(memo.Memo.MemoData)) {
-          throw new ValidationError('MemoData field must be a hex value')
-        }
-        memoCopy.Memo.MemoData = memo.Memo.MemoData.toUpperCase()
-      }
-
-      if (memo.Memo.MemoType) {
-        if (!isHex(memo.Memo.MemoType)) {
-          throw new ValidationError('MemoType field must be a hex value')
-        }
-        memoCopy.Memo.MemoType = memo.Memo.MemoType.toUpperCase()
-      }
-
-      if (memo.Memo.MemoFormat) {
-        if (!isHex(memo.Memo.MemoFormat)) {
-          throw new ValidationError('MemoFormat field must be a hex value')
-        }
-        memoCopy.Memo.MemoFormat = memo.Memo.MemoFormat.toUpperCase()
-      }
-
-      return memo
-    })
-
-    if (txCopy.TransactionType === 'NFTokenMint' && txCopy.URI) {
-      txCopy.URI = txCopy.URI.toUpperCase()
-    }
-
-    /* eslint-disable @typescript-eslint/consistent-type-assertions -- We check at runtime that this is safe */
-    Object.keys(txCopy).forEach((key) => {
-      const standard_currency_code_len = 3
-      if (txCopy[key] && isIssuedCurrency(txCopy[key])) {
-        const decodedAmount = decoded[key] as unknown as IssuedCurrencyAmount
-        const decodedCurrency = decodedAmount.currency
-        const txCurrency = (txCopy[key] as IssuedCurrencyAmount).currency
-
-        if (
-          txCurrency.length === standard_currency_code_len &&
-          txCurrency.toUpperCase() === 'XRP'
-        ) {
-          throw new XrplError(
-            `Trying to sign an issued currency with a similar standard code to XRP (received '${txCurrency}'). XRP is not an issued currency.`,
-          )
-        }
-
-        // Standardize the format of currency codes to the 40 byte hex string for comparison
-        const amount = txCopy[key] as IssuedCurrencyAmount
-        if (amount.currency.length !== decodedCurrency.length) {
-          /* eslint-disable-next-line max-depth -- Easier to read with two if-statements */
-          if (decodedCurrency.length === standard_currency_code_len) {
-            decodedAmount.currency = isoToHex(decodedCurrency)
-          } else {
-            /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- We need to update txCopy directly */
-            txCopy[key].currency = isoToHex(txCopy[key].currency)
-          }
-        }
-      }
-    })
-    /* eslint-enable @typescript-eslint/consistent-type-assertions -- Done with dynamic checking */
-
-    if (!isEqual(decoded, txCopy)) {
-      const data = {
-        decoded,
-        tx,
-      }
-      const error = new ValidationError(
-        'Serialized transaction does not match original txJSON. See error.data',
-        data,
-      )
-      throw error
-    }
-  }
-}
 
 /**
  * Signs a transaction with the proper signing encoding.

--- a/packages/xrpl/src/models/transactions/transaction.ts
+++ b/packages/xrpl/src/models/transactions/transaction.ts
@@ -2,7 +2,7 @@
 /* eslint-disable max-lines-per-function -- need to work with a lot of Tx verifications */
 
 import { ValidationError } from '../../errors'
-import { Memo } from '../common'
+import { IssuedCurrencyAmount, Memo } from '../common'
 import { isHex } from '../utils'
 import { setTransactionFlagsToNumber } from '../utils/flags'
 
@@ -11,6 +11,7 @@ import { AccountSet, validateAccountSet } from './accountSet'
 import { CheckCancel, validateCheckCancel } from './checkCancel'
 import { CheckCash, validateCheckCash } from './checkCash'
 import { CheckCreate, validateCheckCreate } from './checkCreate'
+import { isIssuedCurrency } from './common'
 import { DepositPreauth, validateDepositPreauth } from './depositPreauth'
 import { EscrowCancel, validateEscrowCancel } from './escrowCancel'
 import { EscrowCreate, validateEscrowCreate } from './escrowCreate'
@@ -110,26 +111,45 @@ export function validate(transaction: Record<string, unknown>): void {
   if (tx.Memos != null && typeof tx.Memos !== 'object') {
     throw new ValidationError('Memo must be array')
   }
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- needed here
-  ;(tx.Memos as Array<Memo | null>).forEach((memo) => {
-    if (memo?.Memo == null) {
-      throw new ValidationError('Memo data must be in a `Memo` field')
-    }
-    if (memo.Memo.MemoData) {
-      if (!isHex(memo.Memo.MemoData)) {
-        throw new ValidationError('MemoData field must be a hex value')
+  if (tx.Memos != null) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- needed here
+    ;(tx.Memos as Array<Memo | null>).forEach((memo) => {
+      if (memo?.Memo == null) {
+        throw new ValidationError('Memo data must be in a `Memo` field')
       }
-    }
-
-    if (memo.Memo.MemoType) {
-      if (!isHex(memo.Memo.MemoType)) {
-        throw new ValidationError('MemoType field must be a hex value')
+      if (memo.Memo.MemoData) {
+        if (!isHex(memo.Memo.MemoData)) {
+          throw new ValidationError('MemoData field must be a hex value')
+        }
       }
-    }
 
-    if (memo.Memo.MemoFormat) {
-      if (!isHex(memo.Memo.MemoFormat)) {
-        throw new ValidationError('MemoFormat field must be a hex value')
+      if (memo.Memo.MemoType) {
+        if (!isHex(memo.Memo.MemoType)) {
+          throw new ValidationError('MemoType field must be a hex value')
+        }
+      }
+
+      if (memo.Memo.MemoFormat) {
+        if (!isHex(memo.Memo.MemoFormat)) {
+          throw new ValidationError('MemoFormat field must be a hex value')
+        }
+      }
+    })
+  }
+
+  Object.keys(tx).forEach((key) => {
+    const standard_currency_code_len = 3
+    if (tx[key] && isIssuedCurrency(tx[key])) {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- needed
+      const txCurrency = (tx[key] as IssuedCurrencyAmount).currency
+
+      if (
+        txCurrency.length === standard_currency_code_len &&
+        txCurrency.toUpperCase() === 'XRP'
+      ) {
+        throw new ValidationError(
+          `Cannot have an issued currency with a similar standard code to XRP (received '${txCurrency}'). XRP is not an issued currency.`,
+        )
       }
     }
   })

--- a/packages/xrpl/test/models/trustSet.test.ts
+++ b/packages/xrpl/test/models/trustSet.test.ts
@@ -16,7 +16,7 @@ describe('TrustSet', function () {
       TransactionType: 'TrustSet',
       Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
       LimitAmount: {
-        currency: 'XRP',
+        currency: 'USD',
         issuer: 'rcXY84C4g14iFp6taFXjjQGVeHqSCh9RX',
         value: '4329.23',
       },

--- a/packages/xrpl/test/wallet/index.test.ts
+++ b/packages/xrpl/test/wallet/index.test.ts
@@ -763,7 +763,7 @@ describe('Wallet', function () {
       }
       assert.throws(() => {
         wallet.sign(payment)
-      }, /^Trying to sign an issued currency with a similar standard code to XRP \(received 'xrp'\)\. XRP is not an issued currency\./u)
+      }, /^Cannot have an issued currency with a similar standard code to XRP \(received 'xrp'\)\. XRP is not an issued currency\./u)
     })
 
     it('sign does NOT throw when a payment contains an issued currency like xrp in hex string format', async function () {


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the `decode(encode(tx)) == tx` check in the wallet signing process and moves the other validation checks that happened as a part of signing to `validate`.

### Context of Change

It requires a bunch of edge case checks and it's easy to get tripped up with an error, but it doesn't actually find bugs.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Minorly fixed tests due to moving stuff around (one test was flat out bad).