### PR TITLE
feat: Add optional CTID field to Tx

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,6 +3,9 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 ## Unreleased
 
+### Added
+* Add support for Concise Transaction Identifier (ctid) as defined in [XLS-37](https://github.com/XRPLF/XRPL-Standards/discussions/91)
+
 ## Fixed
 * Fix request model fields related to AMM
 

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -44,6 +44,11 @@ export interface TxResponse<T extends BaseTransaction = Transaction>
   result: {
     /** The SHA-512 hash of the transaction. */
     hash: string
+    /**
+     * The Concise Transaction Identifier of the transaction (16-byte hex string)
+     * Not included in responses from reporting mode servers.
+     */
+    ctid?: string
     /** The ledger index of the ledger that includes this transaction. */
     ledger_index?: number
     /** Transaction metadata, which describes the results of the transaction.


### PR DESCRIPTION
## High Level Overview of Change

Add a field for the Concise Transaction ID that was added in rippled 1.12

### Context of Change

Added to rippled via: https://github.com/XRPLF/rippled/pull/4418

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

### Did you update HISTORY.md?

- [X] Yes

## Test Plan

CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
