### PR TITLE
feat: add missing `AccountRoot` fields

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,6 +3,10 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 ## Unreleased
 
+### Added
+Add `BurnedNFTokens`, `FirstNFTSequence`, `MintedNFTokens`,
+`NFTokenMinter`, and `WalletLocator` to `AccountRoot`.
+
 ## 2.8.0 (2023-06-13)
 
 ### Added

--- a/packages/xrpl/src/models/ledger/AccountRoot.ts
+++ b/packages/xrpl/src/models/ledger/AccountRoot.ts
@@ -72,6 +72,16 @@ export default interface AccountRoot extends BaseLedgerEntry {
    * account to each other.
    */
   TransferRate?: number
+  /** An arbitrary 256-bit value that users can set. */
+  WalletLocator?: string
+  /** How many total of this account's issued NFTokens have been burned. This number is always equal or less than MintedNFTokens. */
+  BurnedNFTokens?: number
+  /** The sequence that the account first minted an NFToken */
+  FirstNFTSequence: number
+  /**	How many total NFToken have been minted by and on behalf of this account.  */
+  MintedNFTokens?: number
+  /** Another account that can mint NFTokens on behalf of this account. */
+  NFTokenMinter?: string
 }
 
 /**


### PR DESCRIPTION
## High Level Overview of Change

Add `BurnedNFTokens`, `FirstNFTSequence`, `MintedNFTokens`, `NFTokenMinter`, and `WalletLocator` to `AccountRoot`.

Closes #2144

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
