### PR TITLE
feat: cleanup types and add missing request fields

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,6 +3,11 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 ## Unreleased
 
+## Added
+* Add `ledger_hash` and `ledger_index` to `account_nfts`,
+  `nft_buy_offers`, and `nft_sell_offers` requests.
+* Add `nft_page` to `ledger_entry` request.
+
 ## 2.8.0 (2023-06-13)
 
 ### Added

--- a/packages/xrpl/src/models/methods/accountChannels.ts
+++ b/packages/xrpl/src/models/methods/accountChannels.ts
@@ -1,6 +1,4 @@
-import { LedgerIndex } from '../common'
-
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 interface Channel {
   account: string
@@ -26,7 +24,9 @@ interface Channel {
  *
  * @category Requests
  */
-export interface AccountChannelsRequest extends BaseRequest {
+export interface AccountChannelsRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'account_channels'
   /**
    * The unique identifier of an account, typically the account's address. The
@@ -40,13 +40,6 @@ export interface AccountChannelsRequest extends BaseRequest {
    * account.
    */
   destination_account?: string
-  /** 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * Limit the number of transactions to retrieve. Cannot be less than 10 or
    * more than 400. The default is 200.

--- a/packages/xrpl/src/models/methods/accountCurrencies.ts
+++ b/packages/xrpl/src/models/methods/accountCurrencies.ts
@@ -1,6 +1,4 @@
-import { LedgerIndex } from '../common'
-
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `account_currencies` command retrieves a list of currencies that an
@@ -9,17 +7,12 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface AccountCurrenciesRequest extends BaseRequest {
+export interface AccountCurrenciesRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'account_currencies'
   /** A unique identifier for the account, most commonly the account's address. */
   account: string
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * If true, then the account field only accepts a public key or XRP Ledger
    * address. Otherwise, account can be a secret or passphrase (not

--- a/packages/xrpl/src/models/methods/accountInfo.ts
+++ b/packages/xrpl/src/models/methods/accountInfo.ts
@@ -1,7 +1,6 @@
-import { LedgerIndex } from '../common'
 import { AccountRoot, SignerList } from '../ledger'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `account_info` command retrieves information about an account, its
@@ -10,17 +9,10 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface AccountInfoRequest extends BaseRequest {
+export interface AccountInfoRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'account_info'
   /** A unique identifier for the account, most commonly the account's address. */
   account: string
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * Whether to get info about this account's queued transactions. Can only be
    * used when querying for the data from the current open ledger. Not available

--- a/packages/xrpl/src/models/methods/accountLines.ts
+++ b/packages/xrpl/src/models/methods/accountLines.ts
@@ -1,6 +1,4 @@
-import { LedgerIndex } from '../common'
-
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 export interface Trustline {
   /** The unique Address of the counterparty to this trust line. */
@@ -74,17 +72,12 @@ export interface Trustline {
  *
  * @category Requests
  */
-export interface AccountLinesRequest extends BaseRequest {
+export interface AccountLinesRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'account_lines'
   /** A unique identifier for the account, most commonly the account's Address. */
   account: string
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * The Address of a second account. If provided, show only lines of trust
    * connecting the two accounts.

--- a/packages/xrpl/src/models/methods/accountNFTs.ts
+++ b/packages/xrpl/src/models/methods/accountNFTs.ts
@@ -1,4 +1,4 @@
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `account_nfts` method retrieves all of the NFTs currently owned by the
@@ -6,7 +6,7 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface AccountNFTsRequest extends BaseRequest {
+export interface AccountNFTsRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'account_nfts'
   /**
    * The unique identifier of an account, typically the account's address. The

--- a/packages/xrpl/src/models/methods/accountObjects.ts
+++ b/packages/xrpl/src/models/methods/accountObjects.ts
@@ -1,4 +1,3 @@
-import { LedgerIndex } from '../common'
 import {
   Check,
   DepositPreauth,
@@ -10,7 +9,7 @@ import {
   Ticket,
 } from '../ledger'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 type AccountObjectType =
   | 'check'
@@ -31,7 +30,9 @@ type AccountObjectType =
  *
  * @category Requests
  */
-export interface AccountObjectsRequest extends BaseRequest {
+export interface AccountObjectsRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'account_objects'
   /** A unique identifier for the account, most commonly the account's address. */
   account: string
@@ -46,13 +47,6 @@ export interface AccountObjectsRequest extends BaseRequest {
    * from being deleted. The default is false.
    */
   deletion_blockers_only?: boolean
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * Ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * The maximum number of objects to include in the results. Must be within
    * the inclusive range 10 to 400 on non-admin connections. The default is 200.

--- a/packages/xrpl/src/models/methods/accountOffers.ts
+++ b/packages/xrpl/src/models/methods/accountOffers.ts
@@ -1,6 +1,6 @@
-import { Amount, LedgerIndex } from '../common'
+import { Amount } from '../common'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The account_offers method retrieves a list of offers made by a given account
@@ -9,17 +9,12 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface AccountOffersRequest extends BaseRequest {
+export interface AccountOffersRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'account_offers'
   /** A unique identifier for the account, most commonly the account's Address. */
   account: string
-  /** A 20-byte hex string identifying the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or "current", "closed", or
-   * "validated" to select a ledger dynamically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * Limit the number of transactions to retrieve. The server is not required
    * to honor this value. Must be within the inclusive range 10 to 400.

--- a/packages/xrpl/src/models/methods/accountTx.ts
+++ b/packages/xrpl/src/models/methods/accountTx.ts
@@ -1,7 +1,7 @@
-import { LedgerIndex, ResponseOnlyTxInfo } from '../common'
+import { ResponseOnlyTxInfo } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The account_tx method retrieves a list of transactions that involved the
@@ -10,7 +10,7 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface AccountTxRequest extends BaseRequest {
+export interface AccountTxRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'account_tx'
   /** A unique identifier for the account, most commonly the account's address. */
   account: string
@@ -26,10 +26,6 @@ export interface AccountTxRequest extends BaseRequest {
    * version available.
    */
   ledger_index_max?: number
-  /** Use to look for transactions from a single ledger only. */
-  ledger_hash?: string
-  /** Use to look for transactions from a single ledger only. */
-  ledger_index?: LedgerIndex
   /**
    * If true, return transactions as hex strings instead of JSON. The default is
    * false.

--- a/packages/xrpl/src/models/methods/baseMethod.ts
+++ b/packages/xrpl/src/models/methods/baseMethod.ts
@@ -1,3 +1,5 @@
+import { LedgerIndex } from '../common'
+
 import type { Request } from '.'
 
 export interface BaseRequest {
@@ -12,6 +14,13 @@ export interface BaseRequest {
   command: string
   /** The API version to use. If omitted, use version 1. */
   api_version?: number
+}
+
+export interface LookupByLedgerRequest {
+  /** A 20-byte hex string for the ledger version to use. */
+  ledger_hash?: string
+  /** The ledger index of the ledger to use, or a shortcut string. */
+  ledger_index?: LedgerIndex
 }
 
 interface Warning {

--- a/packages/xrpl/src/models/methods/bookOffers.ts
+++ b/packages/xrpl/src/models/methods/bookOffers.ts
@@ -1,7 +1,7 @@
-import { Amount, LedgerIndex } from '../common'
+import { Amount } from '../common'
 import { Offer } from '../ledger'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 export interface TakerAmount {
   currency: string
@@ -14,15 +14,8 @@ export interface TakerAmount {
  *
  * @category Requests
  */
-export interface BookOffersRequest extends BaseRequest {
+export interface BookOffersRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'book_offers'
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * If provided, the server does not provide more than this many offers in the
    * results. The total number of results returned may be fewer than the limit,

--- a/packages/xrpl/src/models/methods/depositAuthorized.ts
+++ b/packages/xrpl/src/models/methods/depositAuthorized.ts
@@ -1,6 +1,4 @@
-import { LedgerIndex } from '../common'
-
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The deposit_authorized command indicates whether one account is authorized to
@@ -9,19 +7,14 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface DepositAuthorizedRequest extends BaseRequest {
+export interface DepositAuthorizedRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'deposit_authorized'
   /** The sender of a possible payment. */
   source_account: string
   /** The recipient of a possible payment. */
   destination_account: string
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
 }
 
 /**

--- a/packages/xrpl/src/models/methods/gatewayBalances.ts
+++ b/packages/xrpl/src/models/methods/gatewayBalances.ts
@@ -1,6 +1,4 @@
-import { LedgerIndex } from '../common'
-
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The gateway_balances command calculates the total balances issued by a given
@@ -21,7 +19,9 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface GatewayBalancesRequest extends BaseRequest {
+export interface GatewayBalancesRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'gateway_balances'
   /** The Address to check. This should be the issuing address. */
   account: string
@@ -35,13 +35,6 @@ export interface GatewayBalancesRequest extends BaseRequest {
    * Such addresses.
    */
   hotwallet?: string | string[]
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger version to use, or a shortcut string to
-   * choose a ledger automatically.
-   */
-  ledger_index?: LedgerIndex
 }
 
 interface Balance {

--- a/packages/xrpl/src/models/methods/ledger.ts
+++ b/packages/xrpl/src/models/methods/ledger.ts
@@ -1,9 +1,8 @@
-import { LedgerIndex } from '../common'
 import { Ledger } from '../ledger'
 import { Transaction, TransactionAndMetadata } from '../transactions'
 import { TransactionMetadata } from '../transactions/metadata'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * Retrieve information about the public ledger. Expects a response in the form
@@ -25,15 +24,8 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface LedgerRequest extends BaseRequest {
+export interface LedgerRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'ledger'
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * Admin required If true, return full information on the entire ledger.
    * Ignored if you did not specify a ledger version. Defaults to false.

--- a/packages/xrpl/src/models/methods/ledgerData.ts
+++ b/packages/xrpl/src/models/methods/ledgerData.ts
@@ -1,7 +1,6 @@
-import { LedgerIndex } from '../common'
 import { LedgerEntry } from '../ledger'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `ledger_data` method retrieves contents of the specified ledger. You can
@@ -21,15 +20,8 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface LedgerDataRequest extends BaseRequest {
+export interface LedgerDataRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'ledger_data'
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
   /**
    * If set to true, return ledger objects as hashed hex strings instead of
    * JSON.

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -1,7 +1,6 @@
-import { LedgerIndex } from '../common'
 import { LedgerEntry } from '../ledger'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `ledger_entry` method returns a single ledger object from the XRP Ledger
@@ -19,7 +18,7 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface LedgerEntryRequest extends BaseRequest {
+export interface LedgerEntryRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'ledger_entry'
   /**
    * If true, return the requested ledger object's contents as a hex string in
@@ -27,10 +26,6 @@ export interface LedgerEntryRequest extends BaseRequest {
    * default is false.
    */
   binary?: boolean
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /** The ledger index of the ledger to use, or a shortcut string. */
-  ledger_index?: LedgerIndex
 
   /*
    * Only one of the following properties should be defined in a single request
@@ -137,6 +132,11 @@ export interface LedgerEntryRequest extends BaseRequest {
         ticket_sequence: number
       }
     | string
+
+  /**
+   * Must be the object ID of the NFToken page, as hexadecimal
+   */
+  nft_page?: string
 }
 
 /**

--- a/packages/xrpl/src/models/methods/nftBuyOffers.ts
+++ b/packages/xrpl/src/models/methods/nftBuyOffers.ts
@@ -1,6 +1,6 @@
 import { NFTOffer } from '../common'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `nft_buy_offers` method retrieves all of buy offers for the specified
@@ -8,7 +8,9 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface NFTBuyOffersRequest extends BaseRequest {
+export interface NFTBuyOffersRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'nft_buy_offers'
   /**
    * The unique identifier of an NFToken. The request returns buy offers for this NFToken.

--- a/packages/xrpl/src/models/methods/nftHistory.ts
+++ b/packages/xrpl/src/models/methods/nftHistory.ts
@@ -1,7 +1,7 @@
-import { LedgerIndex, ResponseOnlyTxInfo } from '../common'
+import { ResponseOnlyTxInfo } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The nft_history method retrieves a list of transactions that involved the
@@ -10,7 +10,7 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface NFTHistoryRequest extends BaseRequest {
+export interface NFTHistoryRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'nft_history'
   /**
    * The unique identifier of an NFToken.
@@ -28,10 +28,6 @@ export interface NFTHistoryRequest extends BaseRequest {
    * version available.
    */
   ledger_index_max?: number
-  /** Use to look for transactions from a single ledger only. */
-  ledger_hash?: string
-  /** Use to look for transactions from a single ledger only. */
-  ledger_index?: LedgerIndex
   /**
    * If true, return transactions as hex strings instead of JSON. The default is
    * false.

--- a/packages/xrpl/src/models/methods/nftInfo.ts
+++ b/packages/xrpl/src/models/methods/nftInfo.ts
@@ -1,6 +1,6 @@
-import { LedgerIndex, NFToken } from '../common'
+import { NFToken } from '../common'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `nft_info` method retrieves information about NFToken
@@ -8,19 +8,12 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface NFTInfoRequest extends BaseRequest {
+export interface NFTInfoRequest extends BaseRequest, LookupByLedgerRequest {
   command: 'nft_info'
   /**
    * The unique identifier of an NFToken.
    */
   nft_id: string
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
 }
 
 /**

--- a/packages/xrpl/src/models/methods/nftSellOffers.ts
+++ b/packages/xrpl/src/models/methods/nftSellOffers.ts
@@ -1,6 +1,6 @@
 import { NFTOffer } from '../common'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `nft_sell_offers` method retrieves all of sell offers for the specified
@@ -8,7 +8,9 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface NFTSellOffersRequest extends BaseRequest {
+export interface NFTSellOffersRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'nft_sell_offers'
   /**
    * The unique identifier of an NFToken. The request returns sell offers for this NFToken.

--- a/packages/xrpl/src/models/methods/ripplePathFind.ts
+++ b/packages/xrpl/src/models/methods/ripplePathFind.ts
@@ -1,6 +1,6 @@
-import { Amount, LedgerIndex, Path } from '../common'
+import { Amount, Path } from '../common'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 interface SourceCurrencyAmount {
   currency: string
@@ -14,7 +14,9 @@ interface SourceCurrencyAmount {
  *
  * @category Requests
  */
-export interface RipplePathFindRequest extends BaseRequest {
+export interface RipplePathFindRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'ripple_path_find'
   /** Unique address of the account that would send funds in a transaction. */
   source_account: string
@@ -36,13 +38,6 @@ export interface RipplePathFindRequest extends BaseRequest {
    * and optional issuer field, like how currency amounts are specified.
    */
   source_currencies?: SourceCurrencyAmount
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
 }
 
 interface PathOption {

--- a/packages/xrpl/src/models/methods/transactionEntry.ts
+++ b/packages/xrpl/src/models/methods/transactionEntry.ts
@@ -1,7 +1,7 @@
-import { LedgerIndex, ResponseOnlyTxInfo } from '../common'
+import { ResponseOnlyTxInfo } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 
-import { BaseRequest, BaseResponse } from './baseMethod'
+import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 /**
  * The `transaction_entry` method retrieves information on a single transaction
@@ -10,15 +10,11 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface TransactionEntryRequest extends BaseRequest {
+export interface TransactionEntryRequest
+  extends BaseRequest,
+    LookupByLedgerRequest {
   command: 'transaction_entry'
-  /** A 20-byte hex string for the ledger version to use. */
-  ledger_hash?: string
-  /**
-   * The ledger index of the ledger to use, or a shortcut string to choose a
-   * ledger automatically.
-   */
-  ledger_index?: LedgerIndex
+
   /** Unique hash of the transaction you are looking up. */
   tx_hash: string
 }


### PR DESCRIPTION
## High Level Overview of Change

- Add `ledger_hash` and `ledger_index` to `account_nfts`, `nft_buy_offers`, and `nft_sell_offers` requests.
- Add `nft_page` to `ledger_entry` request.
- Create `LookupByLedgerRequest` to clean up `ledger_hash` and `ledger_index` which are optional on most request objects.

Closes #2135

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Documentation Updates