### PR TITLE
fix: Fix invariant assertion in binary-codec

### DIFF
--- a/packages/ripple-binary-codec/src/serdes/binary-parser.ts
+++ b/packages/ripple-binary-codec/src/serdes/binary-parser.ts
@@ -75,7 +75,7 @@ class BinaryParser {
    * @return The number represented by those bytes
    */
   readUIntN(n: number): number {
-    if (0 >= n && n > 4) {
+    if (0 >= n || n > 4) {
       throw new Error('invalid n')
     }
     return this.read(n).reduce((a, b) => (a << 8) | b) >>> 0

--- a/packages/ripple-binary-codec/test/binary-parser.test.js
+++ b/packages/ripple-binary-codec/test/binary-parser.test.js
@@ -242,6 +242,12 @@ function fieldParsingTests() {
       new Error('Cannot read FieldOrdinal, type_code out of range'),
     )
   })
+  test('readUIntN', () => {
+    const parser = makeParser('0009')
+    expect(parser.readUIntN(2)).toEqual(9)
+    expect(() => parser.readUIntN(-1)).toThrow(new Error('invalid n'))
+    expect(() => parser.readUIntN(5)).toThrow(new Error('invalid n'))
+  })
 }
 
 function assertRecyclable(json, forField) {


### PR DESCRIPTION
## High Level Overview of Change

Found a tiny assertion typo while reviewing the merge in #2337

### Context of Change

This assertion was previously 
```
assert.ok(0 < n && n <= 4, 'invalid n')
```

And since the new version needs to invert the condition (since it throws when true instead of passing when true) the `&&` should be a `||`. 

Link to the line in the 2.x branch: https://github.com/XRPLF/xrpl.js/blob/bd46f1960499974d245e51ba45490cccba9e4517/packages/ripple-binary-codec/src/serdes/binary-parser.ts#L73C1-L74C1

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
