### PR TITLE
fix(types): `SignerList` was missing `WalletLocator`

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -13,6 +13,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Add type for NFToken object that is stored on a `NFTokenPage`.
 * Add type for `account_info`'s `account_flags` property.
 * Add types for `EnableAmendment`, `SetFee`, and `UNLModify` transactions.
+* Add `WalletLocator` to `SignerEntry` on `SignerList` (LedgerEntry).
 
 ## 2.8.0 (2023-06-13)
 

--- a/packages/xrpl/src/models/ledger/SignerList.ts
+++ b/packages/xrpl/src/models/ledger/SignerList.ts
@@ -1,11 +1,6 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { SignerEntry } from '../common'
 
-interface SignerEntry {
-  SignerEntry: {
-    Account: string
-    SignerWeight: number
-  }
-}
+import BaseLedgerEntry from './BaseLedgerEntry'
 
 /**
  * The SignerList object type represents a list of parties that, as a group,


### PR DESCRIPTION
## High Level Overview of Change

`SignerEntry` on `SignerList` (LedgerEntry) was missing `WalletLocator`.

This was found while trying to use types on the xrpl.org explorer.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
