### PR TITLE
fix: add `type` param to `ledger` & `ledger_data`

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -5,11 +5,14 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ## Unreleased
 
 ### Fixed
-- Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
-- Add pseudo transaction types to `tx` and `ledger` methods responses.
+* Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
+* Add pseudo transaction types to `tx` and `ledger` method responses.
+* Add missing `type` param to `ledger_data` and `ledger` requests
+* Type assertions around `PreviousTxnID` and `PreviousTxnLgrSeq` missing on some ledger objects
 
 ### Updated
-- Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
+* Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
+* Clean up typing of `type` param and the response property `account_objects` of the `account_objects` request.
 
 ## 2.12.0 (2023-09-27)
 ### Added

--- a/packages/xrpl/src/models/ledger/AMM.ts
+++ b/packages/xrpl/src/models/ledger/AMM.ts
@@ -1,6 +1,6 @@
 import { AuthAccount, Currency, IssuedCurrencyAmount } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, MissingPreviousTxnID } from './BaseLedgerEntry'
 
 export interface VoteSlot {
   VoteEntry: {
@@ -15,7 +15,7 @@ export interface VoteSlot {
  *
  * @category Ledger Entries
  */
-export default interface AMM extends BaseLedgerEntry {
+export default interface AMM extends BaseLedgerEntry, MissingPreviousTxnID {
   LedgerEntryType: 'AMM'
   /**
    * The address of the special account that holds this AMM's assets.
@@ -75,12 +75,4 @@ export default interface AMM extends BaseLedgerEntry {
    * type, so this value is always 0.
    */
   Flags: 0
-  /**
-   * This field is missing on AMM but is present on all other account_object returned objects.
-   */
-  PreviousTxnID: never
-  /**
-   * This field is missing on AMM but is present on all other account_object returned objects.
-   */
-  PreviousTxnLgrSeq: never
 }

--- a/packages/xrpl/src/models/ledger/AccountRoot.ts
+++ b/packages/xrpl/src/models/ledger/AccountRoot.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The AccountRoot object type describes a single account, its settings, and
@@ -6,7 +6,7 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface AccountRoot extends BaseLedgerEntry {
+export default interface AccountRoot extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'AccountRoot'
   /** The identifying (classic) address of this account. */
   Account: string
@@ -19,16 +19,6 @@ export default interface AccountRoot extends BaseLedgerEntry {
    * to its owner reserve.
    */
   OwnerCount: number
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
   /** The sequence number of the next valid transaction for this account. */
   Sequence: number
   /**

--- a/packages/xrpl/src/models/ledger/Amendments.ts
+++ b/packages/xrpl/src/models/ledger/Amendments.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, MissingPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The unique id for the Amendments object https://xrpl.org/amendments-object.html#amendments-id-format
@@ -24,7 +24,9 @@ export interface Majority {
  *
  * @category Ledger Entries
  */
-export default interface Amendments extends BaseLedgerEntry {
+export default interface Amendments
+  extends BaseLedgerEntry,
+    MissingPreviousTxnID {
   LedgerEntryType: 'Amendments'
   /**
    * Array of 256-bit amendment IDs for all currently-enabled amendments. If

--- a/packages/xrpl/src/models/ledger/BaseLedgerEntry.ts
+++ b/packages/xrpl/src/models/ledger/BaseLedgerEntry.ts
@@ -1,3 +1,27 @@
-export default interface BaseLedgerEntry {
+export interface BaseLedgerEntry {
   index: string
+}
+
+export interface HasPreviousTxnID {
+  /**
+   * The identifying hash of the transaction that most recently modified this
+   * object.
+   */
+  PreviousTxnID: string
+  /**
+   * The index of the ledger that contains the transaction that most recently
+   * modified this object.
+   */
+  PreviousTxnLgrSeq: number
+}
+
+export interface MissingPreviousTxnID {
+  /**
+   * This field is missing on this object but is present on most other returned objects.
+   */
+  PreviousTxnID: never
+  /**
+   * This field is missing on this object but is present on most other returned objects.
+   */
+  PreviousTxnLgrSeq: never
 }

--- a/packages/xrpl/src/models/ledger/Bridge.ts
+++ b/packages/xrpl/src/models/ledger/Bridge.ts
@@ -1,6 +1,6 @@
 import { Amount, XChainBridge } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * A Bridge objects represents a cross-chain bridge and includes information about
@@ -9,7 +9,7 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface Bridge extends BaseLedgerEntry {
+export default interface Bridge extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'Bridge'
 
   /** The door account that owns the bridge. */
@@ -69,16 +69,4 @@ export default interface Bridge extends BaseLedgerEntry {
    * object, in case the directory consists of multiple pages.
    */
   OwnerNode: string
-
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
 }

--- a/packages/xrpl/src/models/ledger/Check.ts
+++ b/packages/xrpl/src/models/ledger/Check.ts
@@ -1,6 +1,6 @@
 import { Amount } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * A Check object describes a check, similar to a paper personal check, which
@@ -8,7 +8,7 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface Check extends BaseLedgerEntry {
+export default interface Check extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'Check'
   /** The sender of the Check. Cashing the Check debits this address's balance. */
   Account: string

--- a/packages/xrpl/src/models/ledger/DepositPreauth.ts
+++ b/packages/xrpl/src/models/ledger/DepositPreauth.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * A DepositPreauth object tracks a preauthorization from one account to
@@ -6,7 +6,9 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface DepositPreauth extends BaseLedgerEntry {
+export default interface DepositPreauth
+  extends BaseLedgerEntry,
+    HasPreviousTxnID {
   LedgerEntryType: 'DepositPreauth'
   /** The account that granted the preauthorization. */
   Account: string
@@ -22,14 +24,4 @@ export default interface DepositPreauth extends BaseLedgerEntry {
    * object, in case the directory consists of multiple pages.
    */
   OwnerNode: string
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
 }

--- a/packages/xrpl/src/models/ledger/DirectoryNode.ts
+++ b/packages/xrpl/src/models/ledger/DirectoryNode.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, MissingPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The DirectoryNode object type provides a list of links to other objects in
@@ -6,7 +6,9 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface DirectoryNode extends BaseLedgerEntry {
+export default interface DirectoryNode
+  extends BaseLedgerEntry,
+    MissingPreviousTxnID {
   LedgerEntryType: 'DirectoryNode'
   /**
    * A bit-map of boolean flags enabled for this directory. Currently, the

--- a/packages/xrpl/src/models/ledger/Escrow.ts
+++ b/packages/xrpl/src/models/ledger/Escrow.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The Escrow object type represents a held payment of XRP waiting to be
@@ -6,7 +6,7 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface Escrow extends BaseLedgerEntry {
+export default interface Escrow extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'Escrow'
   /**
    * The address of the owner (sender) of this held payment. This is the
@@ -61,14 +61,4 @@ export default interface Escrow extends BaseLedgerEntry {
    * this object, in case the directory consists of multiple pages.
    */
   DestinationNode?: string
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
 }

--- a/packages/xrpl/src/models/ledger/FeeSettings.ts
+++ b/packages/xrpl/src/models/ledger/FeeSettings.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, MissingPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The unique id for the FeeSettings object https://xrpl.org/feesettings.html#feesettings-id-format
@@ -26,7 +26,7 @@ export interface FeeSettingsPostAmendmentFields {
   ReserveIncrementDrops: string
 }
 
-export interface FeeSettingsBase extends BaseLedgerEntry {
+export interface FeeSettingsBase extends BaseLedgerEntry, MissingPreviousTxnID {
   LedgerEntryType: 'FeeSettings'
   /**
    * A bit-map of boolean flags for this object. No flags are defined for this type.

--- a/packages/xrpl/src/models/ledger/Ledger.ts
+++ b/packages/xrpl/src/models/ledger/Ledger.ts
@@ -1,7 +1,10 @@
-import { Transaction, TransactionMetadata } from '../transactions'
-import { PseudoTransaction } from '../transactions/transaction'
+import {
+  PseudoTransaction,
+  Transaction,
+  TransactionMetadata,
+} from '../transactions'
 
-import LedgerEntry from './LedgerEntry'
+import { LedgerEntry } from './LedgerEntry'
 
 /**
  * A ledger is a block of transactions and shared state data. It has a unique

--- a/packages/xrpl/src/models/ledger/LedgerEntry.ts
+++ b/packages/xrpl/src/models/ledger/LedgerEntry.ts
@@ -37,4 +37,25 @@ type LedgerEntry =
   | XChainOwnedClaimID
   | XChainOwnedCreateAccountClaimID
 
-export default LedgerEntry
+type LedgerEntryFilter =
+  | 'account'
+  | 'amendments'
+  | 'amm'
+  | 'bridge'
+  | 'check'
+  | 'deposit_preauth'
+  | 'directory'
+  | 'escrow'
+  | 'fee'
+  | 'hashes'
+  | 'nft_offer'
+  | 'nft_page'
+  | 'offer'
+  | 'payment_channel'
+  | 'signer_list'
+  | 'state'
+  | 'ticket'
+  | 'xchain_owned_create_account_claim_id'
+  | 'xchain_owned_claim_id'
+
+export { LedgerEntry, LedgerEntryFilter }

--- a/packages/xrpl/src/models/ledger/LedgerHashes.ts
+++ b/packages/xrpl/src/models/ledger/LedgerHashes.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, MissingPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The LedgerHashes objects exist to make it possible to look up a previous
@@ -7,7 +7,9 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface LedgerHashes extends BaseLedgerEntry {
+export default interface LedgerHashes
+  extends BaseLedgerEntry,
+    MissingPreviousTxnID {
   LedgerEntryType: 'LedgerHashes'
   /** The Ledger Index of the last entry in this object's Hashes array. */
   LastLedgerSequence?: number

--- a/packages/xrpl/src/models/ledger/NFTokenOffer.ts
+++ b/packages/xrpl/src/models/ledger/NFTokenOffer.ts
@@ -1,8 +1,8 @@
 import { Amount } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
-export interface NFTokenOffer extends BaseLedgerEntry {
+export interface NFTokenOffer extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'NFTokenOffer'
   Amount: Amount
   Destination?: string
@@ -11,6 +11,4 @@ export interface NFTokenOffer extends BaseLedgerEntry {
   NFTokenOfferNode?: string
   Owner: string
   OwnerNode?: string
-  PreviousTxnID: string
-  PreviousTxnLgrSeq: number
 }

--- a/packages/xrpl/src/models/ledger/NFTokenPage.ts
+++ b/packages/xrpl/src/models/ledger/NFTokenPage.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 export interface NFToken {
   NFToken: {
@@ -10,11 +10,9 @@ export interface NFToken {
   }
 }
 
-export interface NFTokenPage extends BaseLedgerEntry {
+export interface NFTokenPage extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'NFTokenPage'
   NextPageMin?: string
   NFTokens: NFToken[]
   PreviousPageMin?: string
-  PreviousTxnID?: string
-  PreviousTxnLgrSeq?: number
 }

--- a/packages/xrpl/src/models/ledger/NegativeUNL.ts
+++ b/packages/xrpl/src/models/ledger/NegativeUNL.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, MissingPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The unique id for the nUNL object https://xrpl.org/negativeunl.html#negativeunl-id-format
@@ -12,7 +12,9 @@ export const NEGATIVE_UNL_ID =
  *
  * @category Ledger Entries
  */
-export default interface NegativeUNL extends BaseLedgerEntry {
+export default interface NegativeUNL
+  extends BaseLedgerEntry,
+    MissingPreviousTxnID {
   LedgerEntryType: 'NegativeUNL'
   /**
    * A list of trusted validators that are currently disabled.

--- a/packages/xrpl/src/models/ledger/Offer.ts
+++ b/packages/xrpl/src/models/ledger/Offer.ts
@@ -1,8 +1,8 @@
 import { Amount } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
-export default interface Offer extends BaseLedgerEntry {
+export default interface Offer extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'Offer'
   /** A bit-map of boolean flags enabled for this Offer. */
   Flags: number
@@ -32,16 +32,6 @@ export default interface Offer extends BaseLedgerEntry {
    * in case the directory consists of multiple pages.
    */
   OwnerNode: string
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
   /** The time this Offer expires, in seconds since the Ripple Epoch. */
   Expiration?: number
 }

--- a/packages/xrpl/src/models/ledger/PayChannel.ts
+++ b/packages/xrpl/src/models/ledger/PayChannel.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The PayChannel object type represents a payment channel. Payment channels
@@ -9,7 +9,7 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface PayChannel extends BaseLedgerEntry {
+export default interface PayChannel extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'PayChannel'
   /**
    * The source address that owns this payment channel. This comes from the
@@ -60,16 +60,6 @@ export default interface PayChannel extends BaseLedgerEntry {
    * to this object, in case the directory consists of multiple pages.
    */
   OwnerNode: string
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
   /**
    * A bit-map of boolean flags enabled for this payment channel. Currently,
    * the protocol defines no flags for PayChannel objects.

--- a/packages/xrpl/src/models/ledger/RippleState.ts
+++ b/packages/xrpl/src/models/ledger/RippleState.ts
@@ -1,13 +1,13 @@
 import { IssuedCurrencyAmount } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The RippleState object type connects two accounts in a single currency.
  *
  * @category Ledger Entries
  */
-export default interface RippleState extends BaseLedgerEntry {
+export default interface RippleState extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'RippleState'
   /** A bit-map of boolean options enabled for this object. */
   Flags: number
@@ -27,16 +27,6 @@ export default interface RippleState extends BaseLedgerEntry {
    * the address of the high account that set this limit.
    */
   HighLimit: IssuedCurrencyAmount
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
   /**
    * A hint indicating which page of the low account's owner directory links to
    * this object, in case the directory consists of multiple pages.

--- a/packages/xrpl/src/models/ledger/SignerList.ts
+++ b/packages/xrpl/src/models/ledger/SignerList.ts
@@ -1,6 +1,6 @@
 import { SignerEntry } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The SignerList object type represents a list of parties that, as a group,
@@ -10,23 +10,13 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface SignerList extends BaseLedgerEntry {
+export default interface SignerList extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'SignerList'
   /**
    * A bit-map of Boolean flags enabled for this signer list. For more
    * information, see SignerList Flags.
    */
   Flags: number
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
   /**
    * A hint indicating which page of the owner directory links to this object,
    * in case the directory consists of multiple pages.

--- a/packages/xrpl/src/models/ledger/Ticket.ts
+++ b/packages/xrpl/src/models/ledger/Ticket.ts
@@ -1,4 +1,4 @@
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The Ticket object type represents a Ticket, which tracks an account sequence
@@ -7,7 +7,7 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface Ticket extends BaseLedgerEntry {
+export default interface Ticket extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'Ticket'
   /** The account that owns this Ticket. */
   Account: string
@@ -21,16 +21,6 @@ export default interface Ticket extends BaseLedgerEntry {
    * in case the directory consists of multiple pages.
    */
   OwnerNode: string
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
   /** The Sequence Number this Ticket sets aside. */
   TicketSequence: number
 }

--- a/packages/xrpl/src/models/ledger/XChainOwnedClaimID.ts
+++ b/packages/xrpl/src/models/ledger/XChainOwnedClaimID.ts
@@ -2,7 +2,7 @@ import { Amount } from 'ripple-binary-codec/dist/types'
 
 import { XChainBridge } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * An XChainOwnedClaimID object represents one cross-chain transfer of value
@@ -11,7 +11,9 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  *
  * @category Ledger Entries
  */
-export default interface XChainOwnedClaimID extends BaseLedgerEntry {
+export default interface XChainOwnedClaimID
+  extends BaseLedgerEntry,
+    HasPreviousTxnID {
   LedgerEntryType: 'XChainOwnedClaimID'
 
   /** The account that checked out this unique claim ID value. */
@@ -76,14 +78,4 @@ export default interface XChainOwnedClaimID extends BaseLedgerEntry {
    * object, in case the directory consists of multiple pages.
    */
   OwnerNode: string
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
 }

--- a/packages/xrpl/src/models/ledger/XChainOwnedCreateAccountClaimID.ts
+++ b/packages/xrpl/src/models/ledger/XChainOwnedCreateAccountClaimID.ts
@@ -1,6 +1,6 @@
 import { XChainBridge } from '../common'
 
-import BaseLedgerEntry from './BaseLedgerEntry'
+import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 /**
  * The XChainOwnedCreateAccountClaimID ledger object is used to collect attestations
@@ -9,7 +9,8 @@ import BaseLedgerEntry from './BaseLedgerEntry'
  * @category Ledger Entries
  */
 export default interface XChainOwnedCreateAccountClaimID
-  extends BaseLedgerEntry {
+  extends BaseLedgerEntry,
+    HasPreviousTxnID {
   LedgerEntryType: 'XChainOwnedCreateAccountClaimID'
 
   /** The account that owns this object. */
@@ -61,14 +62,4 @@ export default interface XChainOwnedCreateAccountClaimID
    * object, in case the directory consists of multiple pages.
    */
   OwnerNode: string
-  /**
-   * The identifying hash of the transaction that most recently modified this
-   * object.
-   */
-  PreviousTxnID: string
-  /**
-   * The index of the ledger that contains the transaction that most recently
-   * modified this object.
-   */
-  PreviousTxnLgrSeq: number
 }

--- a/packages/xrpl/src/models/ledger/index.ts
+++ b/packages/xrpl/src/models/ledger/index.ts
@@ -15,7 +15,7 @@ import FeeSettings, {
   FEE_SETTINGS_ID,
 } from './FeeSettings'
 import Ledger from './Ledger'
-import LedgerEntry from './LedgerEntry'
+import { LedgerEntry, LedgerEntryFilter } from './LedgerEntry'
 import LedgerHashes from './LedgerHashes'
 import NegativeUNL, { NEGATIVE_UNL_ID } from './NegativeUNL'
 import { NFTokenOffer } from './NFTokenOffer'
@@ -45,6 +45,7 @@ export {
   FeeSettingsPreAmendmentFields,
   FeeSettingsPostAmendmentFields,
   Ledger,
+  LedgerEntryFilter,
   LedgerEntry,
   LedgerHashes,
   Majority,

--- a/packages/xrpl/src/models/methods/accountObjects.ts
+++ b/packages/xrpl/src/models/methods/accountObjects.ts
@@ -1,35 +1,11 @@
-import {
-  AMM,
-  Bridge,
-  Check,
-  DepositPreauth,
-  Escrow,
-  Offer,
-  PayChannel,
-  RippleState,
-  SignerList,
-  Ticket,
-  XChainOwnedClaimID,
-  XChainOwnedCreateAccountClaimID,
-} from '../ledger'
-
+import { Amendments, FeeSettings, LedgerHashes } from '../ledger'
+import { LedgerEntry, LedgerEntryFilter } from '../ledger/LedgerEntry'
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
-export type AccountObjectType =
-  | 'amm'
-  | 'bridge'
-  | 'check'
-  | 'deposit_preauth'
-  | 'escrow'
-  | 'nft_offer'
-  | 'offer'
-  | 'payment_channel'
-  | 'signer_list'
-  | 'state'
-  | 'ticket'
-  | 'xchain_owned_create_account_claim_id'
-  | 'xchain_owned_claim_id'
-
+export type AccountObjectType = Exclude<
+  LedgerEntryFilter,
+  'amendments' | 'fee' | 'hashes'
+>
 /**
  * The account_objects command returns the raw ledger format for all objects
  * owned by an account. For a higher-level view of an account's trust lines and
@@ -46,8 +22,6 @@ export interface AccountObjectsRequest
   account: string
   /**
    * If included, filter results to include only this type of ledger object.
-   * The valid types are: Check , DepositPreauth, Escrow, Offer, PayChannel,
-   * SignerList, Ticket, and RippleState (trust line).
    */
   type?: AccountObjectType
   /**
@@ -71,19 +45,10 @@ export interface AccountObjectsRequest
  * Account Objects can be a Check, a DepositPreauth, an Escrow, an Offer, a
  * PayChannel, a SignerList, a Ticket, or a RippleState.
  */
-export type AccountObject =
-  | AMM
-  | Bridge
-  | Check
-  | DepositPreauth
-  | Escrow
-  | Offer
-  | PayChannel
-  | SignerList
-  | RippleState
-  | Ticket
-  | XChainOwnedClaimID
-  | XChainOwnedCreateAccountClaimID
+export type AccountObject = Exclude<
+  LedgerEntry,
+  Amendments | FeeSettings | LedgerHashes
+>
 
 /**
  * Response expected from an {@link AccountObjectsRequest}.

--- a/packages/xrpl/src/models/methods/accountObjects.ts
+++ b/packages/xrpl/src/models/methods/accountObjects.ts
@@ -1,5 +1,6 @@
 import { Amendments, FeeSettings, LedgerHashes } from '../ledger'
 import { LedgerEntry, LedgerEntryFilter } from '../ledger/LedgerEntry'
+
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
 export type AccountObjectType = Exclude<

--- a/packages/xrpl/src/models/methods/ledger.ts
+++ b/packages/xrpl/src/models/methods/ledger.ts
@@ -1,4 +1,5 @@
 import { Ledger } from '../ledger'
+import { LedgerEntryFilter } from '../ledger/LedgerEntry'
 import { Transaction, TransactionAndMetadata } from '../transactions'
 import { TransactionMetadata } from '../transactions/metadata'
 
@@ -65,6 +66,10 @@ export interface LedgerRequest extends BaseRequest, LookupByLedgerRequest {
    * array of queued transactions in the results.
    */
   queue?: boolean
+  /**
+   * If included, filter results to include only this type of ledger object.
+   */
+  type?: LedgerEntryFilter
 }
 
 /**

--- a/packages/xrpl/src/models/methods/ledgerData.ts
+++ b/packages/xrpl/src/models/methods/ledgerData.ts
@@ -1,4 +1,4 @@
-import { LedgerEntry } from '../ledger'
+import { LedgerEntry, LedgerEntryFilter } from '../ledger'
 
 import { BaseRequest, BaseResponse, LookupByLedgerRequest } from './baseMethod'
 
@@ -37,6 +37,10 @@ export interface LedgerDataRequest extends BaseRequest, LookupByLedgerRequest {
    * that response left off.
    */
   marker?: unknown
+  /**
+   * If included, filter results to include only this type of ledger object.
+   */
+  type?: LedgerEntryFilter
 }
 
 export type LedgerDataLabeledLedgerEntry = {


### PR DESCRIPTION
## High Level Overview of Change

- Add missing `type` param
- Clean up typing of `type` param and the response property `account_objects` of the `account_objects` request.
- Create interfaces `HasPreviousTxnID` and `MissingPreviousTxnID`. This helps clean up type checking with regard to the presence of `PreviousTxnID` and `MissingPreviousTxnID`

### Context of Change

This field was missing.

https://xrpl.org/ledger_data.html

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change that only restructures code)

### Did you update HISTORY.md?

- [x] Yes

## Test Plan

N/A
