### PR TITLE
feat(types): Export most of the types

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -19,8 +19,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ### Breaking
 * If you were deep importing these types previously you will need to import them from `xrpl` and rename them:
-  * `methods/bookOffers`: `TakerAmount` -> `BookOfferCurrency`
   * `methods/accountLines`: `Trustline` -> `AccountLinesTrustline`
+  * `methods/bookOffers`: `TakerAmount` -> `BookOfferCurrency`
+  * `methods/ledgerData`: `BinaryLedgerEntry` -> `LedgerDataBinaryLedgerEntry`
 
 ## 2.8.0 (2023-06-13)
 

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -15,6 +15,12 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Add types for `EnableAmendment`, `SetFee`, and `UNLModify` transactions.
 * Add the new fields for `XRPFees` amendment and id for the `FeeSettings`
 * Add `FeeSettings` singleton ledger entry id.
+* Export many nested types and interfaces
+
+### Breaking
+* If you were deep importing these types previously you will need to import them from `xrpl` and rename them:
+  * `methods/bookOffers`: `TakerAmount` -> `BookOfferCurrency`
+  * `methods/accountLines`: `Trustline` -> `AccountLinesTrustline`
 
 ## 2.8.0 (2023-06-13)
 

--- a/packages/xrpl/src/client/partialPayment.ts
+++ b/packages/xrpl/src/client/partialPayment.ts
@@ -4,6 +4,7 @@ import { decode } from 'ripple-binary-codec'
 import type {
   AccountTxResponse,
   Response,
+  ResponseWarning,
   TransactionEntryResponse,
   TransactionStream,
   TxResponse,
@@ -111,7 +112,7 @@ export function handlePartialPayment(
   response: Response,
 ): void {
   if (hasPartialPayment(command, response)) {
-    const warnings = response.warnings ?? []
+    const warnings: ResponseWarning[] = response.warnings ?? []
 
     const warning = {
       id: WARN_PARTIAL_PAYMENT_CODE,

--- a/packages/xrpl/src/index.ts
+++ b/packages/xrpl/src/index.ts
@@ -7,6 +7,8 @@ export * from './models'
 
 export * from './utils'
 
+export { default as ECDSA } from './ECDSA'
+
 export * from './errors'
 
 export { Wallet } from './Wallet'

--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -1,10 +1,10 @@
 export type LedgerIndex = number | ('validated' | 'closed' | 'current')
 
-interface XRP {
+export interface XRP {
   currency: 'XRP'
 }
 
-interface IssuedCurrency {
+export interface IssuedCurrency {
   currency: string
   issuer: string
 }
@@ -43,7 +43,7 @@ export type StreamType =
   | 'server'
   | 'validations'
 
-interface PathStep {
+export interface PathStep {
   account?: string
   currency?: string
   issuer?: string

--- a/packages/xrpl/src/models/index.ts
+++ b/packages/xrpl/src/models/index.ts
@@ -13,3 +13,4 @@ export {
 } from './utils/flags'
 export * from './methods'
 export * from './transactions'
+export * from './common'

--- a/packages/xrpl/src/models/ledger/Amendments.ts
+++ b/packages/xrpl/src/models/ledger/Amendments.ts
@@ -1,6 +1,6 @@
 import BaseLedgerEntry from './BaseLedgerEntry'
 
-interface Majority {
+export interface Majority {
   Majority: {
     /** The Amendment ID of the pending amendment. */
     Amendment: string

--- a/packages/xrpl/src/models/ledger/NFTokenPage.ts
+++ b/packages/xrpl/src/models/ledger/NFTokenPage.ts
@@ -1,21 +1,19 @@
 import BaseLedgerEntry from './BaseLedgerEntry'
 
 export interface NFToken {
-  Flags: number
-  Issuer: string
-  NFTokenID: string
-  NFTokenTaxon: number
-  URI?: string
-}
-
-export interface NFTokenWrapper {
-  NFToken: NFToken
+  NFToken: {
+    Flags: number
+    Issuer: string
+    NFTokenID: string
+    NFTokenTaxon: number
+    URI?: string
+  }
 }
 
 export interface NFTokenPage extends BaseLedgerEntry {
   LedgerEntryType: 'NFTokenPage'
   NextPageMin?: string
-  NFTokens: NFTokenWrapper[]
+  NFTokens: NFToken[]
   PreviousPageMin?: string
   PreviousTxnID?: string
   PreviousTxnLgrSeq?: number

--- a/packages/xrpl/src/models/ledger/NegativeUNL.ts
+++ b/packages/xrpl/src/models/ledger/NegativeUNL.ts
@@ -1,10 +1,5 @@
 import BaseLedgerEntry from './BaseLedgerEntry'
 
-interface DisabledValidator {
-  FirstLedgerSequence: number
-  PublicKey: string
-}
-
 /**
  * The NegativeUNL object type contains the current status of the Negative UNL,
  * a list of trusted validators currently believed to be offline.
@@ -16,7 +11,10 @@ export default interface NegativeUNL extends BaseLedgerEntry {
   /**
    * A list of trusted validators that are currently disabled.
    */
-  DisabledValidators?: DisabledValidator[]
+  DisabledValidators?: Array<{
+    FirstLedgerSequence: number
+    PublicKey: string
+  }>
   /**
    * The public key of a trusted validator that is scheduled to be disabled in
    * the next flag ledger.

--- a/packages/xrpl/src/models/ledger/NegativeUNL.ts
+++ b/packages/xrpl/src/models/ledger/NegativeUNL.ts
@@ -1,10 +1,10 @@
 import BaseLedgerEntry from './BaseLedgerEntry'
 
 /**
- * The unique id for the Amendments object https://xrpl.org/amendments-object.html#amendments-id-format
+ * The unique id for the nUNL object https://xrpl.org/negativeunl.html#negativeunl-id-format
  */
-export const AMENDMENTS_ID =
-  '7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4'
+export const NEGATIVE_UNL_ID =
+  '2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244'
 
 /**
  * The NegativeUNL object type contains the current status of the Negative UNL,

--- a/packages/xrpl/src/models/ledger/index.ts
+++ b/packages/xrpl/src/models/ledger/index.ts
@@ -2,7 +2,7 @@ import AccountRoot, {
   AccountRootFlags,
   AccountRootFlagsInterface,
 } from './AccountRoot'
-import Amendments from './Amendments'
+import Amendments, { Majority } from './Amendments'
 import Check from './Check'
 import DepositPreauth from './DepositPreauth'
 import DirectoryNode from './DirectoryNode'
@@ -40,6 +40,7 @@ export {
   Ledger,
   LedgerEntry,
   LedgerHashes,
+  Majority,
   NegativeUNL,
   NFTokenOffer,
   NFTokenPage,

--- a/packages/xrpl/src/models/methods/accountChannels.ts
+++ b/packages/xrpl/src/models/methods/accountChannels.ts
@@ -1,6 +1,6 @@
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
-interface Channel {
+export interface Channel {
   account: string
   amount: string
   balance: string

--- a/packages/xrpl/src/models/methods/accountInfo.ts
+++ b/packages/xrpl/src/models/methods/accountInfo.ts
@@ -31,7 +31,7 @@ export interface AccountInfoRequest extends BaseRequest, LookupByLedgerRequest {
   strict?: boolean
 }
 
-interface QueueTransaction {
+export interface AccountQueueTransaction {
   /**
    * Whether this transaction changes this address's ways of authorizing
    * transactions.
@@ -50,7 +50,7 @@ interface QueueTransaction {
   seq: number
 }
 
-interface QueueData {
+export interface AccountQueueData {
   /** Number of queued transactions from this address. */
   txn_count: number
   /**
@@ -70,7 +70,7 @@ interface QueueData {
    */
   max_spend_drops_total?: string
   /** Information about each queued transaction from this address. */
-  transactions?: QueueTransaction[]
+  transactions?: AccountQueueTransaction[]
 }
 
 export interface AccountInfoAccountFlags {
@@ -168,7 +168,7 @@ export interface AccountInfoResponse extends BaseResponse {
      * fields may be omitted because the values are calculated "lazily" by the
      * queuing mechanism.
      */
-    queue_data?: QueueData
+    queue_data?: AccountQueueData
     /**
      * True if this data is from a validated ledger version; if omitted or set
      * to false, this data is not final.

--- a/packages/xrpl/src/models/methods/accountLines.ts
+++ b/packages/xrpl/src/models/methods/accountLines.ts
@@ -1,6 +1,6 @@
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
-export interface Trustline {
+export interface AccountLinesTrustline {
   /** The unique Address of the counterparty to this trust line. */
   account: string
   /**
@@ -111,7 +111,7 @@ export interface AccountLinesResponse extends BaseResponse {
      * Array of trust line objects. If the number of trust lines is large, only
      * returns up to the limit at a time.
      */
-    lines: Trustline[]
+    lines: AccountLinesTrustline[]
     /**
      * The ledger index of the current open ledger, which was used when
      * retrieving this information.

--- a/packages/xrpl/src/models/methods/accountObjects.ts
+++ b/packages/xrpl/src/models/methods/accountObjects.ts
@@ -11,7 +11,7 @@ import {
 
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
-type AccountObjectType =
+export type AccountObjectType =
   | 'check'
   | 'deposit_preauth'
   | 'escrow'
@@ -63,7 +63,7 @@ export interface AccountObjectsRequest
  * Account Objects can be a Check, a DepositPreauth, an Escrow, an Offer, a
  * PayChannel, a SignerList, a Ticket, or a RippleState.
  */
-type AccountObject =
+export type AccountObject =
   | Check
   | DepositPreauth
   | Escrow

--- a/packages/xrpl/src/models/methods/accountTx.ts
+++ b/packages/xrpl/src/models/methods/accountTx.ts
@@ -49,7 +49,7 @@ export interface AccountTxRequest extends BaseRequest, LookupByLedgerRequest {
   marker?: unknown
 }
 
-interface AccountTransaction {
+export interface AccountTxTransaction {
   /** The ledger index of the ledger version that included this transaction. */
   ledger_index: number
   /**
@@ -98,7 +98,7 @@ export interface AccountTxResponse extends BaseResponse {
      * Array of transactions matching the request's criteria, as explained
      * below.
      */
-    transactions: AccountTransaction[]
+    transactions: AccountTxTransaction[]
     /**
      * If included and set to true, the information in this response comes from
      * a validated ledger version. Otherwise, the information is subject to

--- a/packages/xrpl/src/models/methods/baseMethod.ts
+++ b/packages/xrpl/src/models/methods/baseMethod.ts
@@ -23,7 +23,7 @@ export interface LookupByLedgerRequest {
   ledger_index?: LedgerIndex
 }
 
-interface Warning {
+export interface ResponseWarning {
   id: number
   message: string
   details?: { [key: string]: string }
@@ -35,7 +35,7 @@ export interface BaseResponse {
   type: 'response' | string
   result: unknown
   warning?: 'load'
-  warnings?: Warning[]
+  warnings?: ResponseWarning[]
   forwarded?: boolean
   api_version?: number
 }

--- a/packages/xrpl/src/models/methods/bookOffers.ts
+++ b/packages/xrpl/src/models/methods/bookOffers.ts
@@ -3,7 +3,7 @@ import { Offer } from '../ledger'
 
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
-export interface TakerAmount {
+export interface BookOfferCurrency {
   currency: string
   issuer?: string
 }
@@ -32,13 +32,13 @@ export interface BookOffersRequest extends BaseRequest, LookupByLedgerRequest {
    * receive, as an object with currency and issuer fields (omit issuer for
    * XRP), like currency amounts.
    */
-  taker_gets: TakerAmount
+  taker_gets: BookOfferCurrency
   /**
    * Specification of which currency the account taking the offer would pay, as
    * an object with currency and issuer fields (omit issuer for XRP), like
    * currency amounts.
    */
-  taker_pays: TakerAmount
+  taker_pays: BookOfferCurrency
 }
 
 export interface BookOffer extends Offer {

--- a/packages/xrpl/src/models/methods/gatewayBalances.ts
+++ b/packages/xrpl/src/models/methods/gatewayBalances.ts
@@ -37,7 +37,7 @@ export interface GatewayBalancesRequest
   hotwallet?: string | string[]
 }
 
-interface Balance {
+export interface GatewayBalance {
   currency: string
   value: string
 }
@@ -60,12 +60,12 @@ export interface GatewayBalancesResponse extends BaseResponse {
      * Amounts issued to the hotwallet addresses from the request. The keys are
      * addresses and the values are arrays of currency amounts they hold.
      */
-    balances?: { [address: string]: Balance[] }
+    balances?: { [address: string]: GatewayBalance[] }
     /**
      * Total amounts held that are issued by others. In the recommended
      * configuration, the issuing address should have none.
      */
-    assets?: { [address: string]: Balance[] }
+    assets?: { [address: string]: GatewayBalance[] }
     /**
      * The identifying hash of the ledger version that was used to generate
      * this response.

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -1,6 +1,7 @@
 import {
   AccountChannelsRequest,
   AccountChannelsResponse,
+  Channel,
 } from './accountChannels'
 import {
   AccountCurrenciesRequest,
@@ -10,18 +11,47 @@ import {
   AccountInfoAccountFlags,
   AccountInfoRequest,
   AccountInfoResponse,
+  AccountQueueData,
+  AccountQueueTransaction,
 } from './accountInfo'
-import { AccountLinesRequest, AccountLinesResponse } from './accountLines'
-import { AccountNFTsRequest, AccountNFTsResponse } from './accountNFTs'
-import { AccountObjectsRequest, AccountObjectsResponse } from './accountObjects'
+import {
+  AccountLinesRequest,
+  AccountLinesResponse,
+  AccountLinesTrustline,
+} from './accountLines'
+import {
+  AccountNFToken,
+  AccountNFTsRequest,
+  AccountNFTsResponse,
+} from './accountNFTs'
+import {
+  AccountObject,
+  AccountObjectsRequest,
+  AccountObjectsResponse,
+  AccountObjectType,
+} from './accountObjects'
 import {
   AccountOffer,
   AccountOffersRequest,
   AccountOffersResponse,
 } from './accountOffers'
-import { AccountTxRequest, AccountTxResponse } from './accountTx'
-import { ErrorResponse } from './baseMethod'
-import { BookOffersRequest, BookOffer, BookOffersResponse } from './bookOffers'
+import {
+  AccountTxRequest,
+  AccountTxResponse,
+  AccountTxTransaction,
+} from './accountTx'
+import {
+  BaseRequest,
+  BaseResponse,
+  ErrorResponse,
+  ResponseWarning,
+} from './baseMethod'
+import {
+  BookOffersRequest,
+  BookOffer,
+  BookOffersResponse,
+  BookOfferCurrency,
+} from './bookOffers'
 import { ChannelVerifyRequest, ChannelVerifyResponse } from './channelVerify'
 import {
   DepositAuthorizedRequest,
@@ -29,17 +59,34 @@ import {
 } from './depositAuthorized'
 import { FeeRequest, FeeResponse } from './fee'
 import {
+  GatewayBalance,
   GatewayBalancesRequest,
   GatewayBalancesResponse,
 } from './gatewayBalances'
-import { LedgerRequest, LedgerResponse } from './ledger'
+import {
+  LedgerBinary,
+  LedgerModifiedOfferCreateTransaction,
+  LedgerQueueData,
+  LedgerRequest,
+  LedgerResponse,
+} from './ledger'
 import { LedgerClosedRequest, LedgerClosedResponse } from './ledgerClosed'
 import { LedgerCurrentRequest, LedgerCurrentResponse } from './ledgerCurrent'
-import { LedgerDataRequest, LedgerDataResponse } from './ledgerData'
+import {
+  LedgerDataBinaryLedgerEntry,
+  LedgerDataLabeledLedgerEntry,
+  LedgerDataLedgerState,
+  LedgerDataRequest,
+  LedgerDataResponse,
+} from './ledgerData'
 import { LedgerEntryRequest, LedgerEntryResponse } from './ledgerEntry'
 import { ManifestRequest, ManifestResponse } from './manifest'
 import { NFTBuyOffersRequest, NFTBuyOffersResponse } from './nftBuyOffers'
-import { NFTHistoryRequest, NFTHistoryResponse } from './nftHistory'
+import {
+  NFTHistoryRequest,
+  NFTHistoryResponse,
+  NFTHistoryTransaction,
+} from './nftHistory'
 import { NFTInfoRequest, NFTInfoResponse } from './nftInfo'
 import { NFTSellOffersRequest, NFTSellOffersResponse } from './nftSellOffers'
 import { NoRippleCheckRequest, NoRippleCheckResponse } from './norippleCheck'
@@ -49,11 +96,24 @@ import {
   PathFindCreateRequest,
   PathFindStatusRequest,
   PathFindResponse,
+  PathFindPathOption,
 } from './pathFind'
 import { PingRequest, PingResponse } from './ping'
 import { RandomRequest, RandomResponse } from './random'
-import { RipplePathFindRequest, RipplePathFindResponse } from './ripplePathFind'
-import { ServerInfoRequest, ServerInfoResponse } from './serverInfo'
+import {
+  RipplePathFindPathOption,
+  RipplePathFindRequest,
+  RipplePathFindResponse,
+  SourceCurrencyAmount,
+} from './ripplePathFind'
+import {
+  JobType,
+  ServerInfoRequest,
+  ServerInfoResponse,
+  ServerState,
+  StateAccounting,
+  StateAccountingFinal,
+} from './serverInfo'
 import { ServerStateRequest, ServerStateResponse } from './serverState'
 import { SubmitRequest, SubmitResponse } from './submit'
 import {
@@ -61,12 +121,15 @@ import {
   SubmitMultisignedResponse,
 } from './submitMultisigned'
 import {
+  BooksSnapshot,
   ConsensusStream,
   LedgerStream,
+  LedgerStreamResponse,
   OrderBookStream,
   PathFindStream,
   PeerStatusStream,
   Stream,
+  SubscribeBook,
   SubscribeRequest,
   SubscribeResponse,
   TransactionStream,
@@ -77,7 +140,11 @@ import {
   TransactionEntryResponse,
 } from './transactionEntry'
 import { TxRequest, TxResponse } from './tx'
-import { UnsubscribeRequest, UnsubscribeResponse } from './unsubscribe'
+import {
+  UnsubscribeBook,
+  UnsubscribeRequest,
+  UnsubscribeResponse,
+} from './unsubscribe'
 /**
  * @category Requests
  */
@@ -181,9 +248,14 @@ type Response =
   | NFTHistoryResponse
 
 export {
+  // Allow users to define their own requests and responses.  This is useful for releasing experimental versions
+  BaseRequest,
+  BaseResponse,
   Request,
   Response,
-  // account methods
+  ResponseWarning,
+  // account methods with types
+  Channel,
   AccountChannelsRequest,
   AccountChannelsResponse,
   AccountCurrenciesRequest,
@@ -191,10 +263,16 @@ export {
   AccountInfoAccountFlags,
   AccountInfoRequest,
   AccountInfoResponse,
+  AccountQueueData,
+  AccountQueueTransaction,
   AccountLinesRequest,
   AccountLinesResponse,
+  AccountLinesTrustline,
+  AccountNFToken,
   AccountNFTsRequest,
   AccountNFTsResponse,
+  AccountObject,
+  AccountObjectType,
   AccountObjectsRequest,
   AccountObjectsResponse,
   AccountOffer,
@@ -202,6 +280,8 @@ export {
   AccountOffersResponse,
   AccountTxRequest,
   AccountTxResponse,
+  AccountTxTransaction,
+  GatewayBalance,
   GatewayBalancesRequest,
   GatewayBalancesResponse,
   NoRippleCheckRequest,
@@ -209,15 +289,21 @@ export {
   // ledger methods
   LedgerRequest,
   LedgerResponse,
+  LedgerQueueData,
+  LedgerBinary,
+  LedgerModifiedOfferCreateTransaction,
   LedgerClosedRequest,
   LedgerClosedResponse,
   LedgerCurrentRequest,
   LedgerCurrentResponse,
   LedgerDataRequest,
+  LedgerDataLabeledLedgerEntry,
+  LedgerDataBinaryLedgerEntry,
   LedgerDataResponse,
+  LedgerDataLedgerState,
   LedgerEntryRequest,
   LedgerEntryResponse,
-  // transaction methods
+  // transaction methods with types
   SubmitRequest,
   SubmitResponse,
   SubmitMultisignedRequest,
@@ -226,27 +312,34 @@ export {
   TransactionEntryResponse,
   TxRequest,
   TxResponse,
-  // path and order book methods
+  // path and order book methods with types
   BookOffersRequest,
   BookOffer,
+  BookOfferCurrency,
   BookOffersResponse,
   DepositAuthorizedRequest,
   DepositAuthorizedResponse,
   PathFindRequest,
   PathFindCreateRequest,
   PathFindCloseRequest,
+  PathFindPathOption,
   PathFindStatusRequest,
   PathFindResponse,
+  RipplePathFindPathOption,
   RipplePathFindRequest,
   RipplePathFindResponse,
+  SourceCurrencyAmount,
   // payment channel methods
   ChannelVerifyRequest,
   ChannelVerifyResponse,
-  // Subscribe methods/streams
+  // Subscribe methods/streams with types
   SubscribeRequest,
   SubscribeResponse,
+  SubscribeBook,
   Stream,
+  BooksSnapshot,
   LedgerStream,
+  LedgerStreamResponse,
   ValidationStream,
   TransactionStream,
   PathFindStream,
@@ -255,7 +348,8 @@ export {
   ConsensusStream,
   UnsubscribeRequest,
   UnsubscribeResponse,
-  // server info methods
+  UnsubscribeBook,
+  // server info methods with types
   FeeRequest,
   FeeResponse,
   ManifestRequest,
@@ -264,6 +358,10 @@ export {
   ServerInfoResponse,
   ServerStateRequest,
   ServerStateResponse,
+  JobType,
+  ServerState,
+  StateAccountingFinal,
+  StateAccounting,
   // utility methods
   PingRequest,
   PingResponse,
@@ -280,4 +378,5 @@ export {
   NFTInfoResponse,
   NFTHistoryRequest,
   NFTHistoryResponse,
+  NFTHistoryTransaction,
 }

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- There is a lot to export */
 import {
   AccountChannelsRequest,
   AccountChannelsResponse,

--- a/packages/xrpl/src/models/methods/ledger.ts
+++ b/packages/xrpl/src/models/methods/ledger.ts
@@ -67,20 +67,19 @@ export interface LedgerRequest extends BaseRequest, LookupByLedgerRequest {
   queue?: boolean
 }
 
-interface ModifiedMetadata extends TransactionMetadata {
-  owner_funds: string
-}
-
-interface ModifiedOfferCreateTransaction {
+/**
+ * Special case transaction definition when the request contains `owner_funds: true`.
+ */
+export interface LedgerModifiedOfferCreateTransaction {
   transaction: Transaction
-  metadata: ModifiedMetadata
+  metadata: TransactionMetadata & { owner_funds: string }
 }
 
-interface LedgerQueueData {
+export interface LedgerQueueData {
   account: string
   tx:
     | TransactionAndMetadata
-    | ModifiedOfferCreateTransaction
+    | LedgerModifiedOfferCreateTransaction
     | { tx_blob: string }
   retries_remaining: number
   preflight_result: string
@@ -91,7 +90,7 @@ interface LedgerQueueData {
   max_spend_drops?: string
 }
 
-interface BinaryLedger
+export interface LedgerBinary
   extends Omit<Omit<Ledger, 'transactions'>, 'accountState'> {
   accountState?: string[]
   transactions?: string[]
@@ -105,7 +104,7 @@ interface BinaryLedger
 export interface LedgerResponse extends BaseResponse {
   result: {
     /** The complete header data of this {@link Ledger}. */
-    ledger: Ledger | BinaryLedger
+    ledger: Ledger | LedgerBinary
     /** Unique identifying hash of the entire ledger. */
     ledger_hash: string
     /** The Ledger Index of this ledger. */

--- a/packages/xrpl/src/models/methods/ledgerData.ts
+++ b/packages/xrpl/src/models/methods/ledgerData.ts
@@ -39,13 +39,18 @@ export interface LedgerDataRequest extends BaseRequest, LookupByLedgerRequest {
   marker?: unknown
 }
 
-type LabeledLedgerEntry = { ledgerEntryType: string } & LedgerEntry
+export type LedgerDataLabeledLedgerEntry = {
+  ledgerEntryType: string
+} & LedgerEntry
 
-export interface BinaryLedgerEntry {
+export interface LedgerDataBinaryLedgerEntry {
   data: string
 }
 
-type State = { index: string } & (BinaryLedgerEntry | LabeledLedgerEntry)
+export type LedgerDataLedgerState = { index: string } & (
+  | LedgerDataBinaryLedgerEntry
+  | LedgerDataLabeledLedgerEntry
+)
 
 /**
  * The response expected from a {@link LedgerDataRequest}.
@@ -62,7 +67,7 @@ export interface LedgerDataResponse extends BaseResponse {
      * Array of JSON objects containing data from the ledger's state tree,
      * as defined below.
      */
-    state: State[]
+    state: LedgerDataLedgerState[]
     /**
      * Server-defined value indicating the response is paginated. Pass this to
      * the next call to resume where this call left off.

--- a/packages/xrpl/src/models/methods/nftHistory.ts
+++ b/packages/xrpl/src/models/methods/nftHistory.ts
@@ -51,7 +51,7 @@ export interface NFTHistoryRequest extends BaseRequest, LookupByLedgerRequest {
   marker?: unknown
 }
 
-interface NFTokenTransaction {
+export interface NFTHistoryTransaction {
   /** The ledger index of the ledger version that included this transaction. */
   ledger_index: number
   /**
@@ -102,7 +102,7 @@ export interface NFTHistoryResponse extends BaseResponse {
      * Array of transactions matching the request's criteria, as explained
      * below.
      */
-    transactions: NFTokenTransaction[]
+    transactions: NFTHistoryTransaction[]
     /**
      * If included and set to true, the information in this response comes from
      * a validated ledger version. Otherwise, the information is subject to

--- a/packages/xrpl/src/models/methods/pathFind.ts
+++ b/packages/xrpl/src/models/methods/pathFind.ts
@@ -55,7 +55,7 @@ export type PathFindRequest =
   | PathFindCloseRequest
   | PathFindStatusRequest
 
-interface PathOption {
+export interface PathFindPathOption {
   /** Array of arrays of objects defining payment paths. */
   paths_computed: Path[]
   /**
@@ -82,7 +82,7 @@ export interface PathFindResponse extends BaseResponse {
      * empty, then no paths were found connecting the source and destination
      * accounts.
      */
-    alternatives: PathOption[]
+    alternatives: PathFindPathOption[]
     /** Unique address of the account that would receive a transaction. */
     destination_account: string
     /** Currency amount provided in the WebSocket request. */

--- a/packages/xrpl/src/models/methods/ripplePathFind.ts
+++ b/packages/xrpl/src/models/methods/ripplePathFind.ts
@@ -2,7 +2,7 @@ import { Amount, Path } from '../common'
 
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
-interface SourceCurrencyAmount {
+export interface SourceCurrencyAmount {
   currency: string
   issuer?: string
 }
@@ -37,10 +37,10 @@ export interface RipplePathFindRequest
    * entry in the array should be a JSON object with a mandatory currency field
    * and optional issuer field, like how currency amounts are specified.
    */
-  source_currencies?: SourceCurrencyAmount
+  source_currencies?: SourceCurrencyAmount[]
 }
 
-interface PathOption {
+export interface RipplePathFindPathOption {
   /** Array of arrays of objects defining payment paths. */
   paths_computed: Path[]
   /**
@@ -62,7 +62,7 @@ export interface RipplePathFindResponse extends BaseResponse {
      * empty, then there are no paths connecting the source and destination
      * accounts.
      */
-    alternatives: PathOption[]
+    alternatives: RipplePathFindPathOption[]
     /** Unique address of the account that would receive a payment transaction. */
     destination_account: string
     /**

--- a/packages/xrpl/src/models/methods/submitMultisigned.ts
+++ b/packages/xrpl/src/models/methods/submitMultisigned.ts
@@ -14,7 +14,7 @@ export interface SubmitMultisignedRequest extends BaseRequest {
   /**
    * Transaction in JSON format with an array of Signers. To be successful, the
    * weights of the signatures must be equal or higher than the quorum of the.
-   * {@link SignerList}.
+   * {@link Transaction Type/SignerList}.
    */
   tx_json: Transaction
   /**

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -11,7 +11,7 @@ import { TransactionMetadata } from '../transactions/metadata'
 
 import type { BaseRequest, BaseResponse } from './baseMethod'
 
-interface Book {
+export interface SubscribeBook {
   /**
    * Specification of which currency the account taking the Offer would
    * receive, as a currency object with no amount.
@@ -60,7 +60,7 @@ export interface SubscribeRequest extends BaseRequest {
    * Array of objects defining order books  to monitor for updates, as detailed
    * Below.
    */
-  books?: Book[]
+  books?: SubscribeBook[]
   /**
    * URL where the server sends a JSON-RPC callbacks for each event.
    * Admin-only.
@@ -72,7 +72,7 @@ export interface SubscribeRequest extends BaseRequest {
   url_password?: string
 }
 
-type BooksSnapshot = Offer[]
+export type BooksSnapshot = Offer[]
 
 /**
  * Response expected from a {@link SubscribeRequest}.

--- a/packages/xrpl/src/models/methods/unsubscribe.ts
+++ b/packages/xrpl/src/models/methods/unsubscribe.ts
@@ -2,7 +2,7 @@ import { Currency, StreamType } from '../common'
 
 import type { BaseRequest, BaseResponse } from './baseMethod'
 
-interface Book {
+export interface UnsubscribeBook {
   taker_gets: Currency
   taker_pays: Currency
   both?: boolean
@@ -36,7 +36,7 @@ export interface UnsubscribeRequest extends BaseRequest {
    * Array of objects defining order books to unsubscribe from, as explained
    * below.
    */
-  books?: Book[]
+  books?: UnsubscribeBook[]
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/index.ts
+++ b/packages/xrpl/src/models/transactions/index.ts
@@ -1,5 +1,6 @@
+export { BaseTransaction } from './common'
 export { validate, TransactionAndMetadata, Transaction } from './transaction'
-export { TransactionMetadata } from './metadata'
+export * from './metadata'
 export {
   AccountSetAsfFlags,
   AccountSetTfFlags,

--- a/packages/xrpl/src/sugar/balances.ts
+++ b/packages/xrpl/src/sugar/balances.ts
@@ -1,9 +1,12 @@
 import flatMap from 'lodash/flatMap'
 
 import type { Client } from '..'
-import { LedgerIndex } from '../models/common'
-import { AccountInfoRequest } from '../models/methods'
-import { AccountLinesRequest, Trustline } from '../models/methods/accountLines'
+import {
+  AccountLinesRequest,
+  AccountLinesTrustline,
+  LedgerIndex,
+  AccountInfoRequest,
+} from '../models'
 import { dropsToXrp } from '../utils'
 
 interface Balance {
@@ -12,7 +15,7 @@ interface Balance {
   issuer?: string
 }
 
-function formatBalances(trustlines: Trustline[]): Balance[] {
+function formatBalances(trustlines: AccountLinesTrustline[]): Balance[] {
   return trustlines.map((trustline) => ({
     value: trustline.balance,
     currency: trustline.currency,

--- a/packages/xrpl/src/sugar/getOrderbook.ts
+++ b/packages/xrpl/src/sugar/getOrderbook.ts
@@ -8,8 +8,8 @@ import { LedgerIndex } from '../models/common'
 import { OfferFlags } from '../models/ledger/Offer'
 import {
   BookOffer,
+  BookOfferCurrency,
   BookOffersRequest,
-  TakerAmount,
 } from '../models/methods/bookOffers'
 
 const DEFAULT_LIMIT = 20
@@ -51,8 +51,8 @@ const getOrderbookOptionsSet = new Set([
 // eslint-disable-next-line max-params, complexity -- Once bound to Client, getOrderbook only has 3 parameters.
 async function getOrderbook(
   this: Client,
-  currency1: TakerAmount,
-  currency2: TakerAmount,
+  currency1: BookOfferCurrency,
+  currency2: BookOfferCurrency,
   options: {
     limit?: number
     ledger_index?: LedgerIndex

--- a/packages/xrpl/src/utils/getNFTokenID.ts
+++ b/packages/xrpl/src/utils/getNFTokenID.ts
@@ -1,7 +1,7 @@
 import flatMap from 'lodash/flatMap'
 import { decode } from 'ripple-binary-codec'
 
-import { NFTokenWrapper } from '../models/ledger/NFTokenPage'
+import { NFToken } from '../models/ledger/NFTokenPage'
 import {
   CreatedNode,
   isCreatedNode,
@@ -74,7 +74,7 @@ export default function getNFTokenID(
   const previousTokenIDSet = new Set(
     flatMap(affectedNodes, (node) => {
       const nftokens = isModifiedNode(node)
-        ? (node.ModifiedNode.PreviousFields?.NFTokens as NFTokenWrapper[])
+        ? (node.ModifiedNode.PreviousFields?.NFTokens as NFToken[])
         : []
       return nftokens.map((token) => token.NFToken.NFTokenID)
     }).filter((id) => Boolean(id)),
@@ -84,8 +84,8 @@ export default function getNFTokenID(
   const finalTokenIDs = flatMap(affectedNodes, (node) =>
     (
       (((node as ModifiedNode).ModifiedNode?.FinalFields?.NFTokens ??
-        (node as CreatedNode).CreatedNode?.NewFields
-          ?.NFTokens) as NFTokenWrapper[]) ?? []
+        (node as CreatedNode).CreatedNode?.NewFields?.NFTokens) as NFToken[]) ??
+      []
     ).map((token) => token.NFToken.NFTokenID),
   ).filter((nftokenID) => Boolean(nftokenID))
   /* eslint-enable @typescript-eslint/consistent-type-assertions -- Necessary for parsing metadata */

--- a/packages/xrpl/test/integration/requests/ledgerData.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerData.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai'
 
 import { LedgerDataRequest } from '../../../src'
-import type { BinaryLedgerEntry } from '../../../src/models/methods/ledgerData'
+import type { LedgerDataLBinaryLedgerEntry } from '../../../src/models/methods/ledgerData'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -58,7 +58,7 @@ describe('ledger_data', function () {
 
       assert.equal(ledgerDataResponse.result.state.length, 5)
       ledgerDataResponse.result.state.forEach((item) => {
-        assert.typeOf((item as BinaryLedgerEntry).data, 'string')
+        assert.typeOf((item as LedgerDataLBinaryLedgerEntry).data, 'string')
         assert.typeOf(item.index, 'string')
       })
     },

--- a/packages/xrpl/test/integration/requests/ledgerData.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerData.test.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai'
 
-import { LedgerDataRequest } from '../../../src'
-import type { LedgerDataLBinaryLedgerEntry } from '../../../src/models/methods/ledgerData'
+import { LedgerDataBinaryLedgerEntry, LedgerDataRequest } from '../../../src'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -58,7 +57,7 @@ describe('ledger_data', function () {
 
       assert.equal(ledgerDataResponse.result.state.length, 5)
       ledgerDataResponse.result.state.forEach((item) => {
-        assert.typeOf((item as LedgerDataLBinaryLedgerEntry).data, 'string')
+        assert.typeOf((item as LedgerDataBinaryLedgerEntry).data, 'string')
         assert.typeOf(item.index, 'string')
       })
     },


### PR DESCRIPTION
## High Level Overview of Change

Expose most of the types in the `xrpl` package.

BREAKING CHANGE: Renames of deep importable types:
- `methods/accountLines`: `Trustline` -> `AccountLinesTrustline`
- `methods/bookOffers`: `TakerAmount` -> `BookOfferCurrency`
- `methods/ledgerData`: `BinaryLedgerEntry` -> `LedgerDataBinaryLedgerEntry`


### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation Updates