### PR TITLE
doc: update HISTORY.md with source-map fix

### DIFF
--- a/packages/ripple-address-codec/HISTORY.md
+++ b/packages/ripple-address-codec/HISTORY.md
@@ -1,6 +1,8 @@
 # ripple-address-codec
 
 ## Unreleased
+
+### Fixed
 * Fix source-maps not finding their designated source
 
 ## 4.3.0 (2023-06-13)

--- a/packages/ripple-address-codec/HISTORY.md
+++ b/packages/ripple-address-codec/HISTORY.md
@@ -1,6 +1,7 @@
 # ripple-address-codec
 
 ## Unreleased
+* Fix source-maps not finding their designated source
 
 ## 4.3.0 (2023-06-13)
 ### Added

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -7,6 +7,7 @@
 ### Added
 * Add AMM support [XLS-30](https://github.com/XRPLF/XRPL-Standards/discussions/78)
 * Updated to include latest updates to `definitions.json`.
+* Fix source-maps not finding their designated source
 
 ## 1.8.0 (2023-08-07)
 

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -7,6 +7,8 @@
 ### Added
 * Add AMM support [XLS-30](https://github.com/XRPLF/XRPL-Standards/discussions/78)
 * Updated to include latest updates to `definitions.json`.
+
+### Fixed
 * Fix source-maps not finding their designated source
 
 ## 1.8.0 (2023-08-07)

--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -1,6 +1,8 @@
 # ripple-keypairs Release History
 
 ## Unreleased
+
+### Fixed
 * Fix source-maps not finding their designated source
 
 ## 1.3.0 (2023-06-13)

--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -1,6 +1,7 @@
 # ripple-keypairs Release History
 
 ## Unreleased
+* Fix source-maps not finding their designated source
 
 ## 1.3.0 (2023-06-13)
 ### Added

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -8,6 +8,8 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ### Added
 * Add AMM support [XLS-30](https://github.com/XRPLF/XRPL-Standards/discussions/78)
 * Add `walletFromSecretNumbers` to derive a wallet from [XLS-12](https://github.com/XRPLF/XRPL-Standards/issues/15). Currently only works with `secp256k1` keys, but will work with `ED25519` keys as part of 3.0 via [#2376](https://github.com/XRPLF/xrpl.js/pull/2376).
+
+### Fixed
 * Fix source-maps not finding their designated source
 
 ## 2.10.0 (2023-08-07)

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -8,6 +8,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ### Added
 * Add AMM support [XLS-30](https://github.com/XRPLF/XRPL-Standards/discussions/78)
 * Add `walletFromSecretNumbers` to derive a wallet from [XLS-12](https://github.com/XRPLF/XRPL-Standards/issues/15). Currently only works with `secp256k1` keys, but will work with `ED25519` keys as part of 3.0 via [#2376](https://github.com/XRPLF/xrpl.js/pull/2376).
+* Fix source-maps not finding their designated source
 
 ## 2.10.0 (2023-08-07)
 


### PR DESCRIPTION
## High Level Overview of Change

This was missed when I did #2435 which led to `ripple-address-codec` and `ripple-keypairs` not being released.

### Type of Change

- [x] Documentation Updates

### Did you update HISTORY.md?

- [x] Yes