### PR TITLE
fix: pseudo-transactions for `ledger` and `tx`

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -8,6 +8,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 - Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
 - Add pseudo transaction types to `tx` and `ledger` methods responses.
 
+### Updated
+- Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
+
 ## 2.12.0 (2023-09-27)
 ### Added
 * Added `ports` field to `ServerInfoResponse`

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,13 +3,16 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
+### Added
+* New type `PseudoTransaction` which equates to `EnableAmendment | SetFee | UNLModify`
+* New type `AnyTransaction` which equates to `Transaction | PseudoTransaction`
 
 ### Fixed
-- Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
-- Add pseudo transaction types to `tx` and `ledger` methods responses.
+* Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
+* Add pseudo transaction types to `tx` and `ledger` methods responses.
 
 ### Updated
-- Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
+* Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
 
 ## 2.12.0 (2023-09-27)
 ### Added

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -3,16 +3,13 @@
 Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xrpl-announce) for release announcements. We recommend that xrpl.js (ripple-lib) users stay up-to-date with the latest stable release.
 
 ## Unreleased
-### Added
-* New type `PseudoTransaction` which equates to `EnableAmendment | SetFee | UNLModify`
-* New type `AnyTransaction` which equates to `Transaction | PseudoTransaction`
 
 ### Fixed
-* Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
-* Add pseudo transaction types to `tx` and `ledger` methods responses.
+- Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
+- Add pseudo transaction types to `tx` and `ledger` methods responses.
 
 ### Updated
-* Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
+- Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
 
 ## 2.12.0 (2023-09-27)
 ### Added

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -6,6 +6,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ### Fixed
 - Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
+- Add pseudo transaction types to `tx` and `ledger` methods responses.
 
 ## 2.12.0 (2023-09-27)
 ### Added

--- a/packages/xrpl/src/client/partialPayment.ts
+++ b/packages/xrpl/src/client/partialPayment.ts
@@ -10,7 +10,11 @@ import type {
   TxResponse,
 } from '..'
 import type { Amount } from '../models/common'
-import { PaymentFlags, Transaction } from '../models/transactions'
+import {
+  PaymentFlags,
+  PseudoTransaction,
+  Transaction,
+} from '../models/transactions'
 import type { TransactionMetadata } from '../models/transactions/metadata'
 import { isFlagEnabled } from '../models/utils'
 
@@ -36,7 +40,7 @@ function amountsEqual(amt1: Amount, amt2: Amount): boolean {
 }
 
 function isPartialPayment(
-  tx?: Transaction,
+  tx?: Transaction | PseudoTransaction,
   metadata?: TransactionMetadata | string,
 ): boolean {
   if (tx == null || metadata == null || tx.TransactionType !== 'Payment') {

--- a/packages/xrpl/src/client/partialPayment.ts
+++ b/packages/xrpl/src/client/partialPayment.ts
@@ -10,11 +10,7 @@ import type {
   TxResponse,
 } from '..'
 import type { Amount } from '../models/common'
-import {
-  PaymentFlags,
-  PseudoTransaction,
-  Transaction,
-} from '../models/transactions'
+import { PaymentFlags, AnyTransaction } from '../models/transactions'
 import type { TransactionMetadata } from '../models/transactions/metadata'
 import { isFlagEnabled } from '../models/utils'
 
@@ -40,7 +36,7 @@ function amountsEqual(amt1: Amount, amt2: Amount): boolean {
 }
 
 function isPartialPayment(
-  tx?: Transaction | PseudoTransaction,
+  tx?: AnyTransaction,
   metadata?: TransactionMetadata | string,
 ): boolean {
   if (tx == null || metadata == null || tx.TransactionType !== 'Payment') {

--- a/packages/xrpl/src/client/partialPayment.ts
+++ b/packages/xrpl/src/client/partialPayment.ts
@@ -10,7 +10,11 @@ import type {
   TxResponse,
 } from '..'
 import type { Amount } from '../models/common'
-import { PaymentFlags, AnyTransaction } from '../models/transactions'
+import {
+  PaymentFlags,
+  PseudoTransaction,
+  Transaction,
+} from '../models/transactions'
 import type { TransactionMetadata } from '../models/transactions/metadata'
 import { isFlagEnabled } from '../models/utils'
 
@@ -36,7 +40,7 @@ function amountsEqual(amt1: Amount, amt2: Amount): boolean {
 }
 
 function isPartialPayment(
-  tx?: AnyTransaction,
+  tx?: Transaction | PseudoTransaction,
   metadata?: TransactionMetadata | string,
 ): boolean {
   if (tx == null || metadata == null || tx.TransactionType !== 'Payment') {

--- a/packages/xrpl/src/models/ledger/Ledger.ts
+++ b/packages/xrpl/src/models/ledger/Ledger.ts
@@ -1,4 +1,5 @@
 import { Transaction, TransactionMetadata } from '../transactions'
+import { PseudoTransaction } from '../transactions/transaction'
 
 import LedgerEntry from './LedgerEntry'
 
@@ -61,5 +62,7 @@ export default interface Ledger {
    * either JSON or binary depending on whether the request specified binary
    * as true.
    */
-  transactions?: Array<Transaction & { metaData?: TransactionMetadata }>
+  transactions?: Array<
+    (Transaction | PseudoTransaction) & { metaData?: TransactionMetadata }
+  >
 }

--- a/packages/xrpl/src/models/ledger/Ledger.ts
+++ b/packages/xrpl/src/models/ledger/Ledger.ts
@@ -1,4 +1,5 @@
-import { AnyTransaction, TransactionMetadata } from '../transactions'
+import { Transaction, TransactionMetadata } from '../transactions'
+import { PseudoTransaction } from '../transactions/transaction'
 
 import LedgerEntry from './LedgerEntry'
 
@@ -61,5 +62,7 @@ export default interface Ledger {
    * either JSON or binary depending on whether the request specified binary
    * as true.
    */
-  transactions?: Array<AnyTransaction & { metaData?: TransactionMetadata }>
+  transactions?: Array<
+    (Transaction | PseudoTransaction) & { metaData?: TransactionMetadata }
+  >
 }

--- a/packages/xrpl/src/models/ledger/Ledger.ts
+++ b/packages/xrpl/src/models/ledger/Ledger.ts
@@ -1,5 +1,4 @@
-import { Transaction, TransactionMetadata } from '../transactions'
-import { PseudoTransaction } from '../transactions/transaction'
+import { AnyTransaction, TransactionMetadata } from '../transactions'
 
 import LedgerEntry from './LedgerEntry'
 
@@ -62,7 +61,5 @@ export default interface Ledger {
    * either JSON or binary depending on whether the request specified binary
    * as true.
    */
-  transactions?: Array<
-    (Transaction | PseudoTransaction) & { metaData?: TransactionMetadata }
-  >
+  transactions?: Array<AnyTransaction & { metaData?: TransactionMetadata }>
 }

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -184,7 +184,7 @@ export interface LedgerEntryRequest extends BaseRequest, LookupByLedgerRequest {
  *
  * @category Responses
  */
-export interface LedgerEntryResponse extends BaseResponse {
+export interface LedgerEntryResponse<T = LedgerEntry> extends BaseResponse {
   result: {
     /** The unique ID of this ledger object. */
     index: string
@@ -194,7 +194,7 @@ export interface LedgerEntryResponse extends BaseResponse {
      * Object containing the data of this ledger object, according to the
      * ledger format.
      */
-    node?: LedgerEntry
+    node?: T
     /** The binary representation of the ledger object, as hexadecimal. */
     node_binary?: string
     validated?: boolean

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -1,5 +1,6 @@
-import { AnyTransaction, TransactionMetadata } from '../transactions'
+import { Transaction, TransactionMetadata } from '../transactions'
 import { BaseTransaction } from '../transactions/common'
+import { PseudoTransaction } from '../transactions/transaction'
 
 import { BaseRequest, BaseResponse } from './baseMethod'
 
@@ -39,8 +40,9 @@ export interface TxRequest extends BaseRequest {
  *
  * @category Responses
  */
-export interface TxResponse<T extends BaseTransaction = AnyTransaction>
-  extends BaseResponse {
+export interface TxResponse<
+  T extends BaseTransaction = Transaction | PseudoTransaction,
+> extends BaseResponse {
   result: {
     /** The SHA-512 hash of the transaction. */
     hash: string

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -1,6 +1,5 @@
-import { Transaction, TransactionMetadata } from '../transactions'
+import { AnyTransaction, TransactionMetadata } from '../transactions'
 import { BaseTransaction } from '../transactions/common'
-import { PseudoTransaction } from '../transactions/transaction'
 
 import { BaseRequest, BaseResponse } from './baseMethod'
 
@@ -40,9 +39,8 @@ export interface TxRequest extends BaseRequest {
  *
  * @category Responses
  */
-export interface TxResponse<
-  T extends BaseTransaction = Transaction | PseudoTransaction,
-> extends BaseResponse {
+export interface TxResponse<T extends BaseTransaction = AnyTransaction>
+  extends BaseResponse {
   result: {
     /** The SHA-512 hash of the transaction. */
     hash: string

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -41,7 +41,7 @@ export interface TxRequest extends BaseRequest {
  * @category Responses
  */
 export interface TxResponse<
-  T extends BaseTransaction | PseudoTransaction = Transaction,
+  T extends BaseTransaction = Transaction | PseudoTransaction,
 > extends BaseResponse {
   result: {
     /** The SHA-512 hash of the transaction. */

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -1,5 +1,6 @@
 import { Transaction, TransactionMetadata } from '../transactions'
 import { BaseTransaction } from '../transactions/common'
+import { PseudoTransaction } from '../transactions/transaction'
 
 import { BaseRequest, BaseResponse } from './baseMethod'
 
@@ -39,8 +40,9 @@ export interface TxRequest extends BaseRequest {
  *
  * @category Responses
  */
-export interface TxResponse<T extends BaseTransaction = Transaction>
-  extends BaseResponse {
+export interface TxResponse<
+  T extends BaseTransaction | PseudoTransaction = Transaction,
+> extends BaseResponse {
   result: {
     /** The SHA-512 hash of the transaction. */
     hash: string

--- a/packages/xrpl/src/models/transactions/UNLModify.ts
+++ b/packages/xrpl/src/models/transactions/UNLModify.ts
@@ -1,9 +1,11 @@
+import { BaseTransaction } from './common'
+
 /**
  * Mark a change to the Negative UNL.
  *
  * @category Pseudo Transaction Models
  */
-export interface UNLModify {
+export interface UNLModify extends BaseTransaction {
   TransactionType: 'UNLModify'
   /**
    * The ledger index where this pseudo-transaction appears.

--- a/packages/xrpl/src/models/transactions/index.ts
+++ b/packages/xrpl/src/models/transactions/index.ts
@@ -1,5 +1,10 @@
 export { BaseTransaction } from './common'
-export { validate, TransactionAndMetadata, Transaction } from './transaction'
+export {
+  validate,
+  PseudoTransaction,
+  TransactionAndMetadata,
+  Transaction,
+} from './transaction'
 export * from './metadata'
 export {
   AccountSetAsfFlags,

--- a/packages/xrpl/src/models/transactions/index.ts
+++ b/packages/xrpl/src/models/transactions/index.ts
@@ -1,6 +1,7 @@
 export { BaseTransaction } from './common'
 export {
   validate,
+  AnyTransaction,
   PseudoTransaction,
   TransactionAndMetadata,
   Transaction,

--- a/packages/xrpl/src/models/transactions/index.ts
+++ b/packages/xrpl/src/models/transactions/index.ts
@@ -1,7 +1,6 @@
 export { BaseTransaction } from './common'
 export {
   validate,
-  AnyTransaction,
   PseudoTransaction,
   TransactionAndMetadata,
   Transaction,

--- a/packages/xrpl/src/models/transactions/transaction.ts
+++ b/packages/xrpl/src/models/transactions/transaction.ts
@@ -20,6 +20,7 @@ import { CheckCreate, validateCheckCreate } from './checkCreate'
 import { Clawback, validateClawback } from './clawback'
 import { isIssuedCurrency } from './common'
 import { DepositPreauth, validateDepositPreauth } from './depositPreauth'
+import { EnableAmendment } from './enableAmendment'
 import { EscrowCancel, validateEscrowCancel } from './escrowCancel'
 import { EscrowCreate, validateEscrowCreate } from './escrowCreate'
 import { EscrowFinish, validateEscrowFinish } from './escrowFinish'
@@ -53,10 +54,12 @@ import {
   PaymentChannelFund,
   validatePaymentChannelFund,
 } from './paymentChannelFund'
+import { SetFee } from './setFee'
 import { SetRegularKey, validateSetRegularKey } from './setRegularKey'
 import { SignerListSet, validateSignerListSet } from './signerListSet'
 import { TicketCreate, validateTicketCreate } from './ticketCreate'
 import { TrustSet, validateTrustSet } from './trustSet'
+import { UNLModify } from './UNLModify'
 import {
   XChainAccountCreateCommit,
   validateXChainAccountCreateCommit,
@@ -127,6 +130,8 @@ export type Transaction =
   | XChainCreateClaimID
   | XChainAccountCreateCommit
   | XChainModifyBridge
+
+export type PseudoTransaction = EnableAmendment | SetFee | UNLModify
 
 /**
  * @category Transaction Models

--- a/packages/xrpl/src/models/transactions/transaction.ts
+++ b/packages/xrpl/src/models/transactions/transaction.ts
@@ -133,8 +133,6 @@ export type Transaction =
 
 export type PseudoTransaction = EnableAmendment | SetFee | UNLModify
 
-export type AnyTransaction = Transaction | PseudoTransaction
-
 /**
  * @category Transaction Models
  */

--- a/packages/xrpl/src/models/transactions/transaction.ts
+++ b/packages/xrpl/src/models/transactions/transaction.ts
@@ -133,6 +133,8 @@ export type Transaction =
 
 export type PseudoTransaction = EnableAmendment | SetFee | UNLModify
 
+export type AnyTransaction = Transaction | PseudoTransaction
+
 /**
  * @category Transaction Models
  */

--- a/packages/xrpl/src/utils/hashes/hashLedger.ts
+++ b/packages/xrpl/src/utils/hashes/hashLedger.ts
@@ -10,6 +10,7 @@ import { ValidationError, XrplError } from '../../errors'
 import type { Ledger } from '../../models/ledger'
 import { LedgerEntry } from '../../models/ledger'
 import { Transaction, TransactionMetadata } from '../../models/transactions'
+import { PseudoTransaction } from '../../models/transactions/transaction'
 
 import HashPrefix from './HashPrefix'
 import sha512Half from './sha512Half'
@@ -124,7 +125,9 @@ export function hashLedgerHeader(ledgerHeader: Ledger): string {
  * @category Utilities
  */
 export function hashTxTree(
-  transactions: Array<Transaction & { metaData?: TransactionMetadata }>,
+  transactions: Array<
+    (Transaction | PseudoTransaction) & { metaData?: TransactionMetadata }
+  >,
 ): string {
   const shamap = new SHAMap()
   for (const txJSON of transactions) {

--- a/packages/xrpl/src/utils/hashes/hashLedger.ts
+++ b/packages/xrpl/src/utils/hashes/hashLedger.ts
@@ -9,11 +9,8 @@ import { decode, encode } from 'ripple-binary-codec'
 import { ValidationError, XrplError } from '../../errors'
 import type { Ledger } from '../../models/ledger'
 import { LedgerEntry } from '../../models/ledger'
-import {
-  AnyTransaction,
-  Transaction,
-  TransactionMetadata,
-} from '../../models/transactions'
+import { Transaction, TransactionMetadata } from '../../models/transactions'
+import { PseudoTransaction } from '../../models/transactions/transaction'
 
 import HashPrefix from './HashPrefix'
 import sha512Half from './sha512Half'
@@ -128,7 +125,9 @@ export function hashLedgerHeader(ledgerHeader: Ledger): string {
  * @category Utilities
  */
 export function hashTxTree(
-  transactions: Array<AnyTransaction & { metaData?: TransactionMetadata }>,
+  transactions: Array<
+    (Transaction | PseudoTransaction) & { metaData?: TransactionMetadata }
+  >,
 ): string {
   const shamap = new SHAMap()
   for (const txJSON of transactions) {

--- a/packages/xrpl/src/utils/hashes/hashLedger.ts
+++ b/packages/xrpl/src/utils/hashes/hashLedger.ts
@@ -9,8 +9,11 @@ import { decode, encode } from 'ripple-binary-codec'
 import { ValidationError, XrplError } from '../../errors'
 import type { Ledger } from '../../models/ledger'
 import { LedgerEntry } from '../../models/ledger'
-import { Transaction, TransactionMetadata } from '../../models/transactions'
-import { PseudoTransaction } from '../../models/transactions/transaction'
+import {
+  AnyTransaction,
+  Transaction,
+  TransactionMetadata,
+} from '../../models/transactions'
 
 import HashPrefix from './HashPrefix'
 import sha512Half from './sha512Half'
@@ -125,9 +128,7 @@ export function hashLedgerHeader(ledgerHeader: Ledger): string {
  * @category Utilities
  */
 export function hashTxTree(
-  transactions: Array<
-    (Transaction | PseudoTransaction) & { metaData?: TransactionMetadata }
-  >,
+  transactions: Array<AnyTransaction & { metaData?: TransactionMetadata }>,
 ): string {
   const shamap = new SHAMap()
   for (const txJSON of transactions) {


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

Currently the explicit responses for `tx` and `ledger` methods do not include psedo-transactions (EnableAmendment, UNLModify, SetFee) even though these transactions should still be found with the above methods. This PR will add these types to the responses.

The response type for `ledger` will allow specifying a custom ledger entry type.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users