### PR TITLE
fix: rename `AMMAccount` to `Account` on `AMM`

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -9,6 +9,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ### Fixed
 * Fix request model fields related to AMM
+* Rename `AMMAccount` to `Account` on `AMM` ledger objects
 * Fixed `EscrowCancel` and `EscrowFinish` validation
 
 ## 2.11.0 (2023-08-24)

--- a/packages/xrpl/src/models/ledger/AMM.ts
+++ b/packages/xrpl/src/models/ledger/AMM.ts
@@ -20,7 +20,7 @@ export default interface AMM extends BaseLedgerEntry {
   /**
    * The address of the special account that holds this AMM's assets.
    */
-  AMMAccount: string
+  Account: string
   /**
    * The definition for one of the two assets this AMM holds.
    */


### PR DESCRIPTION
## High Level Overview of Change

The `AMM` ledger object had the wrong property name

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users