### PR TITLE
docs: Remove TODO with rippled version check

### DIFF
--- a/packages/xrpl/src/sugar/autofill.ts
+++ b/packages/xrpl/src/sugar/autofill.ts
@@ -176,8 +176,6 @@ function txNeedsNetworkID(client: Client): boolean {
     client.networkID !== undefined &&
     client.networkID > RESTRICTED_NETWORKS
   ) {
-    // TODO: remove the buildVersion logic when 1.11.0 is out and widely used.
-    // Issue: https://github.com/XRPLF/xrpl.js/issues/2339
     if (
       (client.buildVersion &&
         isNotLaterRippledVersion(


### PR DESCRIPTION
## High Level Overview of Change

We decided to keep the version check because not everyone operates with the same version of rippled, even if there is wide adoption for newer versions.

### Context of Change

Closes #2339

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

### Did you update HISTORY.md?

- [ ] Yes
- [X] No, this change does not impact library users

## Test Plan

N/A

<!--
## Future Tasks
For future tasks related to PR.
-->
