### PR TITLE
Retry releasing ripple-keypairs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16827,7 +16827,7 @@
       }
     },
     "packages/ripple-keypairs": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "bn.js": "^5.1.1",
@@ -16841,7 +16841,7 @@
       }
     },
     "packages/xrpl": {
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "ISC",
       "dependencies": {
         "bignumber.js": "^9.0.0",
@@ -16851,7 +16851,7 @@
         "lodash": "^4.17.4",
         "ripple-address-codec": "^4.3.0",
         "ripple-binary-codec": "^1.6.0",
-        "ripple-keypairs": "^1.1.5",
+        "ripple-keypairs": "^1.3.0",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -29993,7 +29993,7 @@
         "react": "^18.2.0",
         "ripple-address-codec": "^4.3.0",
         "ripple-binary-codec": "^1.6.0",
-        "ripple-keypairs": "^1.1.5",
+        "ripple-keypairs": "^1.3.0",
         "typedoc": "^0.24.6",
         "ws": "^8.2.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16851,7 +16851,7 @@
         "lodash": "^4.17.4",
         "ripple-address-codec": "^4.3.0",
         "ripple-binary-codec": "^1.6.0",
-        "ripple-keypairs": "^1.2.0",
+        "ripple-keypairs": "^1.1.5",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -29993,7 +29993,7 @@
         "react": "^18.2.0",
         "ripple-address-codec": "^4.3.0",
         "ripple-binary-codec": "^1.6.0",
-        "ripple-keypairs": "^1.2.0",
+        "ripple-keypairs": "^1.1.5",
         "typedoc": "^0.24.6",
         "ws": "^8.2.2"
       }

--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+## 1.3.0 (2023-06-13)
 ### Added
 * Adds support for npm v9
 

--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-## 1.2.0 (2023-06-13)
 ### Added
 * Adds support for npm v9
 

--- a/packages/ripple-keypairs/package.json
+++ b/packages/ripple-keypairs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-keypairs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Cryptographic key pairs for the XRP Ledger",
   "scripts": {
     "build": "tsc -b",

--- a/packages/xrpl/package-lock.json
+++ b/packages/xrpl/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [
@@ -29,7 +29,7 @@
     "lodash": "^4.17.4",
     "ripple-address-codec": "^4.3.0",
     "ripple-binary-codec": "^1.6.0",
-    "ripple-keypairs": "^1.1.5",
+    "ripple-keypairs": "^1.3.0",
     "ws": "^8.2.2"
   },
   "devDependencies": {

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.4",
     "ripple-address-codec": "^4.3.0",
     "ripple-binary-codec": "^1.6.0",
-    "ripple-keypairs": "^1.2.0",
+    "ripple-keypairs": "^1.1.5",
     "ws": "^8.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## High Level Overview of Change

Lerna didn't release an update to ripple-keypairs because the last beta release used the name 1.2.0, which caused a collision with our updated version. So, we're updating the release of ripple-keypairs to be 1.3.0 to avoid that.

### Context of Change

Above says it all.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Release

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
