### PR TITLE
fix: tx fields for accounts allowing empty string

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -7,9 +7,11 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ### Fixed
 - Allow flag maps when submitting `NFTokenMint` and `NFTokenCreateOffer` transactions like others with flags
 - Add pseudo transaction types to `tx` and `ledger` methods responses.
+- Transaction fields that equate to an address no longer allow an empty string `''`. If you want to specify the genesis account you must manually specify `rrrrrrrrrrrrrrrrrrrrrhoLvTp`
 
 ### Updated
 - Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
+- Error messages for fields that equate to an address, `DestinationTag`, or `NFTokenID`.  They will still be of type `ValidationError`.
 
 ## 2.12.0 (2023-09-27)
 ### Added

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -10,11 +10,13 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Add missing `type` param to `ledger_data` and `ledger` requests
 * Type assertions around `PreviousTxnID` and `PreviousTxnLgrSeq` missing on some ledger objects
 * Transaction fields that represent an address no longer allow an empty string (`''`). If you want to specify [ACCOUNT_ZERO](https://xrpl.org/addresses.html#special-addresses), you can specify `rrrrrrrrrrrrrrrrrrrrrhoLvTp`. ⚠️ **WARNING:** `rrrrrrrrrrrrrrrrrrrrrhoLvTp` is a black hole address, with no corresponding private key. Accounts/funds controlled by this address are not accessible.
+* Invalid addresses on a transaction now throws a `ValidationError` when submitting a transaction instead of `Error('checksum_invalid')`
 
 ### Updated
 * Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`
 * Clean up typing of `type` param and the response property `account_objects` of the `account_objects` request.
 * Error messages for fields that equate to an address, `DestinationTag`, or `NFTokenID`.  They will still be of type `ValidationError`.
+* Add alias type of `Account` to improve intellisense for Transaction fields that equate to an address.
 
 ### Changed
 * Removed sidechain-devnet faucet support as it is being moved to Devnet

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -9,7 +9,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Add pseudo transaction types to `tx` and `ledger` method responses.
 * Add missing `type` param to `ledger_data` and `ledger` requests
 * Type assertions around `PreviousTxnID` and `PreviousTxnLgrSeq` missing on some ledger objects
-* Transaction fields that equate to an address no longer allow an empty string `''`. If you want to specify the genesis account you must manually specify `rrrrrrrrrrrrrrrrrrrrrhoLvTp`
+* Transaction fields that represent an address no longer allow an empty string (`''`). If you want to specify [ACCOUNT_ZERO](https://xrpl.org/addresses.html#special-addresses), you can specify `rrrrrrrrrrrrrrrrrrrrrhoLvTp`. ⚠️ **WARNING:** `rrrrrrrrrrrrrrrrrrrrrhoLvTp` is a black hole address, with no corresponding private key. Accounts/funds controlled by this address are not accessible.
 
 ### Updated
 * Make `LedgerEntryResponse` a generic so it can be used like `LedgerEntryResponse<Escrow>`

--- a/packages/xrpl/src/models/transactions/NFTokenBurn.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenBurn.ts
@@ -1,4 +1,5 @@
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isString,
@@ -25,7 +26,7 @@ export interface NFTokenBurn extends BaseTransaction {
    * in the NFToken, either the issuer account or an account authorized by the
    * issuer, i.e. MintAccount.
    */
-  Account: string
+  Account: Account
   /**
    * Identifies the NFToken object to be removed by the transaction.
    */
@@ -35,7 +36,7 @@ export interface NFTokenBurn extends BaseTransaction {
    * Account. Only used to burn tokens which have the lsfBurnable flag enabled
    * and are not owned by the signing account.
    */
-  Owner?: string
+  Owner?: Account
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/NFTokenBurn.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenBurn.ts
@@ -1,6 +1,11 @@
-import { ValidationError } from '../../errors'
-
-import { BaseTransaction, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  isAccount,
+  isString,
+  validateBaseTransaction,
+  validateOptionalField,
+  validateRequiredField,
+} from './common'
 
 /**
  * The NFTokenBurn transaction is used to remove an NFToken object from the
@@ -41,8 +46,6 @@ export interface NFTokenBurn extends BaseTransaction {
  */
 export function validateNFTokenBurn(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
-
-  if (tx.NFTokenID == null) {
-    throw new ValidationError('NFTokenBurn: missing field NFTokenID')
-  }
+  validateRequiredField(tx, 'NFTokenID', isString)
+  validateOptionalField(tx, 'Owner', isAccount)
 }

--- a/packages/xrpl/src/models/transactions/NFTokenCreateOffer.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenCreateOffer.ts
@@ -10,6 +10,7 @@ import {
   parseAmountValue,
   isAccount,
   validateOptionalField,
+  Account,
 } from './common'
 
 /**
@@ -69,7 +70,7 @@ export interface NFTokenCreateOffer extends BaseTransaction {
    * (since an offer to sell a token one doesn't already hold
    * is meaningless).
    */
-  Owner?: string
+  Owner?: Account
   /**
    * Indicates the time after which the offer will no longer
    * be valid. The value is the number of seconds since the
@@ -81,7 +82,7 @@ export interface NFTokenCreateOffer extends BaseTransaction {
    * accepted by the specified account. Attempts by other
    * accounts to accept this offer MUST fail.
    */
-  Destination?: string
+  Destination?: Account
   Flags?: number | NFTokenCreateOfferFlagsInterface
 }
 

--- a/packages/xrpl/src/models/transactions/NFTokenCreateOffer.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenCreateOffer.ts
@@ -8,6 +8,8 @@ import {
   validateBaseTransaction,
   isAmount,
   parseAmountValue,
+  isAccount,
+  validateOptionalField,
 } from './common'
 
 /**
@@ -125,6 +127,9 @@ export function validateNFTokenCreateOffer(tx: Record<string, unknown>): void {
       'NFTokenCreateOffer: Destination and Account must not be equal',
     )
   }
+
+  validateOptionalField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'Owner', isAccount)
 
   if (tx.NFTokenID == null) {
     throw new ValidationError('NFTokenCreateOffer: missing field NFTokenID')

--- a/packages/xrpl/src/models/transactions/NFTokenMint.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenMint.ts
@@ -1,7 +1,13 @@
 import { ValidationError } from '../../errors'
 import { isHex } from '../utils'
 
-import { BaseTransaction, GlobalFlags, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  GlobalFlags,
+  isAccount,
+  validateBaseTransaction,
+  validateOptionalField,
+} from './common'
 
 /**
  * Transaction Flags for an NFTokenMint Transaction.
@@ -108,6 +114,8 @@ export function validateNFTokenMint(tx: Record<string, unknown>): void {
       'NFTokenMint: Issuer must not be equal to Account',
     )
   }
+
+  validateOptionalField(tx, 'Issuer', isAccount)
 
   if (typeof tx.URI === 'string' && tx.URI === '') {
     throw new ValidationError('NFTokenMint: URI must not be empty string')

--- a/packages/xrpl/src/models/transactions/NFTokenMint.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenMint.ts
@@ -2,6 +2,7 @@ import { ValidationError } from '../../errors'
 import { isHex } from '../utils'
 
 import {
+  Account,
   BaseTransaction,
   GlobalFlags,
   isAccount,
@@ -74,7 +75,7 @@ export interface NFTokenMint extends BaseTransaction {
    * present, the `MintAccount` field in the `AccountRoot` of the `Issuer`
    * field must match the `Account`, otherwise the transaction will fail.
    */
-  Issuer?: string
+  Issuer?: Account
   /**
    * Specifies the fee charged by the issuer for secondary sales of the Token,
    * if such sales are allowed. Valid values for this field are between 0 and

--- a/packages/xrpl/src/models/transactions/XChainAccountCreateCommit.ts
+++ b/packages/xrpl/src/models/transactions/XChainAccountCreateCommit.ts
@@ -7,6 +7,7 @@ import {
   validateBaseTransaction,
   validateRequiredField,
   isAccount,
+  Account,
 } from './common'
 
 /**
@@ -38,7 +39,7 @@ export interface XChainAccountCreateCommit extends BaseTransaction {
   /**
    * The destination account on the destination chain.
    */
-  Destination: string
+  Destination: Account
 
   /**
    * The amount, in XRP, to use for account creation. This must be greater than or

--- a/packages/xrpl/src/models/transactions/XChainAccountCreateCommit.ts
+++ b/packages/xrpl/src/models/transactions/XChainAccountCreateCommit.ts
@@ -4,9 +4,9 @@ import {
   BaseTransaction,
   isAmount,
   isXChainBridge,
-  isString,
   validateBaseTransaction,
   validateRequiredField,
+  isAccount,
 } from './common'
 
 /**
@@ -62,7 +62,7 @@ export function validateXChainAccountCreateCommit(
 
   validateRequiredField(tx, 'SignatureReward', isAmount)
 
-  validateRequiredField(tx, 'Destination', isString)
+  validateRequiredField(tx, 'Destination', isAccount)
 
   validateRequiredField(tx, 'Amount', isAmount)
 }

--- a/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
@@ -1,6 +1,7 @@
 import { Amount, XChainBridge } from '../common'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isAmount,
@@ -30,23 +31,23 @@ export interface XChainAddAccountCreateAttestation extends BaseTransaction {
   /**
    * The account that should receive this signer's share of the SignatureReward.
    */
-  AttestationRewardAccount: string
+  AttestationRewardAccount: Account
 
   /**
    * The account on the door account's signer list that is signing the transaction.
    */
-  AttestationSignerAccount: string
+  AttestationSignerAccount: Account
 
   /**
    * The destination account for the funds on the destination chain.
    */
-  Destination: string
+  Destination: Account
 
   /**
    * The account on the source chain that submitted the {@link XChainAccountCreateCommit}
    * transaction that triggered the event associated with the attestation.
    */
-  OtherChainSource: string
+  OtherChainSource: Account
 
   /**
    * The public key used to verify the signature.

--- a/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
@@ -2,6 +2,7 @@ import { Amount, XChainBridge } from '../common'
 
 import {
   BaseTransaction,
+  isAccount,
   isAmount,
   isNumber,
   isString,
@@ -91,13 +92,13 @@ export function validateXChainAddAccountCreateAttestation(
 
   validateRequiredField(tx, 'Amount', isAmount)
 
-  validateRequiredField(tx, 'AttestationRewardAccount', isString)
+  validateRequiredField(tx, 'AttestationRewardAccount', isAccount)
 
-  validateRequiredField(tx, 'AttestationSignerAccount', isString)
+  validateRequiredField(tx, 'AttestationSignerAccount', isAccount)
 
-  validateRequiredField(tx, 'Destination', isString)
+  validateRequiredField(tx, 'Destination', isAccount)
 
-  validateRequiredField(tx, 'OtherChainSource', isString)
+  validateRequiredField(tx, 'OtherChainSource', isAccount)
 
   validateRequiredField(tx, 'PublicKey', isString)
 

--- a/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
@@ -1,6 +1,7 @@
 import { Amount, XChainBridge } from '../common'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isAmount,
@@ -29,24 +30,24 @@ export interface XChainAddClaimAttestation extends BaseTransaction {
   /**
    * The account that should receive this signer's share of the SignatureReward.
    */
-  AttestationRewardAccount: string
+  AttestationRewardAccount: Account
 
   /**
    * The account on the door account's signer list that is signing the transaction.
    */
-  AttestationSignerAccount: string
+  AttestationSignerAccount: Account
 
   /**
    * The destination account for the funds on the destination chain (taken from
    * the {@link XChainCommit} transaction).
    */
-  Destination?: string
+  Destination?: Account
 
   /**
    * The account on the source chain that submitted the {@link XChainCommit}
    * transaction that triggered the event associated with the attestation.
    */
-  OtherChainSource: string
+  OtherChainSource: Account
 
   /**
    * The public key used to verify the attestation signature.

--- a/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
@@ -2,6 +2,7 @@ import { Amount, XChainBridge } from '../common'
 
 import {
   BaseTransaction,
+  isAccount,
   isAmount,
   isNumber,
   isString,
@@ -87,13 +88,13 @@ export function validateXChainAddClaimAttestation(
 
   validateRequiredField(tx, 'Amount', isAmount)
 
-  validateRequiredField(tx, 'AttestationRewardAccount', isString)
+  validateRequiredField(tx, 'AttestationRewardAccount', isAccount)
 
-  validateRequiredField(tx, 'AttestationSignerAccount', isString)
+  validateRequiredField(tx, 'AttestationSignerAccount', isAccount)
 
-  validateOptionalField(tx, 'Destination', isString)
+  validateOptionalField(tx, 'Destination', isAccount)
 
-  validateRequiredField(tx, 'OtherChainSource', isString)
+  validateRequiredField(tx, 'OtherChainSource', isAccount)
 
   validateRequiredField(tx, 'PublicKey', isString)
 

--- a/packages/xrpl/src/models/transactions/XChainClaim.ts
+++ b/packages/xrpl/src/models/transactions/XChainClaim.ts
@@ -1,6 +1,7 @@
 import { Amount, XChainBridge } from '../common'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isAmount,
@@ -39,7 +40,7 @@ export interface XChainClaim extends BaseTransaction {
    * sequence number and collected signatures won't be destroyed, and the
    * transaction can be rerun with a different destination.
    */
-  Destination: string
+  Destination: Account
 
   /**
    * An integer destination tag.

--- a/packages/xrpl/src/models/transactions/XChainClaim.ts
+++ b/packages/xrpl/src/models/transactions/XChainClaim.ts
@@ -2,6 +2,7 @@ import { Amount, XChainBridge } from '../common'
 
 import {
   BaseTransaction,
+  isAccount,
   isAmount,
   isNumber,
   isString,
@@ -69,7 +70,7 @@ export function validateXChainClaim(tx: Record<string, unknown>): void {
     (inp) => isNumber(inp) || isString(inp),
   )
 
-  validateRequiredField(tx, 'Destination', isString)
+  validateRequiredField(tx, 'Destination', isAccount)
 
   validateOptionalField(tx, 'DestinationTag', isNumber)
 

--- a/packages/xrpl/src/models/transactions/XChainCommit.ts
+++ b/packages/xrpl/src/models/transactions/XChainCommit.ts
@@ -1,6 +1,7 @@
 import { Amount, XChainBridge } from '../common'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isAmount,
@@ -42,7 +43,7 @@ export interface XChainCommit extends BaseTransaction {
    * destination chain will need to submit a {@link XChainClaim} transaction to
    * claim the funds.
    */
-  OtherChainDestination?: string
+  OtherChainDestination?: Account
 
   /**
    * The asset to commit, and the quantity. This must match the door account's

--- a/packages/xrpl/src/models/transactions/XChainCommit.ts
+++ b/packages/xrpl/src/models/transactions/XChainCommit.ts
@@ -2,6 +2,7 @@ import { Amount, XChainBridge } from '../common'
 
 import {
   BaseTransaction,
+  isAccount,
   isAmount,
   isNumber,
   isString,
@@ -68,7 +69,7 @@ export function validateXChainCommit(tx: Record<string, unknown>): void {
     (inp) => isNumber(inp) || isString(inp),
   )
 
-  validateOptionalField(tx, 'OtherChainDestination', isString)
+  validateOptionalField(tx, 'OtherChainDestination', isAccount)
 
   validateRequiredField(tx, 'Amount', isAmount)
 }

--- a/packages/xrpl/src/models/transactions/XChainCreateClaimID.ts
+++ b/packages/xrpl/src/models/transactions/XChainCreateClaimID.ts
@@ -1,6 +1,7 @@
 import { Amount, XChainBridge } from '../common'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isAmount,
@@ -33,7 +34,7 @@ export interface XChainCreateClaimID extends BaseTransaction {
   /**
    * The account that must send the {@link XChainCommit} transaction on the source chain.
    */
-  OtherChainSource: string
+  OtherChainSource: Account
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/XChainCreateClaimID.ts
+++ b/packages/xrpl/src/models/transactions/XChainCreateClaimID.ts
@@ -2,8 +2,8 @@ import { Amount, XChainBridge } from '../common'
 
 import {
   BaseTransaction,
+  isAccount,
   isAmount,
-  isString,
   isXChainBridge,
   validateBaseTransaction,
   validateRequiredField,
@@ -49,5 +49,5 @@ export function validateXChainCreateClaimID(tx: Record<string, unknown>): void {
 
   validateRequiredField(tx, 'SignatureReward', isAmount)
 
-  validateRequiredField(tx, 'OtherChainSource', isString)
+  validateRequiredField(tx, 'OtherChainSource', isAccount)
 }

--- a/packages/xrpl/src/models/transactions/accountDelete.ts
+++ b/packages/xrpl/src/models/transactions/accountDelete.ts
@@ -1,4 +1,5 @@
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isNumber,
@@ -21,7 +22,7 @@ export interface AccountDelete extends BaseTransaction {
    * sending account. Must be a funded account in the ledger, and must not be.
    * the sending account.
    */
-  Destination: string
+  Destination: Account
   /**
    * Arbitrary destination tag that identifies a hosted recipient or other.
    * information for the recipient of the deleted account's leftover XRP.

--- a/packages/xrpl/src/models/transactions/accountDelete.ts
+++ b/packages/xrpl/src/models/transactions/accountDelete.ts
@@ -1,6 +1,11 @@
-import { ValidationError } from '../../errors'
-
-import { BaseTransaction, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  isAccount,
+  isNumber,
+  validateBaseTransaction,
+  validateOptionalField,
+  validateRequiredField,
+} from './common'
 
 /**
  * An AccountDelete transaction deletes an account and any objects it owns in
@@ -33,18 +38,6 @@ export interface AccountDelete extends BaseTransaction {
 export function validateAccountDelete(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  if (tx.Destination === undefined) {
-    throw new ValidationError('AccountDelete: missing field Destination')
-  }
-
-  if (typeof tx.Destination !== 'string') {
-    throw new ValidationError('AccountDelete: invalid Destination')
-  }
-
-  if (
-    tx.DestinationTag !== undefined &&
-    typeof tx.DestinationTag !== 'number'
-  ) {
-    throw new ValidationError('AccountDelete: invalid DestinationTag')
-  }
+  validateRequiredField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'DestinationTag', isNumber)
 }

--- a/packages/xrpl/src/models/transactions/accountSet.ts
+++ b/packages/xrpl/src/models/transactions/accountSet.ts
@@ -1,8 +1,11 @@
-import { isValidClassicAddress } from 'ripple-address-codec'
-
 import { ValidationError } from '../../errors'
 
-import { BaseTransaction, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  isAccount,
+  validateBaseTransaction,
+  validateOptionalField,
+} from './common'
 
 /**
  * Enum for AccountSet Flags.
@@ -167,16 +170,11 @@ const MAX_TICK_SIZE = 15
  * @param tx - An AccountSet Transaction.
  * @throws When the AccountSet is Malformed.
  */
-// eslint-disable-next-line max-lines-per-function, max-statements -- okay for this method, only a little over
+// eslint-disable-next-line max-lines-per-function -- okay for this method, only a little over
 export function validateAccountSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  if (
-    tx.NFTokenMinter !== undefined &&
-    !isValidClassicAddress(String(tx.NFTokenMinter))
-  ) {
-    throw new ValidationError('AccountSet: invalid NFTokenMinter')
-  }
+  validateOptionalField(tx, 'NFTokenMinter', isAccount)
 
   if (tx.ClearFlag !== undefined) {
     if (typeof tx.ClearFlag !== 'number') {

--- a/packages/xrpl/src/models/transactions/accountSet.ts
+++ b/packages/xrpl/src/models/transactions/accountSet.ts
@@ -1,6 +1,7 @@
 import { ValidationError } from '../../errors'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   validateBaseTransaction,
@@ -158,7 +159,7 @@ export interface AccountSet extends BaseTransaction {
    * Sets an alternate account that is allowed to mint NFTokens on this
    * account's behalf using NFTokenMint's `Issuer` field.
    */
-  NFTokenMinter?: string
+  NFTokenMinter?: Account
 }
 
 const MIN_TICK_SIZE = 3

--- a/packages/xrpl/src/models/transactions/checkCreate.ts
+++ b/packages/xrpl/src/models/transactions/checkCreate.ts
@@ -9,6 +9,7 @@ import {
   validateRequiredField,
   validateOptionalField,
   isNumber,
+  Account,
 } from './common'
 
 /**
@@ -21,7 +22,7 @@ import {
 export interface CheckCreate extends BaseTransaction {
   TransactionType: 'CheckCreate'
   /** The unique address of the account that can cash the Check. */
-  Destination: string
+  Destination: Account
   /**
    * Maximum amount of source currency the Check is allowed to debit the
    * sender, including transfer fees on non-XRP currencies. The Check can only

--- a/packages/xrpl/src/models/transactions/checkCreate.ts
+++ b/packages/xrpl/src/models/transactions/checkCreate.ts
@@ -5,6 +5,10 @@ import {
   BaseTransaction,
   validateBaseTransaction,
   isIssuedCurrency,
+  isAccount,
+  validateRequiredField,
+  validateOptionalField,
+  isNumber,
 } from './common'
 
 /**
@@ -56,9 +60,8 @@ export function validateCheckCreate(tx: Record<string, unknown>): void {
     throw new ValidationError('CheckCreate: missing field SendMax')
   }
 
-  if (tx.Destination === undefined) {
-    throw new ValidationError('CheckCreate: missing field Destination')
-  }
+  validateRequiredField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'DestinationTag', isNumber)
 
   if (
     typeof tx.SendMax !== 'string' &&
@@ -66,17 +69,6 @@ export function validateCheckCreate(tx: Record<string, unknown>): void {
     !isIssuedCurrency(tx.SendMax as Record<string, unknown>)
   ) {
     throw new ValidationError('CheckCreate: invalid SendMax')
-  }
-
-  if (typeof tx.Destination !== 'string') {
-    throw new ValidationError('CheckCreate: invalid Destination')
-  }
-
-  if (
-    tx.DestinationTag !== undefined &&
-    typeof tx.DestinationTag !== 'number'
-  ) {
-    throw new ValidationError('CheckCreate: invalid DestinationTag')
   }
 
   if (tx.Expiration !== undefined && typeof tx.Expiration !== 'number') {

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -1,4 +1,4 @@
-import { isValidClassicAddress } from 'ripple-address-codec'
+import { isValidClassicAddress, isValidXAddress } from 'ripple-address-codec'
 import { TRANSACTION_TYPES } from 'ripple-binary-codec'
 
 import { ValidationError } from '../../errors'
@@ -120,13 +120,21 @@ export function isIssuedCurrency(
 }
 
 /**
- * Verify a string is in fact a valid account.
+ * Must be a valid account address
+ */
+export type Account = string
+
+/**
+ * Verify a string is in fact a valid account address.
  *
  * @param account - The object to check the form and type of.
  * @returns Whether the account is properly formed account for a transaction.
  */
-export function isAccount(account: unknown): boolean {
-  return typeof account === 'string' && isValidClassicAddress(account)
+export function isAccount(account: unknown): account is Account {
+  return (
+    typeof account === 'string' &&
+    (isValidClassicAddress(account) || isValidXAddress(account))
+  )
 }
 
 /**
@@ -214,7 +222,7 @@ export interface GlobalFlags {}
  */
 export interface BaseTransaction {
   /** The unique address of the transaction sender. */
-  Account: string
+  Account: Account
   /**
    * The type of transaction. Valid types include: `Payment`, `OfferCreate`,
    * `TrustSet`, and many others.

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -1,3 +1,4 @@
+import { isValidClassicAddress } from 'ripple-address-codec'
 import { TRANSACTION_TYPES } from 'ripple-binary-codec'
 
 import { ValidationError } from '../../errors'
@@ -116,6 +117,16 @@ export function isIssuedCurrency(
     typeof input.issuer === 'string' &&
     typeof input.currency === 'string'
   )
+}
+
+/**
+ * Verify a string is in fact a valid account.
+ *
+ * @param account - The object to check the form and type of.
+ * @returns Whether the account is properly formed account for a transaction.
+ */
+export function isAccount(account: unknown): boolean {
+  return typeof account === 'string' && isValidClassicAddress(account)
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/escrowCancel.ts
+++ b/packages/xrpl/src/models/transactions/escrowCancel.ts
@@ -1,6 +1,7 @@
 import { ValidationError } from '../../errors'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   validateBaseTransaction,
@@ -15,7 +16,7 @@ import {
 export interface EscrowCancel extends BaseTransaction {
   TransactionType: 'EscrowCancel'
   /** Address of the source account that funded the escrow payment. */
-  Owner: string
+  Owner: Account
   /**
    * Transaction sequence (or Ticket  number) of EscrowCreate transaction that.
    * created the escrow to cancel.

--- a/packages/xrpl/src/models/transactions/escrowCancel.ts
+++ b/packages/xrpl/src/models/transactions/escrowCancel.ts
@@ -1,6 +1,11 @@
 import { ValidationError } from '../../errors'
 
-import { BaseTransaction, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  isAccount,
+  validateBaseTransaction,
+  validateRequiredField,
+} from './common'
 
 /**
  * Return escrowed XRP to the sender.
@@ -27,13 +32,7 @@ export interface EscrowCancel extends BaseTransaction {
 export function validateEscrowCancel(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  if (tx.Owner == null) {
-    throw new ValidationError('EscrowCancel: missing Owner')
-  }
-
-  if (typeof tx.Owner !== 'string') {
-    throw new ValidationError('EscrowCancel: Owner must be a string')
-  }
+  validateRequiredField(tx, 'Owner', isAccount)
 
   if (tx.OfferSequence == null) {
     throw new ValidationError('EscrowCancel: missing OfferSequence')

--- a/packages/xrpl/src/models/transactions/escrowCreate.ts
+++ b/packages/xrpl/src/models/transactions/escrowCreate.ts
@@ -1,6 +1,13 @@
 import { ValidationError } from '../../errors'
 
-import { BaseTransaction, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  isAccount,
+  isNumber,
+  validateBaseTransaction,
+  validateOptionalField,
+  validateRequiredField,
+} from './common'
 
 /**
  * Sequester XRP until the escrow process either finishes or is canceled.
@@ -58,13 +65,8 @@ export function validateEscrowCreate(tx: Record<string, unknown>): void {
     throw new ValidationError('EscrowCreate: Amount must be a string')
   }
 
-  if (tx.Destination === undefined) {
-    throw new ValidationError('EscrowCreate: missing field Destination')
-  }
-
-  if (typeof tx.Destination !== 'string') {
-    throw new ValidationError('EscrowCreate: Destination must be a string')
-  }
+  validateRequiredField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'DestinationTag', isNumber)
 
   if (tx.CancelAfter === undefined && tx.FinishAfter === undefined) {
     throw new ValidationError(
@@ -88,12 +90,5 @@ export function validateEscrowCreate(tx: Record<string, unknown>): void {
 
   if (tx.Condition !== undefined && typeof tx.Condition !== 'string') {
     throw new ValidationError('EscrowCreate: Condition must be a string')
-  }
-
-  if (
-    tx.DestinationTag !== undefined &&
-    typeof tx.DestinationTag !== 'number'
-  ) {
-    throw new ValidationError('EscrowCreate: DestinationTag must be a number')
   }
 }

--- a/packages/xrpl/src/models/transactions/escrowCreate.ts
+++ b/packages/xrpl/src/models/transactions/escrowCreate.ts
@@ -1,6 +1,7 @@
 import { ValidationError } from '../../errors'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isNumber,
@@ -23,7 +24,7 @@ export interface EscrowCreate extends BaseTransaction {
    */
   Amount: string
   /** Address to receive escrowed XRP. */
-  Destination: string
+  Destination: Account
   /**
    * The time, in seconds since the Ripple Epoch, when this escrow expires.
    * This value is immutable; the funds can only be returned the sender after.

--- a/packages/xrpl/src/models/transactions/escrowFinish.ts
+++ b/packages/xrpl/src/models/transactions/escrowFinish.ts
@@ -1,6 +1,7 @@
 import { ValidationError } from '../../errors'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   validateBaseTransaction,
@@ -15,7 +16,7 @@ import {
 export interface EscrowFinish extends BaseTransaction {
   TransactionType: 'EscrowFinish'
   /** Address of the source account that funded the held payment. */
-  Owner: string
+  Owner: Account
   /**
    * Transaction sequence of EscrowCreate transaction that created the held.
    * payment to finish.

--- a/packages/xrpl/src/models/transactions/escrowFinish.ts
+++ b/packages/xrpl/src/models/transactions/escrowFinish.ts
@@ -1,6 +1,11 @@
 import { ValidationError } from '../../errors'
 
-import { BaseTransaction, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  isAccount,
+  validateBaseTransaction,
+  validateRequiredField,
+} from './common'
 
 /**
  * Deliver XRP from a held payment to the recipient.
@@ -37,13 +42,7 @@ export interface EscrowFinish extends BaseTransaction {
 export function validateEscrowFinish(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  if (tx.Owner == null) {
-    throw new ValidationError('EscrowFinish: missing field Owner')
-  }
-
-  if (typeof tx.Owner !== 'string') {
-    throw new ValidationError('EscrowFinish: Owner must be a string')
-  }
+  validateRequiredField(tx, 'Owner', isAccount)
 
   if (tx.OfferSequence == null) {
     throw new ValidationError('EscrowFinish: missing field OfferSequence')

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -11,6 +11,7 @@ import {
   validateRequiredField,
   validateOptionalField,
   isNumber,
+  Account,
 } from './common'
 
 /**
@@ -116,7 +117,7 @@ export interface Payment extends BaseTransaction {
    */
   Amount: Amount
   /** The unique address of the account receiving the payment. */
-  Destination: string
+  Destination: Account
   /**
    * Arbitrary tag that identifies the reason for the payment to the
    * destination, or a hosted recipient to pay.

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -7,6 +7,10 @@ import {
   isAmount,
   GlobalFlags,
   validateBaseTransaction,
+  isAccount,
+  validateRequiredField,
+  validateOptionalField,
+  isNumber,
 } from './common'
 
 /**
@@ -163,19 +167,8 @@ export function validatePayment(tx: Record<string, unknown>): void {
     throw new ValidationError('PaymentTransaction: invalid Amount')
   }
 
-  if (tx.Destination === undefined) {
-    throw new ValidationError('PaymentTransaction: missing field Destination')
-  }
-
-  if (!isAmount(tx.Destination)) {
-    throw new ValidationError('PaymentTransaction: invalid Destination')
-  }
-
-  if (tx.DestinationTag != null && typeof tx.DestinationTag !== 'number') {
-    throw new ValidationError(
-      'PaymentTransaction: DestinationTag must be a number',
-    )
-  }
+  validateRequiredField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'DestinationTag', isNumber)
 
   if (tx.InvoiceID !== undefined && typeof tx.InvoiceID !== 'string') {
     throw new ValidationError('PaymentTransaction: InvoiceID must be a string')

--- a/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
+++ b/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
@@ -1,6 +1,13 @@
 import { ValidationError } from '../../errors'
 
-import { BaseTransaction, validateBaseTransaction } from './common'
+import {
+  BaseTransaction,
+  isAccount,
+  isNumber,
+  validateBaseTransaction,
+  validateOptionalField,
+  validateRequiredField,
+} from './common'
 
 /**
  * Create a unidirectional channel and fund it with XRP. The address sending
@@ -54,7 +61,6 @@ export interface PaymentChannelCreate extends BaseTransaction {
  * @param tx - An PaymentChannelCreate Transaction.
  * @throws When the PaymentChannelCreate is Malformed.
  */
-// eslint-disable-next-line max-lines-per-function -- okay for this function, there's a lot of things to check
 export function validatePaymentChannelCreate(
   tx: Record<string, unknown>,
 ): void {
@@ -68,15 +74,8 @@ export function validatePaymentChannelCreate(
     throw new ValidationError('PaymentChannelCreate: Amount must be a string')
   }
 
-  if (tx.Destination === undefined) {
-    throw new ValidationError('PaymentChannelCreate: missing Destination')
-  }
-
-  if (typeof tx.Destination !== 'string') {
-    throw new ValidationError(
-      'PaymentChannelCreate: Destination must be a string',
-    )
-  }
+  validateRequiredField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'DestinationTag', isNumber)
 
   if (tx.SettleDelay === undefined) {
     throw new ValidationError('PaymentChannelCreate: missing SettleDelay')
@@ -101,15 +100,6 @@ export function validatePaymentChannelCreate(
   if (tx.CancelAfter !== undefined && typeof tx.CancelAfter !== 'number') {
     throw new ValidationError(
       'PaymentChannelCreate: CancelAfter must be a number',
-    )
-  }
-
-  if (
-    tx.DestinationTag !== undefined &&
-    typeof tx.DestinationTag !== 'number'
-  ) {
-    throw new ValidationError(
-      'PaymentChannelCreate: DestinationTag must be a number',
     )
   }
 }

--- a/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
+++ b/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
@@ -1,6 +1,7 @@
 import { ValidationError } from '../../errors'
 
 import {
+  Account,
   BaseTransaction,
   isAccount,
   isNumber,
@@ -28,7 +29,7 @@ export interface PaymentChannelCreate extends BaseTransaction {
    * Address to receive XRP claims against this channel. This is also known as
    * the "destination address" for the channel.
    */
-  Destination: string
+  Destination: Account
   /**
    * Amount of time the source address must wait before closing the channel if
    * it has unclaimed XRP.

--- a/packages/xrpl/test/models/NFTokenCreateOffer.test.ts
+++ b/packages/xrpl/test/models/NFTokenCreateOffer.test.ts
@@ -16,7 +16,7 @@ describe('NFTokenCreateOffer', function () {
       TransactionType: 'NFTokenCreateOffer',
       NFTokenID: NFTOKEN_ID,
       Amount: '1',
-      Owner: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
+      Owner: 'rcXY84C4g14iFp6taFXjjQGVeHqSCh9RX',
       Expiration: 1000,
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Destination: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
@@ -36,7 +36,7 @@ describe('NFTokenCreateOffer', function () {
         tfSellNFToken: true,
       },
       Expiration: 1000,
-      Destination: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
+      Destination: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Fee: '5000000',
       Sequence: 2470665,
@@ -104,7 +104,7 @@ describe('NFTokenCreateOffer', function () {
     const invalid = {
       TransactionType: 'NFTokenCreateOffer',
       Amount: '1',
-      Owner: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXe',
+      Owner: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
       Expiration: 1000,
       Destination: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
@@ -124,7 +124,7 @@ describe('NFTokenCreateOffer', function () {
       TransactionType: 'NFTokenCreateOffer',
       NFTokenID: NFTOKEN_ID,
       Amount: 1,
-      Owner: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXe',
+      Owner: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
       Expiration: 1000,
       Destination: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
@@ -142,7 +142,7 @@ describe('NFTokenCreateOffer', function () {
   it(`throws w/ missing Amount`, function () {
     const invalid = {
       TransactionType: 'NFTokenCreateOffer',
-      Owner: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXe',
+      Owner: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
       Expiration: 1000,
       NFTokenID: NFTOKEN_ID,
       Destination: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
@@ -162,7 +162,7 @@ describe('NFTokenCreateOffer', function () {
     const invalid = {
       TransactionType: 'NFTokenCreateOffer',
       Expiration: 1000,
-      Owner: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
+      Owner: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       NFTokenID: NFTOKEN_ID,
       Flags: NFTokenCreateOfferFlags.tfSellNFToken,

--- a/packages/xrpl/test/models/NFTokenCreateOffer.test.ts
+++ b/packages/xrpl/test/models/NFTokenCreateOffer.test.ts
@@ -36,7 +36,7 @@ describe('NFTokenCreateOffer', function () {
         tfSellNFToken: true,
       },
       Expiration: 1000,
-      Destination: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
+      Destination: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Fee: '5000000',
       Sequence: 2470665,

--- a/packages/xrpl/test/models/accountDelete.test.ts
+++ b/packages/xrpl/test/models/accountDelete.test.ts
@@ -58,12 +58,12 @@ describe('AccountDelete', function () {
     assert.throws(
       () => validateAccountDelete(invalidDestination),
       ValidationError,
-      'AccountDelete: invalid Destination',
+      'AccountDelete: invalid field Destination',
     )
     assert.throws(
       () => validate(invalidDestination),
       ValidationError,
-      'AccountDelete: invalid Destination',
+      'AccountDelete: invalid field Destination',
     )
   })
 
@@ -81,13 +81,13 @@ describe('AccountDelete', function () {
     assert.throws(
       () => validateAccountDelete(invalidDestinationTag),
       ValidationError,
-      'AccountDelete: invalid DestinationTag',
+      'AccountDelete: invalid field DestinationTag',
     )
 
     assert.throws(
       () => validate(invalidDestinationTag),
       ValidationError,
-      'AccountDelete: invalid DestinationTag',
+      'AccountDelete: invalid field DestinationTag',
     )
   })
 })

--- a/packages/xrpl/test/models/accountSet.test.ts
+++ b/packages/xrpl/test/models/accountSet.test.ts
@@ -155,12 +155,12 @@ describe('AccountSet', function () {
     assert.throws(
       () => validateAccountSet(account),
       ValidationError,
-      'AccountSet: invalid NFTokenMinter',
+      'AccountSet: invalid field NFTokenMinter',
     )
     assert.throws(
       () => validate(account),
       ValidationError,
-      'AccountSet: invalid NFTokenMinter',
+      'AccountSet: invalid field NFTokenMinter',
     )
   })
 })

--- a/packages/xrpl/test/models/checkCreate.test.ts
+++ b/packages/xrpl/test/models/checkCreate.test.ts
@@ -42,12 +42,12 @@ describe('CheckCreate', function () {
     assert.throws(
       () => validateCheckCreate(invalidDestination),
       ValidationError,
-      'CheckCreate: invalid Destination',
+      'CheckCreate: invalid field Destination',
     )
     assert.throws(
       () => validate(invalidDestination),
       ValidationError,
-      'CheckCreate: invalid Destination',
+      'CheckCreate: invalid field Destination',
     )
   })
 
@@ -92,12 +92,12 @@ describe('CheckCreate', function () {
     assert.throws(
       () => validateCheckCreate(invalidDestinationTag),
       ValidationError,
-      'CheckCreate: invalid DestinationTag',
+      'CheckCreate: invalid field DestinationTag',
     )
     assert.throws(
       () => validate(invalidDestinationTag),
       ValidationError,
-      'CheckCreate: invalid DestinationTag',
+      'CheckCreate: invalid field DestinationTag',
     )
   })
 

--- a/packages/xrpl/test/models/escrowCancel.test.ts
+++ b/packages/xrpl/test/models/escrowCancel.test.ts
@@ -38,12 +38,12 @@ describe('EscrowCancel', function () {
     assert.throws(
       () => validateEscrowCancel(cancel),
       ValidationError,
-      'EscrowCancel: missing Owner',
+      'EscrowCancel: missing field Owner',
     )
     assert.throws(
       () => validate(cancel),
       ValidationError,
-      'EscrowCancel: missing Owner',
+      'EscrowCancel: missing field Owner',
     )
   })
 
@@ -68,12 +68,12 @@ describe('EscrowCancel', function () {
     assert.throws(
       () => validateEscrowCancel(cancel),
       ValidationError,
-      'EscrowCancel: Owner must be a string',
+      'EscrowCancel: invalid field Owner',
     )
     assert.throws(
       () => validate(cancel),
       ValidationError,
-      'EscrowCancel: Owner must be a string',
+      'EscrowCancel: invalid field Owner',
     )
   })
 

--- a/packages/xrpl/test/models/escrowCreate.test.ts
+++ b/packages/xrpl/test/models/escrowCreate.test.ts
@@ -67,12 +67,12 @@ describe('EscrowCreate', function () {
     assert.throws(
       () => validateEscrowCreate(escrow),
       ValidationError,
-      'EscrowCreate: Destination must be a string',
+      'EscrowCreate: invalid field Destination',
     )
     assert.throws(
       () => validate(escrow),
       ValidationError,
-      'EscrowCreate: Destination must be a string',
+      'EscrowCreate: invalid field Destination',
     )
   })
 
@@ -137,12 +137,12 @@ describe('EscrowCreate', function () {
     assert.throws(
       () => validateEscrowCreate(escrow),
       ValidationError,
-      'EscrowCreate: DestinationTag must be a number',
+      'EscrowCreate: invalid field DestinationTag',
     )
     assert.throws(
       () => validate(escrow),
       ValidationError,
-      'EscrowCreate: DestinationTag must be a number',
+      'EscrowCreate: invalid field DestinationTag',
     )
   })
 

--- a/packages/xrpl/test/models/escrowFinish.test.ts
+++ b/packages/xrpl/test/models/escrowFinish.test.ts
@@ -48,12 +48,12 @@ describe('EscrowFinish', function () {
     assert.throws(
       () => validateEscrowFinish(escrow),
       ValidationError,
-      'EscrowFinish: Owner must be a string',
+      'EscrowFinish: invalid field Owner',
     )
     assert.throws(
       () => validate(escrow),
       ValidationError,
-      'EscrowFinish: Owner must be a string',
+      'EscrowFinish: invalid field Owner',
     )
   })
 

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -102,12 +102,12 @@ describe('Payment', function () {
     assert.throws(
       () => validatePayment(paymentTransaction),
       ValidationError,
-      'PaymentTransaction: missing field Destination',
+      'Payment: missing field Destination',
     )
     assert.throws(
       () => validate(paymentTransaction),
       ValidationError,
-      'PaymentTransaction: missing field Destination',
+      'Payment: missing field Destination',
     )
   })
 
@@ -116,12 +116,26 @@ describe('Payment', function () {
     assert.throws(
       () => validatePayment(paymentTransaction),
       ValidationError,
-      'PaymentTransaction: invalid Destination',
+      'Payment: invalid field Destination',
     )
     assert.throws(
       () => validate(paymentTransaction),
       ValidationError,
-      'PaymentTransaction: invalid Destination',
+      'Payment: invalid field Destination',
+    )
+  })
+
+  it(`throws when Destination is invalid classic address`, function () {
+    paymentTransaction.Destination = 'rABCD'
+    assert.throws(
+      () => validatePayment(paymentTransaction),
+      ValidationError,
+      'Payment: invalid field Destination',
+    )
+    assert.throws(
+      () => validate(paymentTransaction),
+      ValidationError,
+      'Payment: invalid field Destination',
     )
   })
 
@@ -130,12 +144,12 @@ describe('Payment', function () {
     assert.throws(
       () => validatePayment(paymentTransaction),
       ValidationError,
-      'PaymentTransaction: DestinationTag must be a number',
+      'Payment: invalid field DestinationTag',
     )
     assert.throws(
       () => validate(paymentTransaction),
       ValidationError,
-      'PaymentTransaction: DestinationTag must be a number',
+      'Payment: invalid field DestinationTag',
     )
   })
 

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -139,6 +139,13 @@ describe('Payment', function () {
     )
   })
 
+  it(`does not throw when Destination is a valid x-address`, function () {
+    paymentTransaction.Destination =
+      'X7WZKEeNVS2p9Tire9DtNFkzWBZbFtSiS2eDBib7svZXuc2'
+    assert.doesNotThrow(() => validatePayment(paymentTransaction))
+    assert.doesNotThrow(() => validate(paymentTransaction))
+  })
+
   it(`throws when Destination is an empty string`, function () {
     paymentTransaction.Destination = ''
     assert.throws(

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -139,6 +139,20 @@ describe('Payment', function () {
     )
   })
 
+  it(`throws when Destination is an empty string`, function () {
+    paymentTransaction.Destination = ''
+    assert.throws(
+      () => validatePayment(paymentTransaction),
+      ValidationError,
+      'Payment: invalid field Destination',
+    )
+    assert.throws(
+      () => validate(paymentTransaction),
+      ValidationError,
+      'Payment: invalid field Destination',
+    )
+  })
+
   it(`throws when DestinationTag is not a number`, function () {
     paymentTransaction.DestinationTag = '1'
     assert.throws(

--- a/packages/xrpl/test/models/paymentChannelCreate.test.ts
+++ b/packages/xrpl/test/models/paymentChannelCreate.test.ts
@@ -61,12 +61,12 @@ describe('PaymentChannelCreate', function () {
     assert.throws(
       () => validatePaymentChannelCreate(channel),
       ValidationError,
-      'PaymentChannelCreate: missing Destination',
+      'PaymentChannelCreate: missing field Destination',
     )
     assert.throws(
       () => validate(channel),
       ValidationError,
-      'PaymentChannelCreate: missing Destination',
+      'PaymentChannelCreate: missing field Destination',
     )
   })
 
@@ -121,12 +121,12 @@ describe('PaymentChannelCreate', function () {
     assert.throws(
       () => validatePaymentChannelCreate(channel),
       ValidationError,
-      'PaymentChannelCreate: Destination must be a string',
+      'PaymentChannelCreate: invalid field Destination',
     )
     assert.throws(
       () => validate(channel),
       ValidationError,
-      'PaymentChannelCreate: Destination must be a string',
+      'PaymentChannelCreate: invalid field Destination',
     )
   })
 
@@ -166,12 +166,12 @@ describe('PaymentChannelCreate', function () {
     assert.throws(
       () => validatePaymentChannelCreate(channel),
       ValidationError,
-      'PaymentChannelCreate: DestinationTag must be a number',
+      'PaymentChannelCreate: invalid field DestinationTag',
     )
     assert.throws(
       () => validate(channel),
       ValidationError,
-      'PaymentChannelCreate: DestinationTag must be a number',
+      'PaymentChannelCreate: invalid field DestinationTag',
     )
   })
 


### PR DESCRIPTION
## High Level Overview of Change

Fields that were encoded as STAccounts were turning `''` into `rrrrrrrrrrrrrrrrrrrrrhoLvTp` the ACCOUNT_ZERO account. They will now throw a `ValidationError`.

Invalid addresses on a transaction now throws a `ValidationError` when submitting a transaction instead of `Error('checksum_invalid')`.

This change updates some error messages for fields a few fields that aren't accounts, `DestinationTag` or `NFTokenID`.  They will still be of type `ValidationError`.

Fixes: #2517 and #2475

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users