### PR TITLE
fix: add AMM to BaseLedgerEntry and AccountObject types

### DIFF
--- a/packages/xrpl/src/models/ledger/AMM.ts
+++ b/packages/xrpl/src/models/ledger/AMM.ts
@@ -75,4 +75,12 @@ export default interface AMM extends BaseLedgerEntry {
    * type, so this value is always 0.
    */
   Flags: 0
+  /**
+   * This field is missing on AMM but is present on all other account_object returned objects.
+   */
+  PreviousTxnID: never
+  /**
+   * This field is missing on AMM but is present on all other account_object returned objects.
+   */
+  PreviousTxnLgrSeq: never
 }

--- a/packages/xrpl/src/models/ledger/AccountRoot.ts
+++ b/packages/xrpl/src/models/ledger/AccountRoot.ts
@@ -39,6 +39,12 @@ export default interface AccountRoot extends BaseLedgerEntry {
    */
   AccountTxnID?: string
   /**
+   * The ledger entry ID of the corresponding AMM ledger entry.
+   * Set during account creation; cannot be modified.
+   * If present, indicates that this is a special AMM AccountRoot; always omitted on non-AMM accounts.
+   */
+  AMMID?: string
+  /**
    * A domain associated with this account. In JSON, this is the hexadecimal
    * for the ASCII representation of the domain.
    */

--- a/packages/xrpl/src/models/ledger/index.ts
+++ b/packages/xrpl/src/models/ledger/index.ts
@@ -3,7 +3,7 @@ import AccountRoot, {
   AccountRootFlagsInterface,
 } from './AccountRoot'
 import Amendments, { Majority, AMENDMENTS_ID } from './Amendments'
-import AMM from './AMM'
+import AMM, { VoteSlot } from './AMM'
 import Check from './Check'
 import DepositPreauth from './DepositPreauth'
 import DirectoryNode from './DirectoryNode'
@@ -57,4 +57,5 @@ export {
   SignerList,
   SignerListFlags,
   Ticket,
+  VoteSlot,
 }

--- a/packages/xrpl/src/models/ledger/index.ts
+++ b/packages/xrpl/src/models/ledger/index.ts
@@ -3,6 +3,7 @@ import AccountRoot, {
   AccountRootFlagsInterface,
 } from './AccountRoot'
 import Amendments, { Majority, AMENDMENTS_ID } from './Amendments'
+import AMM from './AMM'
 import Check from './Check'
 import DepositPreauth from './DepositPreauth'
 import DirectoryNode from './DirectoryNode'
@@ -30,6 +31,7 @@ export {
   AccountRootFlagsInterface,
   AMENDMENTS_ID,
   Amendments,
+  AMM,
   Check,
   DepositPreauth,
   DirectoryNode,

--- a/packages/xrpl/src/models/methods/accountObjects.ts
+++ b/packages/xrpl/src/models/methods/accountObjects.ts
@@ -1,4 +1,5 @@
 import {
+  AMM,
   Check,
   DepositPreauth,
   Escrow,
@@ -12,6 +13,7 @@ import {
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 export type AccountObjectType =
+  | 'amm'
   | 'check'
   | 'deposit_preauth'
   | 'escrow'
@@ -64,6 +66,7 @@ export interface AccountObjectsRequest
  * PayChannel, a SignerList, a Ticket, or a RippleState.
  */
 export type AccountObject =
+  | AMM
   | Check
   | DepositPreauth
   | Escrow

--- a/packages/xrpl/src/models/methods/ammInfo.ts
+++ b/packages/xrpl/src/models/methods/ammInfo.ts
@@ -12,6 +12,11 @@ export interface AMMInfoRequest extends BaseRequest {
   command: 'amm_info'
 
   /**
+   * The address of the AMM Account to look up.
+   */
+  amm_account: string
+
+  /**
    * One of the assets of the AMM pool to look up.
    */
   asset: Currency

--- a/packages/xrpl/src/models/methods/ammInfo.ts
+++ b/packages/xrpl/src/models/methods/ammInfo.ts
@@ -14,17 +14,17 @@ export interface AMMInfoRequest extends BaseRequest {
   /**
    * The address of the AMM Account to look up.
    */
-  amm_account: string
+  amm_account?: string
 
   /**
    * One of the assets of the AMM pool to look up.
    */
-  asset: Currency
+  asset?: Currency
 
   /**
    * The other asset of the AMM pool.
    */
-  asset2: Currency
+  asset2?: Currency
 }
 
 /**


### PR DESCRIPTION
## High Level Overview of Change

- Add AMM to BaseLedgerEntry and AccountObject types.
- Add `amm_account` to `amm_info` request
- Add `AMMID` to `AccountRoot`

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

All tests pass.