### PR TITLE
feat: isomorphic sockets and use eventemitter3

### DIFF
--- a/UNIQUE_SETUPS.md
+++ b/UNIQUE_SETUPS.md
@@ -37,11 +37,6 @@ To use `xrpl.js` with React, you need to install shims for core NodeJS modules. 
       const webpack = require("webpack");
 
       module.exports = function override(config) {
-        const fallback = config.resolve.fallback || {};
-        Object.assign(fallback, {
-          ws: require.resolve("xrpl/dist/npm/client/WSWrapper"),
-        });
-        config.resolve.fallback = fallback;
         config.plugins = (config.plugins || []).concat([
           new webpack.ProvidePlugin({
             process: "process/browser",
@@ -127,30 +122,25 @@ export default defineConfig({
   },
   optimizeDeps: {
     esbuildOptions: {
-        define: {
-          global: 'globalThis',
-        },
-        plugins: [
-            NodeGlobalsPolyfillPlugin({
-                process: true,
-                buffer: true,
-            }),
-        ],
-    },
-},
-build: {
-  rollupOptions: {
+      define: {
+       global: 'globalThis',
+      },
       plugins: [
-          polyfillNode(),
+        NodeGlobalsPolyfillPlugin({ 
+          process: true, 
+          buffer: true, 
+        }),
+      ],
+    },
+  }, 
+  build: { 
+    rollupOptions: {
+      plugins: [
+        polyfillNode(),
       ]
-  }
-},
-resolve: {
-  alias: {
-    events: 'events',
-    ws: 'xrpl/dist/npm/client/WSWrapper',
+    } 
   },
-}})
+})
 ```
 
 3. Install the config dependencies and xrpl (e.g. using this command)
@@ -158,9 +148,7 @@ resolve: {
 ```shell
 npm install --save-dev @esbuild-plugins/node-globals-polyfill \
 		rollup-plugin-polyfill-node \
-		&& npm install
-		events \
-		xrpl
+		&& npm install xrpl
 ```
 
 ### Using xrpl.js with Deno

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@xrplf/isomorphic": "file:packages/isomorphic",
         "@xrplf/secret-numbers": "file:packages/secret-numbers",
+        "eventemitter3": "^5.0.1",
         "ripple-address-codec": "file:packages/ripple-address-codec",
         "ripple-binary-codec": "file:packages/ripple-binary-codec",
         "ripple-keypairs": "file:packages/ripple-keypairs",
@@ -39,7 +40,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-tsdoc": "^0.2.16",
-        "eventemitter2": "^6.0.0",
         "expect": "^29.3.1",
         "jest": "^29.3.1",
         "jest-mock": "^29.3.1",
@@ -3089,9 +3089,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
+      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -6721,17 +6721,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "dev": true
-    },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -7831,6 +7824,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/http-proxy/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -11681,6 +11680,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "node_modules/p-reduce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
@@ -15439,13 +15444,36 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@noble/hashes": "^1.0.0"
+        "@noble/hashes": "^1.0.0",
+        "eventemitter3": "5.0.1",
+        "ws": "^8.13.0"
       },
       "devDependencies": {
-        "@types/node": "^16.18.38"
+        "@types/node": "^16.18.38",
+        "@types/ws": "^8.5.6"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "packages/isomorphic/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/ripple-address-codec": {
@@ -15506,10 +15534,10 @@
         "@xrplf/secret-numbers": "^1.0.0",
         "bignumber.js": "^9.0.0",
         "cross-fetch": "^4.0.0",
+        "eventemitter3": "^5.0.1",
         "ripple-address-codec": "^4.3.1",
         "ripple-binary-codec": "^1.10.0",
-        "ripple-keypairs": "^1.3.1",
-        "ws": "^8.2.2"
+        "ripple-keypairs": "^1.3.1"
       },
       "devDependencies": {
         "@types/node": "^16.18.38",
@@ -15548,26 +15576,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "packages/xrpl/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     }
   },
@@ -18075,9 +18083,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
+      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -18422,7 +18430,18 @@
       "version": "file:packages/isomorphic",
       "requires": {
         "@noble/hashes": "^1.0.0",
-        "@types/node": "^16.18.38"
+        "@types/node": "^16.18.38",
+        "@types/ws": "^8.5.6",
+        "eventemitter3": "5.0.1",
+        "ws": "^8.13.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+          "requires": {}
+        }
       }
     },
     "@xrplf/prettier-config": {
@@ -20829,17 +20848,10 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "dev": true
-    },
     "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "events": {
       "version": "3.3.0",
@@ -21665,6 +21677,14 @@
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+          "dev": true
+        }
       }
     },
     "http-proxy-agent": {
@@ -24671,6 +24691,14 @@
       "requires": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+          "dev": true
+        }
       }
     },
     "p-reduce": {
@@ -27427,6 +27455,7 @@
         "@xrplf/secret-numbers": "^1.0.0",
         "bignumber.js": "^9.0.0",
         "cross-fetch": "^4.0.0",
+        "eventemitter3": "^5.0.1",
         "https-proxy-agent": "^7.0.1",
         "karma": "^6.4.1",
         "karma-chrome-launcher": "^3.1.1",
@@ -27438,8 +27467,7 @@
         "ripple-binary-codec": "^1.10.0",
         "ripple-keypairs": "^1.3.1",
         "run-s": "^0.0.0",
-        "typedoc": "^0.25.0",
-        "ws": "^8.2.2"
+        "typedoc": "^0.25.0"
       },
       "dependencies": {
         "agent-base": {
@@ -27456,12 +27484,6 @@
             "agent-base": "^7.0.2",
             "debug": "4"
           }
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "requires": {}
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@xrplf/isomorphic": "file:packages/isomorphic",
         "@xrplf/secret-numbers": "file:packages/secret-numbers",
-        "eventemitter3": "^5.0.1",
         "ripple-address-codec": "file:packages/ripple-address-codec",
         "ripple-binary-codec": "file:packages/ripple-binary-codec",
         "ripple-keypairs": "file:packages/ripple-keypairs",
@@ -15541,6 +15540,7 @@
       },
       "devDependencies": {
         "@types/node": "^16.18.38",
+        "eventemitter3": "^5.0.1",
         "https-proxy-agent": "^7.0.1",
         "karma": "^6.4.1",
         "karma-chrome-launcher": "^3.1.1",
@@ -15549,7 +15549,8 @@
         "lodash": "^4.17.4",
         "react": "^18.2.0",
         "run-s": "^0.0.0",
-        "typedoc": "^0.25.0"
+        "typedoc": "^0.25.0",
+        "ws": "^8.14.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -15576,6 +15577,27 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "packages/xrpl/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   },
@@ -27467,7 +27489,8 @@
         "ripple-binary-codec": "^1.10.0",
         "ripple-keypairs": "^1.3.1",
         "run-s": "^0.0.0",
-        "typedoc": "^0.25.0"
+        "typedoc": "^0.25.0",
+        "ws": "^8.14.2"
       },
       "dependencies": {
         "agent-base": {
@@ -27484,6 +27507,13 @@
             "agent-base": "^7.0.2",
             "debug": "4"
           }
+        },
+        "ws": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+          "dev": true,
+          "requires": {}
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@xrplf/isomorphic": "file:packages/isomorphic",
     "@xrplf/secret-numbers": "file:packages/secret-numbers",
+    "eventemitter3": "^5.0.1",
     "ripple-address-codec": "file:packages/ripple-address-codec",
     "ripple-binary-codec": "file:packages/ripple-binary-codec",
     "ripple-keypairs": "file:packages/ripple-keypairs",
@@ -44,7 +45,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-tsdoc": "^0.2.16",
-    "eventemitter2": "^6.0.0",
     "expect": "^29.3.1",
     "jest": "^29.3.1",
     "jest-mock": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@xrplf/isomorphic": "file:packages/isomorphic",
     "@xrplf/secret-numbers": "file:packages/secret-numbers",
-    "eventemitter3": "^5.0.1",
     "ripple-address-codec": "file:packages/ripple-address-codec",
     "ripple-binary-codec": "file:packages/ripple-binary-codec",
     "ripple-keypairs": "file:packages/ripple-keypairs",

--- a/packages/isomorphic/HISTORY.md
+++ b/packages/isomorphic/HISTORY.md
@@ -10,3 +10,4 @@ Initial release providing isomorphic and tree-shakable implementations of:
 - bytesToHash
 - hashToBytes
 - randomBytes
+- ws

--- a/packages/isomorphic/README.md
+++ b/packages/isomorphic/README.md
@@ -97,4 +97,8 @@ console.log(hexToBytes('DEADBEEF')) // [222, 173, 190, 239]
 
 ### `@xrplf/isomorphic/ws`
 
-// TODO: Websocket Wrapper and `ws`
+```typescript
+import WebSocket from '@xrplf/isomorphic/ws'
+
+const socket = new WebSocket('wss://localhost:8080')
+```

--- a/packages/isomorphic/package.json
+++ b/packages/isomorphic/package.json
@@ -21,16 +21,20 @@
     "sha512/*",
     "ripemd160/*",
     "src/*",
-    "utils/*"
+    "utils/*",
+    "ws/*"
   ],
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "@noble/hashes": "^1.0.0"
+    "@noble/hashes": "^1.0.0",
+    "eventemitter3": "5.0.1",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
-    "@types/node": "^16.18.38"
+    "@types/node": "^16.18.38",
+    "@types/ws": "^8.5.6"
   },
   "repository": {
     "type": "git",

--- a/packages/isomorphic/src/ws/browser.ts
+++ b/packages/isomorphic/src/ws/browser.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file -- Needs to be a wrapper for ws */
-import { EventEmitter } from 'events'
+import { EventEmitter } from 'eventemitter3'
 
 // Define the global WebSocket class found on the native browser
 declare class WebSocket {
@@ -31,7 +31,7 @@ export default class WSWrapper extends EventEmitter {
   public static CONNECTING = 0
   public static OPEN = 1
   public static CLOSING = 2
-  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- magic number is being defined here
+
   public static CLOSED = 3
   private readonly ws: WebSocket
 
@@ -48,7 +48,6 @@ export default class WSWrapper extends EventEmitter {
     _websocketOptions: WSWrapperOptions,
   ) {
     super()
-    this.setMaxListeners(Infinity)
 
     this.ws = new WebSocket(url)
 

--- a/packages/isomorphic/src/ws/index.ts
+++ b/packages/isomorphic/src/ws/index.ts
@@ -1,0 +1,10 @@
+import WebSocket from 'ws'
+
+export default class Socket extends WebSocket {
+  constructor(...args) {
+    super(args[0], args[1], args[2])
+    this.setMaxListeners(Infinity)
+  }
+}
+
+export type ClientOptions = WebSocket.ClientOptions

--- a/packages/isomorphic/ws/package.json
+++ b/packages/isomorphic/ws/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@xrplf/isomorphic/ws",
+  "private": true,
+  "main": "../dist/ws",
+  "types": "../dist/ws",
+  "browser": "../dist/ws/browser.js",
+  "dependencies": {
+    "ws": "^8.13.0",
+    "eventemitter3": "^5.0.1"
+  }
+}

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -17,20 +17,23 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Uses `@xrplf/secret-numbers` instead of `xrpl-secret-numbers`
 * Improve key algorithm detection. It will now throw Errors with helpful messages
 * Move `authorizeChannel` from `wallet/signer` to `wallet/authorizeChannel` to solve a circular dependency issue.
+* When using a bundler you must remove the mapping of `ws` to `WSWrapper`. ex. `ws: 'xrpl/dist/npm/client/WSWrapper'`. See [../UNIQUE_STEPS](Unique Steps) for the new, much smaller, configs.
 
 ### Bundling Changes
-* Bundler configurations are much more simplified.
-    * removed the following polyfills:
-        * `assert`
-        * `crypto-browserify`
-        * `https-browserify`
-        * `os-browserify`
-        * `stream-browserify`
-        * `stream-http`
-        * `url`
-        * `util` - previously added automatically by `webpack`
-    * Removed mappings for:
-        * Excluding `https-proxy-agent`
+Bundler configurations are much more simplified. See [../UNIQUE_STEPS](Unique Steps) for the new, much smaller, configs.
+* removed the following polyfills:
+    * `assert`
+    * `crypto-browserify`
+    * `https-browserify`
+    * `os-browserify`
+    * `stream-browserify`
+    * `stream-http`
+    * `url`
+    * `util` - previously added automatically by `webpack`
+    * `events` - previously added automatically by `webpack` but manual for `vite`
+* Removed mappings for:
+    * `ws` to `WsWrapper`
+    * Excluding `https-proxy-agent`
 
 ### Changed
 * Remove `lodash` as a dependency

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/node": "^16.18.38",
+    "eventemitter3": "^5.0.1",
     "https-proxy-agent": "^7.0.1",
     "karma": "^6.4.1",
     "karma-chrome-launcher": "^3.1.1",
@@ -43,7 +44,8 @@
     "lodash": "^4.17.4",
     "run-s": "^0.0.0",
     "react": "^18.2.0",
-    "typedoc": "^0.25.0"
+    "typedoc": "^0.25.0",
+    "ws": "^8.14.2"
   },
   "resolutions": {
     "elliptic": "^6.5.4"

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -28,10 +28,10 @@
     "@xrplf/secret-numbers": "^1.0.0",
     "bignumber.js": "^9.0.0",
     "cross-fetch": "^4.0.0",
+    "eventemitter3": "^5.0.1",
     "ripple-address-codec": "^4.3.1",
     "ripple-binary-codec": "^1.10.0",
-    "ripple-keypairs": "^1.3.1",
-    "ws": "^8.2.2"
+    "ripple-keypairs": "^1.3.1"
   },
   "devDependencies": {
     "@types/node": "^16.18.38",

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-lines -- Connection is a large file w/ lots of imports/exports */
-import { EventEmitter } from 'events'
 import type { Agent } from 'http'
 
-import WebSocket from 'ws'
+import WebSocket, { ClientOptions } from '@xrplf/isomorphic/ws'
+import { EventEmitter } from 'eventemitter3'
 
 import {
   DisconnectedError,
@@ -61,7 +61,7 @@ function createWebSocket(
   url: string,
   config: ConnectionOptions,
 ): WebSocket | null {
-  const options: WebSocket.ClientOptions = {
+  const options: ClientOptions = {
     agent: config.agent,
   }
   if (config.headers) {
@@ -136,7 +136,6 @@ export class Connection extends EventEmitter {
    */
   public constructor(url?: string, options: ConnectionUserOptions = {}) {
     super()
-    this.setMaxListeners(Infinity)
     this.url = url
     this.config = {
       timeout: TIMEOUT * 1000,

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -75,15 +75,7 @@ function createWebSocket(
     }
   }
   const websocketOptions = { ...options }
-  const websocket = new WebSocket(url, websocketOptions)
-  /*
-   * we will have a listener for each outstanding request,
-   * so we have to raise the limit (the default is 10)
-   */
-  if (typeof websocket.setMaxListeners === 'function') {
-    websocket.setMaxListeners(Infinity)
-  }
-  return websocket
+  return new WebSocket(url, websocketOptions)
 }
 
 /**

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -37,7 +37,10 @@ import type {
   SubmitResponse,
 } from '../models/methods'
 import type { BookOffer, BookOfferCurrency } from '../models/methods/bookOffers'
-import type { EventTypes, OnEventToListenerMap } from '../models/methods/subscribe'
+import type {
+  EventTypes,
+  OnEventToListenerMap,
+} from '../models/methods/subscribe'
 import type { Transaction } from '../models/transactions'
 import { setTransactionFlagsToNumber } from '../models/utils/flags'
 import {

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jsdoc/require-jsdoc -- Request has many aliases, but they don't need unique docs */
 
 /* eslint-disable max-lines -- Client is a large file w/ lots of imports/exports */
-import { EventEmitter } from 'events'
+import { EventEmitter } from 'eventemitter3'
 
 import {
   RippledError,
@@ -37,7 +37,7 @@ import type {
   SubmitResponse,
 } from '../models/methods'
 import type { BookOffer, BookOfferCurrency } from '../models/methods/bookOffers'
-import type { OnEventToListenerMap } from '../models/methods/subscribe'
+import type { EventTypes, OnEventToListenerMap } from '../models/methods/subscribe'
 import type { Transaction } from '../models/transactions'
 import { setTransactionFlagsToNumber } from '../models/utils/flags'
 import {
@@ -161,7 +161,7 @@ const NORMAL_DISCONNECT_CODE = 1000
  *
  * @category Clients
  */
-class Client extends EventEmitter {
+class Client extends EventEmitter<EventTypes> {
   /*
    * Underlying connection to rippled.
    */
@@ -381,12 +381,12 @@ class Client extends EventEmitter {
    * })
    * ```
    */
-  public on<T extends string, U = OnEventToListenerMap<T>>(
-    eventName: T,
-    listener: U,
-  ): this {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any -- Compatible
-    return super.on(eventName, listener as (...args: any[]) => void)
+  public on<
+    T extends EventTypes,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- needs to be any for overload
+    U extends (...args: any[]) => void = OnEventToListenerMap<T>,
+  >(eventName: T, listener: U): this {
+    return super.on(eventName, listener)
   }
 
   /**

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -435,7 +435,19 @@ export type Stream =
   | OrderBookStream
   | ConsensusStream
 
-export type OnEventToListenerMap<T> = T extends 'connected'
+export type EventTypes =
+  | 'connected'
+  | 'disconnected'
+  | 'ledgerClosed'
+  | 'validationReceived'
+  | 'transaction'
+  | 'peerStatusChange'
+  | 'consensusPhase'
+  | 'manifestReceived'
+  | 'path_find'
+  | 'error'
+
+export type OnEventToListenerMap<T extends EventTypes> = T extends 'connected'
   ? () => void
   : T extends 'disconnected'
   ? (code: number) => void
@@ -456,7 +468,4 @@ export type OnEventToListenerMap<T> = T extends 'connected'
   : T extends 'error'
   ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- needs to be any for overload
     (...err: any[]) => void
-  : T extends string
-  ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- needs to be any for overload
-    (...args: any[]) => void
-  : never
+  : (...args: never[]) => void

--- a/packages/xrpl/test/createMockRippled.ts
+++ b/packages/xrpl/test/createMockRippled.ts
@@ -83,8 +83,8 @@ export function destroyMockRippled(server: MockedWebSocketServer): void {
 }
 
 export default function createMockRippled(port: number): MockedWebSocketServer {
+  Object.assign(WebSocketServer.prototype, EventEmitter.prototype)
   const mock = new WebSocketServer({ port }) as MockedWebSocketServer
-  Object.assign(mock, EventEmitter.prototype)
 
   mock.responses = {}
   mock.suppressOutput = false

--- a/packages/xrpl/test/createMockRippled.ts
+++ b/packages/xrpl/test/createMockRippled.ts
@@ -1,4 +1,4 @@
-import { EventEmitter2 } from 'eventemitter2'
+import { EventEmitter } from 'eventemitter3'
 import { Server as WebSocketServer, type WebSocket } from 'ws'
 
 import type { Request } from '../src'
@@ -48,7 +48,7 @@ export interface PortResponse extends BaseResponse {
  */
 
 export type MockedWebSocketServer = WebSocketServer &
-  EventEmitter2 & {
+  EventEmitter & {
     responses: Record<string, unknown>
     suppressOutput: boolean
     socket: WebSocket
@@ -84,7 +84,7 @@ export function destroyMockRippled(server: MockedWebSocketServer): void {
 
 export default function createMockRippled(port: number): MockedWebSocketServer {
   const mock = new WebSocketServer({ port }) as MockedWebSocketServer
-  Object.assign(mock, EventEmitter2.prototype)
+  Object.assign(mock, EventEmitter.prototype)
 
   mock.responses = {}
   mock.suppressOutput = false

--- a/packages/xrpl/webpack.base.config.js
+++ b/packages/xrpl/webpack.base.config.js
@@ -10,11 +10,5 @@ module.exports = merge(getDefaultConfiguration(), {
     library: 'xrpl',
     path: path.join(__dirname, 'build/'),
     filename: `xrpl.default.js`,
-  },
-  plugins: [new webpack.NormalModuleReplacementPlugin(/^ws$/, './WSWrapper')],
-  resolve: {
-    alias: {
-      ws: './dist/npm/client/WSWrapper.js',
-    },
-  },
+  }
 })


### PR DESCRIPTION
## High Level Overview of Change

Reduces filesize by 3kb minified and gzipped or 2.8% and reduces bundler config steps.

- Move `WSWrapper` to `@xrpl/isomorphic` to remove the need to add mapping of `ws` to `WSWrapper` file in bundler configs
- Switch to `eventemitter3` which is smaller than `events` by almost 1kb and will not require a mapping to node's `events` in `vite` bundling. `webpack` always automatically maps it.
    - max listeners is not a thing for `eventemitter3` so we do not need to set it to `Infinity`. `ws` uses the native event emitter which does still need that to be set.
- Remove `eventemitter2` which was only used in tests and was replaced with `eventemitter3`

BREAKING CHANGE: Configuration for frontend bundlers has changed for `ws`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Documentation Updates

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users