### PR TITLE
fix: remove need to --force builds + cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15657,7 +15657,7 @@
     "packages/secret-numbers": {
       "name": "@xrplf/secret-numbers",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
         "brorand": "^1.1.0",
         "ripple-keypairs": "^1.3.0"

--- a/packages/ripple-address-codec/package.json
+++ b/packages/ripple-address-codec/package.json
@@ -23,7 +23,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "jest --verbose false --silent=false ./test/*.test.ts",
     "lint": "eslint . --ext .ts",
-    "clean": "rm -rf ./dist && rm -rf ./coverage && rm -rf tsconfig.tsbuildinfo"
+    "clean": "rm -rf ./dist ./coverage ./test/testCompiledForWeb tsconfig.build.tsbuildinfo"
   },
   "prettier": "@xrplf/prettier-config",
   "engines": {

--- a/packages/ripple-binary-codec/package.json
+++ b/packages/ripple-binary-codec/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "tsc -b && copyfiles ./src/enums/definitions.json ./dist/enums/",
-    "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
+    "clean": "rm -rf ./dist ./coverage tsconfig.tsbuildinfo",
     "prepublishOnly": "npm test",
     "test": "npm run build && jest --verbose false --silent=false ./test/*.test.js",
     "lint": "eslint . --ext .ts --ext .test.js"

--- a/packages/ripple-keypairs/package.json
+++ b/packages/ripple-keypairs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "jest --verbose false --silent=false ./test/*.test.ts",
-    "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
+    "clean": "rm -rf ./dist ./coverage tsconfig.tsbuildinfo",
     "lint": "eslint . --ext .ts",
     "prepublish": "npm run lint && npm test"
   },

--- a/packages/secret-numbers/package.json
+++ b/packages/secret-numbers/package.json
@@ -8,11 +8,11 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepublish": "npm run clean && npm run lint && npm run test && npm run test:browser && npm run build",
-    "clean": "rm -rf dist build coverage",
+    "clean": "rm -rf ./dist ./coverage ./test/testCompiledForWeb tsconfig.build.tsbuildinfo",
     "test": "jest --verbose",
     "test:browser": "npm run build && npm run build:browserTests && karma start ./karma.config.js --single-run",
     "build": "run-s build:lib build:web",
-    "build:lib": "tsc --build tsconfig.build.json --force",
+    "build:lib": "tsc --build tsconfig.build.json",
     "build:web": "webpack",
     "build:browserTests": "webpack --config ./test/webpack.config.js",
     "lint": "eslint . --ext .ts --ext .test.ts --fix",

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -55,7 +55,7 @@
     "build:browserTests": "webpack --config ./test/webpack.config.js",
     "analyze": "webpack --analyze",
     "watch": "run-s build:lib --watch",
-    "clean": "rm -rf dist build coverage",
+    "clean": "rm -rf ./dist ./coverage ./test/testCompiledForWeb tsconfig.build.tsbuildinfo",
     "docgen": "tsc --build tsconfig.docs.json && typedoc && echo js.xrpl.org >> ../../docs/CNAME",
     "prepublish": "run-s clean build",
     "test": "jest --config=jest.config.unit.js --verbose false --silent=false",


### PR DESCRIPTION
## High Level Overview of Change

This is done by properly deleting all build files.

`package-lock.json` was due to it not reflecting the license of @xrplf/secret-numbers.  This was fixed by running `npm i`.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change that only restructures code)

### Did you update HISTORY.md?

- [x] No, this change does not impact library users