### PR TITLE
fix README for integ tests

### DIFF
--- a/packages/xrpl/test/integration/README.md
+++ b/packages/xrpl/test/integration/README.md
@@ -4,4 +4,4 @@ To run integration tests:
   * With docker, run `docker run -p 6006:6006 --interactive -t --volume $PWD/.ci-config:/config/ xrpllabsofficial/xrpld:latest -a --start`
   * Or [download and build rippled](https://xrpl.org/install-rippled.html) and run `./rippled -a --start`
     * If you'd like to use the latest rippled amendments, you should modify your `rippled.cfg` file to enable amendments in the `[amendments]` section. You can view `.ci-config/rippled.cfg` in the top level folder as an example of this.
-2. Run `npm test:integration` or `npm test:browser`
+2. Run `npm run test:integration` or `npm run test:browser`


### PR DESCRIPTION
## High Level Overview of Change

Inside integ tests README, add missing `run` in npm commands for running integ tests

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

## Test Plan

Integ tests now run when copy/pasting npm commands from integ tests README