### PR TITLE
fix: copy root README during `xrpl` publish

### DIFF
--- a/packages/xrpl/.gitignore
+++ b/packages/xrpl/.gitignore
@@ -1,0 +1,3 @@
+# Replaced by root README during the prepare lifecycle phase because npm does not allow symlinking README files
+# https://docs.npmjs.com/cli/v7/using-npm/scripts#npm-publish
+README.md

--- a/packages/xrpl/README.md
+++ b/packages/xrpl/README.md
@@ -1,8 +1,0 @@
-# xrpl.js
-
-This package includes the `xrpl` library. This repository uses a monorepo
-layout. Please find the README for `xrpl` [here](https://github.com/XRPLF/xrpl.js/tree/main/README.md).
-
-READMEs for other packages in this monorepo are located at the root of their
-package, but since newcomers to XRPL are likely to want to use the `xrpl`
-package this README is at the root of the project.

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -62,6 +62,7 @@
     "watch": "run-s build:lib --watch",
     "clean": "rm -rf dist build coverage",
     "docgen": "tsc --build tsconfig.docs.json && typedoc && echo js.xrpl.org >> ../../docs/CNAME",
+    "prepare": "copyfiles ../../README.md xrpl/README.md",
     "prepublish": "run-s clean build",
     "test": "jest --config=jest.config.unit.js --verbose false --silent=false",
     "test:integration": "TS_NODE_PROJECT=tsconfig.build.json jest --config=jest.config.integration.js --verbose false --silent=false --runInBand",


### PR DESCRIPTION
## High Level Overview of Change

The `xrpl` package had a less than helpful docs when viewed on the npm website. The fix is a workaround that copies the root `README` over to `packages/xrpl/README.md` during the `prepare` lifecycle phase.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release