### PR TITLE
docs: End of Life ripple-lib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,25 +268,6 @@ This should almost always be done using the [`xrpl-codec-gen`](https://github.co
    1. Highlights of important changes
 
 
-# ripple-lib 1.x releases
-
-- [ ] Publish the release to npm.
-
-  - [ ] If you are publishing a 1.x release to the `xrpl` package, use:
-
-        npm publish --tag ripple-lib
-
-    This prevents the release from taking the `latest` tag.
-
-For ripple-lib:
-
- - Have one of the ripple-lib package maintainers push to `ripple-lib` (npm package name). You can contact [@intelliot](https://github.com/intelliot) to request the npm publish.
-- For ripple-lib releases, cross-publish the package to `xrpl` with `--tag ripple-lib`
-  - [Here's why](https://blog.greenkeeper.io/one-simple-trick-for-javascript-package-maintainers-to-avoid-breaking-their-user-s-software-and-to-6edf06dc5617).
-
-- https://www.npmjs.com/package/ripple-lib
-- https://www.npmjs.com/package/xrpl
-
 ## Mailing Lists
 
 We have a low-traffic mailing list for announcements of new `xrpl.js` releases. (About 1 email every couple of weeks)

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -1,4 +1,4 @@
-# xrpl.js (ripple-lib) Release History
+# xrpl.js Release History
 
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 


### PR DESCRIPTION
## High Level Overview of Change

With xrpl@3.0 coming out we are fully ending support for ripple-lib

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Documentation Updates
