### PR TITLE
feat: add support for node v20

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -150,7 +150,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x] # This just needs to be compatible w/ puppeteer
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -150,7 +150,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 ### Requirements
 
-We use Node v14 for development - that is the version that our linters require.
+We use Node v16 for development - that is the version that our linters require.
 You must also use `npm` v7. You can check your `npm` version with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All of which works in Node.js (tested for v14+) & web browsers (tested for Chrom
 
 ### Requirements
 
-+ **[Node.js v14](https://nodejs.org/)** is recommended. We also support v16 and v18. Other versions may work but are not frequently tested.
++ **[Node.js v16](https://nodejs.org/)** is recommended. We also support v14, v18 and v20. Other versions may work but are not frequently tested.
 
 ### Installing xrpl.js
 


### PR DESCRIPTION
## High Level Overview of Change

Title says it all. I also updated our linter and browser tests to use v16 instead of now-deprecated v14.

### Context of Change

node v20 was just released

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes with node 20.