### PR TITLE
Improve instructions for updating integration test docker container config

### DIFF
--- a/.ci-config/rippled.cfg
+++ b/.ci-config/rippled.cfg
@@ -92,7 +92,13 @@ validators.txt
 
 
 # In order to enable an amendment which by default would vote "No", you must include its amendment id and name here.
-# To get the list of amendments on a network:
+# To add amendments specifically from the latest releases of rippled:
+# 1. Go to https://xrpl.org/known-amendments.html
+# 2. Find the first amendment in the latest releases of rippled which are not already in the list below
+# 3. Click on each amendment to get their Amendment ID and name to add to this list manually.
+#    You will likely update the list with all amendments from a new release of rippled all at once.
+
+# To get the list of amendments on a network (e.g. devnet):
 # 1. Run this ledger_entry command against the network to get a list of enabled amendment ids. (Command is in the websocket link as an easy way to run it)
 #    https://xrpl.org/websocket-api-tool.html?server=wss%3A%2F%2Fs1.ripple.com%2F&req=%7B%22command%22%3A%22ledger_entry%22%2C%22index%22%3A%227DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4%22%2C%22ledger_index%22%3A%22validated%22%7D
 # 2. Strip away the quotes and commas
@@ -101,6 +107,7 @@ validators.txt
 #   The amendment name can be any string (including just a number)
 #
 # Note: The version of rippled you use this config with must have an implementation for the amendments you attempt to enable or it will crash.
+# If you need the version of rippled to be more up to date, you may need to make a comment on this repo: https://github.com/WietseWind/docker-rippled
 
 [amendments]
 # Devnet amendments as of March 28th, 2023


### PR DESCRIPTION
## High Level Overview of Change

Added instructions for adding amendments which aren't enabled on devnet yet for integration testing. 

### Context of Change

Sometimes amendments take a while to be added to devnet, but we still want to test them.

### Type of Change

- [X] Documentation Updates

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
