### PR TITLE
fix: Avoid casting when using `Currency` type for AMM objects

### DIFF
--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -2,6 +2,7 @@ export type LedgerIndex = number | ('validated' | 'closed' | 'current')
 
 export interface XRP {
   currency: 'XRP'
+  issuer: never
 }
 
 export interface IssuedCurrency {


### PR DESCRIPTION
## High Level Overview of Change

Makes the interface of `XRP` and `IssuedCurrency` compatible to avoid casting when referencing `Currency.issuer`

### Context of Change

Found when trying to access `Currency.issuer` in the explorer while trying to add the support for `AMMDelete`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Manually via type checking when experimenting with types in the explorer.

<!--
## Future Tasks
For future tasks related to PR.
-->
