### PR TITLE
docs: Update xrpl.js keywords to make it easier to find

### DIFF
--- a/packages/ripple-address-codec/package.json
+++ b/packages/ripple-address-codec/package.json
@@ -13,6 +13,12 @@
     "base-x": "^3.0.9",
     "create-hash": "^1.1.2"
   },
+  "keywords": [
+    "ripple",
+    "xrp",
+    "xrp ledger",
+    "xrpl"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:XRPLF/xrpl.js.git"

--- a/packages/ripple-binary-codec/package.json
+++ b/packages/ripple-binary-codec/package.json
@@ -25,6 +25,12 @@
     "test": "npm run build && jest --verbose false --silent=false ./test/*.test.js",
     "lint": "eslint . --ext .ts --ext .test.js"
   },
+  "keywords": [
+    "ripple",
+    "xrp",
+    "xrp ledger",
+    "xrpl"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:XRPLF/xrpl.js.git"

--- a/packages/ripple-keypairs/package.json
+++ b/packages/ripple-keypairs/package.json
@@ -24,6 +24,12 @@
     "hash.js": "^1.0.3",
     "ripple-address-codec": "^4.3.1"
   },
+  "keywords": [
+    "ripple",
+    "xrp",
+    "xrp ledger",
+    "xrpl"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:XRPLF/xrpl.js.git"

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -80,6 +80,10 @@
     "url": "git@github.com:XRPLF/xrpl.js.git"
   },
   "readmeFilename": "README.md",
+  "keywords": [
+    "ripple-lib",
+    "ripple"
+  ],
   "engines": {
     "node": ">=10.13.0"
   }

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -82,7 +82,10 @@
   "readmeFilename": "README.md",
   "keywords": [
     "ripple-lib",
-    "ripple"
+    "ripple",
+    "xrp",
+    "xrp ledger",
+    "xrpl"
   ],
   "engines": {
     "node": ">=10.13.0"


### PR DESCRIPTION
## High Level Overview of Change

Since we've deprecated ripple-lib, we should make xrpl.js show up when they search for that instead. 

### Context of Change

Helping to make xrpl.js more discoverable, especially for people who knew older names for the library.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

### Did you update HISTORY.md?

- [X] No, this change does not impact library users

## Test Plan

Inspection + Search npm for ripple-lib after the next release and see if this shows up.

<!--
## Future Tasks
For future tasks related to PR.
-->
