### PR TITLE
Update the dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: monthly
+    interval: weekly
     time: "15:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
## High Level Overview of Change

Changes the dependabot interval to weekly

### Context of Change

Closes #2394 - There's unfortunately no option for twice a month, but weekly should be about as good. Anything which keeps getting re-opened we can use the dependabot commands to indicate our preferences for when to be notified about changes. (E.g. on the next major version)

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Automations

### Did you update HISTORY.md?

- [X] No, this change does not impact library users

## Test Plan

N/A

<!--
## Future Tasks
For future tasks related to PR.
-->
