### PR TITLE
fix docs broken links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ It goes through:
 
 If you're using xrpl.js with React or Deno, you'll need to do a couple extra steps to set it up:
 
-- [Using xrpl.js with a CDN](./UNIQUE_SETUPS.md#using-xrpljs-from-a-cdn)
-- [Using xrpl.js with `create-react-app`](./UNIQUE_SETUPS.md#using-xrpljs-with-create-react-app)
-- [Using xrpl.js with `React Native`](./UNIQUE_SETUPS.md#using-xrpljs-with-react-native)
-- [Using xrpl.js with `Vite React`](./UNIQUE_SETUPS.md#using-xrpljs-with-vite-react)
-- [Using xrpl.js with `Deno`](./UNIQUE_SETUPS.md#using-xrpljs-with-deno)
+- [Using xrpl.js with a CDN](https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-from-a-cdn)
+- [Using xrpl.js with `create-react-app`](https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-create-react-app)
+- [Using xrpl.js with `React Native`](https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-react-native)
+- [Using xrpl.js with `Vite React`](https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-vite-react)
+- [Using xrpl.js with `Deno`](https://github.com/XRPLF/xrpl.js/blob/main/UNIQUE_SETUPS.md#using-xrpljs-with-deno)
 
 ## Documentation
 


### PR DESCRIPTION
## High Level Overview of Change
 Unique setup links on docs are broken because they are relative links which aren't generated in js.xrpl.org, changed the links to guide back to github pages. 

### Type of Change
<!--
Please check relevant options, delete irrelevant ones.
-->
- [X ] Bug fix (non-breaking change which fixes an issue)
