### PR TITLE
fix: fix the location of `signer_lists` in the `account_info` response

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -10,6 +10,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Fixed `ServerState.transitions` typing, it is now a string instead of a number. (Only used in return from `server_state` request)
 * Added `destination_amount` to `PathOption` which is returned as part of a `path_find` request
 * Removed the `decode(encode(tx)) == tx` check from the wallet signing process
+* Fixed the location of `signer_lists` in the `account_info` response so that it matches rippled
 
 ### Removed
 * RPCs and utils related to the old sidechain design

--- a/packages/xrpl/src/models/methods/accountInfo.ts
+++ b/packages/xrpl/src/models/methods/accountInfo.ts
@@ -91,14 +91,12 @@ export interface AccountInfoResponse extends BaseResponse {
     /**
      * The AccountRoot ledger object with this account's information, as stored
      * in the ledger.
+     * If requested, also includes Array of SignerList ledger objects
+     * associated with this account for Multi-Signing. Since an account can own
+     * at most one SignerList, this array must have exactly one member if it is
+     * present.
      */
-    account_data: AccountRoot
-    /**
-     * Array of SignerList ledger objects associated with this account for
-     * Multi-Signing. Since an account can own at most one SignerList, this
-     * array must have exactly one member if it is present.
-     */
-    signer_lists?: SignerList[]
+    account_data: AccountRoot & { signer_lists?: SignerList[] }
     /**
      * The ledger index of the current in-progress ledger, which was used when
      * retrieving this information.


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

The `account_info` response type had `signer_lists` under `result`, but it's actually under `account_data`.

I ran into this issue when writing some integration tests.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Matches actual rippled responses, and works with an `account_info` request that asks for the signer list.