### PR TITLE
fix docs broken link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,11 +53,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </ol>
 <a id="md:case-by-case-setup-steps" class="tsd-anchor"></a><h3><a href="#md:case-by-case-setup-steps">Case by Case Setup Steps</a></h3><p>If you&#39;re using xrpl.js with React or Deno, you&#39;ll need to do a couple extra steps to set it up:</p>
 <ul>
-<li><a href="./UNIQUE_SETUPS.md#using-xrpljs-from-a-cdn">Using xrpl.js with a CDN</a></li>
-<li><a href="./UNIQUE_SETUPS.md#using-xrpljs-with-create-react-app">Using xrpl.js with <code>create-react-app</code></a></li>
-<li><a href="./UNIQUE_SETUPS.md#using-xrpljs-with-react-native">Using xrpl.js with <code>React Native</code></a></li>
-<li><a href="./UNIQUE_SETUPS.md#using-xrpljs-with-vite-react">Using xrpl.js with <code>Vite React</code></a></li>
-<li><a href="./UNIQUE_SETUPS.md#using-xrpljs-with-deno">Using xrpl.js with <code>Deno</code></a></li>
+<li><a href="https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-from-a-cdn">Using xrpl.js with a CDN</a></li>
+<li><a href="https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-create-react-app">Using xrpl.js with <code>create-react-app</code></a></li>
+<li><a href="https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-react-native">Using xrpl.js with <code>React Native</code></a></li>
+<li><a href="https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-vite-react">Using xrpl.js with <code>Vite React</code></a></li>
+<li><a href="https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-deno">Using xrpl.js with <code>Deno</code></a></li>
 </ul>
 <a id="md:documentation" class="tsd-anchor"></a><h2><a href="#md:documentation">Documentation</a></h2><p>As you develop with xrpl.js, there&#39;s two sites you&#39;ll use extensively:</p>
 <ol>


### PR DESCRIPTION
## High Level Overview of Change
The docs site js.xrpl.org has broken links for [Case by Case Setup Steps](https://js.xrpl.org/#md:case-by-case-setup-steps), this PR fixes it 
