### PR TITLE
feat: remove `util` polyfill and fix `HISTORY.md`

### DIFF
--- a/packages/ripple-address-codec/HISTORY.md
+++ b/packages/ripple-address-codec/HISTORY.md
@@ -1,6 +1,10 @@
 # ripple-address-codec
 
 ## Unreleased
+### Breaking Changes
+* Bump typescript to 5.x
+* Remove Node 14 support
+* Remove `assert` dependency. If you were catching `AssertionError` you need to change to `Error`.
 
 ## 4.3.0 (2023-06-13)
 ### Added

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -1,6 +1,12 @@
 # ripple-binary-codec Release History
 
 ## Unreleased
+### Breaking Changes
+* Bump typescript to 5.x
+* Remove Node 14 support
+* Remove decimal.js and big-integer. Use `BigNumber` from `bignumber.js` instead of `Decimal` and the native `BigInt` instead of `bigInt`.
+* Remove `assert` dependency. If you were catching `AssertionError` you need to change to `Error`.
+
 
 ## 1.8.0 (2023-08-07)
 * Added Clawback transaction type

--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -1,6 +1,10 @@
 # ripple-keypairs Release History
 
 ## Unreleased
+### Breaking Changes
+* Bump typescript to 5.x
+* Remove Node 14 support
+* Remove `assert` dependency. If you were catching `AssertionError` you need to change to `Error`.
 * Fix `deriveKeypair` ignoring manual decoding algorithm. (Specifying algorithm=`ed25519` in `opts` now works on secrets like `sNa1...`)
 
 ## 1.3.0 (2023-06-13)

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,13 +3,42 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 ## Unreleased
 
+### Breaking Changes
+
+* Bump typescript to 5.x
+* Remove Node 14 support
+* Remove `assert` dependency. If you were catching `AssertionError` you need to change to `Error`
+* Configuring a proxy:
+  * Instead of passing various parameters on the `ConnectionsOptions` you know specify the `agent` parameter. This object can use be created by libraries such as `https-proxy-agent` or any that implements the `http.Agent`.
+  * This was changed to both support the latest `https-proxy-agent` and to remove the need to include the package in bundlers.   Tests will still be done using `https-proxy-agent` and only tested in a node environment which was the only way it was previously supported anyway
+* Remove `BroadcastClient` which was deprecated
+
+### Bundling Changes
+* Bundler configurations are much more simplified.
+  * removed the following polyfills:
+    * `assert`
+    * `buffer`
+    * `https-browserify`
+    * `os-browserify`
+    * `stream-browserify`
+    * `stream-http`
+    * `url`
+    * `util` - previously added automatically by `webpack`
+  * Removed mappings for:
+    * `ws` to `WsWrapper`
+    * Excluding `https-proxy-agent`
+
 ### Added
 * Add `walletFromSecretNumbers` to derive a wallet from [XLS-12](https://github.com/XRPLF/XRPL-Standards/issues/15). Currently only works with `secp256k1` keys, but will work with `ED25519` keys as part of 3.0 via [#2376](https://github.com/XRPLF/xrpl.js/pull/2376).
 
+### Changed
+* Remove `lodash` as a dependency
+* Remove many polyfills that were only used for testing in the browser
+* Remove `util` from bundle by switching `inspect` to `JSON.stringify`
+
 ### Fixed
 * Fixed Wallet.generate() ignoring the `algorithm` parameter (Only a problem once binary-codec fix for `derive_keypair` is added)
-* Fixed Wallet.fromSeed() ignoring the `algorithm` parameter
-* 
+
 ## 2.10.0 (2023-08-07)
 
 ### Added

--- a/packages/xrpl/src/errors.ts
+++ b/packages/xrpl/src/errors.ts
@@ -1,6 +1,4 @@
 /* eslint-disable max-classes-per-file -- Errors can be defined in the same file */
-import { inspect } from 'util'
-
 /**
  * Base Error class for xrpl.js. All Errors thrown by xrpl.js should throw
  * XrplErrors.
@@ -38,7 +36,7 @@ class XrplError extends Error {
   public toString(): string {
     let result = `[${this.name}(${this.message}`
     if (this.data) {
-      result += `, ${inspect(this.data)}`
+      result += `, ${JSON.stringify(this.data)}`
     }
     result += ')]'
     return result

--- a/packages/xrpl/test/client/errors.test.ts
+++ b/packages/xrpl/test/client/errors.test.ts
@@ -5,7 +5,7 @@ import { XrplError, NotFoundError } from '../../src'
 describe('client errors', function () {
   it('XrplError with data', async function () {
     const error = new XrplError('_message_', '_data_')
-    assert.strictEqual(error.toString(), "[XrplError(_message_, '_data_')]")
+    assert.strictEqual(error.toString(), '[XrplError(_message_, "_data_")]')
   })
 
   it('NotFoundError default message', async function () {


### PR DESCRIPTION
## High Level Overview of Change

- Remove `util` from bundle by switching `inspect` to `JSON.stringify`
- Update `HISTORY.md` with latest 3.0 changes

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
