### PR TITLE
fix: allow flag maps when submitting NFToken txs

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 
+### Fixed
+- Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
+
 ## 2.12.0 (2023-09-27)
 ### Added
 * Added `ports` field to `ServerInfoResponse`

--- a/packages/xrpl/src/models/utils/flags.ts
+++ b/packages/xrpl/src/models/utils/flags.ts
@@ -10,6 +10,8 @@ import { AccountSetTfFlags } from '../transactions/accountSet'
 import { AMMDepositFlags } from '../transactions/AMMDeposit'
 import { AMMWithdrawFlags } from '../transactions/AMMWithdraw'
 import { GlobalFlags } from '../transactions/common'
+import { NFTokenCreateOfferFlags } from '../transactions/NFTokenCreateOffer'
+import { NFTokenMintFlags } from '../transactions/NFTokenMint'
 import { OfferCreateFlags } from '../transactions/offerCreate'
 import { PaymentFlags } from '../transactions/payment'
 import { PaymentChannelClaimFlags } from '../transactions/paymentChannelClaim'
@@ -43,6 +45,19 @@ export function parseAccountRootFlags(
   return flagsInterface
 }
 
+const txToFlag = {
+  AccountSet: AccountSetTfFlags,
+  AMMDeposit: AMMDepositFlags,
+  AMMWithdraw: AMMWithdrawFlags,
+  NFTokenCreateOffer: NFTokenCreateOfferFlags,
+  NFTokenMint: NFTokenMintFlags,
+  OfferCreate: OfferCreateFlags,
+  PaymentChannelClaim: PaymentChannelClaimFlags,
+  Payment: PaymentFlags,
+  TrustSet: TrustSetFlags,
+  XChainModifyBridge: XChainModifyBridgeFlags,
+}
+
 /**
  * Sets a transaction's flags to its numeric representation.
  *
@@ -57,34 +72,9 @@ export function setTransactionFlagsToNumber(tx: Transaction): void {
     return
   }
 
-  switch (tx.TransactionType) {
-    case 'AccountSet':
-      tx.Flags = convertFlagsToNumber(tx.Flags, AccountSetTfFlags)
-      return
-    case 'AMMDeposit':
-      tx.Flags = convertFlagsToNumber(tx.Flags, AMMDepositFlags)
-      return
-    case 'AMMWithdraw':
-      tx.Flags = convertFlagsToNumber(tx.Flags, AMMWithdrawFlags)
-      return
-    case 'OfferCreate':
-      tx.Flags = convertFlagsToNumber(tx.Flags, OfferCreateFlags)
-      return
-    case 'PaymentChannelClaim':
-      tx.Flags = convertFlagsToNumber(tx.Flags, PaymentChannelClaimFlags)
-      return
-    case 'Payment':
-      tx.Flags = convertFlagsToNumber(tx.Flags, PaymentFlags)
-      return
-    case 'TrustSet':
-      tx.Flags = convertFlagsToNumber(tx.Flags, TrustSetFlags)
-      return
-    case 'XChainModifyBridge':
-      tx.Flags = convertFlagsToNumber(tx.Flags, XChainModifyBridgeFlags)
-      return
-    default:
-      tx.Flags = 0
-  }
+  tx.Flags = txToFlag[tx.TransactionType]
+    ? convertFlagsToNumber(tx.Flags, txToFlag[tx.TransactionType])
+    : 0
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- added ValidationError check for flagEnum

--- a/packages/xrpl/test/models/NFTokenCreateOffer.test.ts
+++ b/packages/xrpl/test/models/NFTokenCreateOffer.test.ts
@@ -32,7 +32,9 @@ describe('NFTokenCreateOffer', function () {
       TransactionType: 'NFTokenCreateOffer',
       NFTokenID: NFTOKEN_ID,
       Amount: '1',
-      Flags: NFTokenCreateOfferFlags.tfSellNFToken,
+      Flags: {
+        tfSellNFToken: true,
+      },
       Expiration: 1000,
       Destination: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',

--- a/packages/xrpl/test/models/NFTokenMint.test.ts
+++ b/packages/xrpl/test/models/NFTokenMint.test.ts
@@ -19,7 +19,9 @@ describe('NFTokenMint', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Fee: '5000000',
       Sequence: 2470665,
-      Flags: NFTokenMintFlags.tfTransferable,
+      Flags: {
+        tfTransferable: true,
+      },
       NFTokenTaxon: 0,
       Issuer: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
       TransferFee: 1,


### PR DESCRIPTION
## High Level Overview of Change

You can now `NFTokenMint` and `NFTokenCreateOffer` transactions with `Flags` set to a map like other transactions with flags do.

ex. `{ tfSellNFToken: true }`

This also cleans up the code around choosing which flags map to which transactions.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users