### PR TITLE
Fix typo in documentation: on('transactions') -> on('transaction')

### DIFF
--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -438,7 +438,7 @@ class Client extends EventEmitter {
    * ```ts
    * const api = new Client('wss://s.altnet.rippletest.net:51233')
    *
-   * api.on('transactions', (tx: TransactionStream) => {
+   * api.on('transaction', (tx: TransactionStream) => {
    *  console.log("Received Transaction")
    *  console.log(tx)
    * })


### PR DESCRIPTION
## High Level Overview of Change

Fixes typo in typedoc example comment.

### Context of Change

The documentation describing the client.on method provides an example where the 'transactions' event stream is listened to. This is a mistake as it should not be plural. This patch fixes it to demonstrate listening on the 'transaction' event stream

### Type of Change

- [X] Documentation Updates


## Test Plan

Copy the example and make sure it works! :smile: 
