### PR TITLE
test: POC for using global test data in integ tests

### DIFF
--- a/packages/xrpl/globalSetup.js
+++ b/packages/xrpl/globalSetup.js
@@ -1,0 +1,11 @@
+// globalSetup.js
+const fs = require('fs')
+const path = require('path')
+
+const jsonFilePath = path.join(__dirname, 'globalTestData.json')
+
+module.exports = async () => {
+  const initialData = {}
+  // Create globalTestData.json before tests start
+  fs.writeFileSync(jsonFilePath, JSON.stringify(initialData, null, 2))
+}

--- a/packages/xrpl/globalTeardown.js
+++ b/packages/xrpl/globalTeardown.js
@@ -1,0 +1,12 @@
+// globalTeardown.js
+const fs = require('fs')
+const path = require('path')
+
+const jsonFilePath = path.join(__dirname, 'globalTestData.json')
+
+module.exports = async () => {
+  // Delete globalTestData.json after all tests have run
+  if (fs.existsSync(jsonFilePath)) {
+    fs.unlinkSync(jsonFilePath)
+  }
+}

--- a/packages/xrpl/jest.config.integration.js
+++ b/packages/xrpl/jest.config.integration.js
@@ -9,4 +9,6 @@ module.exports = {
     '<rootDir>/test/integration/*.test.ts',
   ],
   displayName: 'xrpl.js',
+  globalSetup: '<rootDir>/globalSetup.js',
+  globalTeardown: '<rootDir>/globalTeardown.js',
 }

--- a/packages/xrpl/test/integration/globalTestDataUtils.test.ts
+++ b/packages/xrpl/test/integration/globalTestDataUtils.test.ts
@@ -1,0 +1,25 @@
+import { assert } from 'chai'
+
+import { GlobalTestDataUtils } from './globalTestDataUtils'
+
+describe('globalTestDataUtils', function () {
+  it('base', async function () {
+    const testData = {
+      issuerWalletSeed: 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV',
+      lpWalletSeed: 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV',
+      testWalletSeed: 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV',
+      asset: {
+        currency: 'USD',
+        issuer: 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV',
+      },
+      asset2: {
+        currency: 'XRP',
+      },
+    }
+    GlobalTestDataUtils.set('ammPool', testData)
+
+    const ammPool = await GlobalTestDataUtils.get('ammPool')
+
+    assert.deepEqual(ammPool, testData)
+  })
+})

--- a/packages/xrpl/test/integration/globalTestDataUtils.ts
+++ b/packages/xrpl/test/integration/globalTestDataUtils.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const jsonFilePath = path.join(__dirname, '../../globalTestData.json')
+
+interface IGlobalTestDataMap {
+  // TODO: add sidechains test data types here and remove AMM example below
+  ammPool?: {
+    issuerWalletSeed: string
+    lpWalletSeed: string
+    testWalletSeed: string
+    asset: object
+    asset2: object
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- required
+export class GlobalTestDataUtils {
+  public static get = async <K extends keyof IGlobalTestDataMap>(
+    key: K,
+  ): Promise<IGlobalTestDataMap[K]> => {
+    const data = GlobalTestDataUtils._getAllData()
+    return data[key]
+  }
+
+  public static set = <K extends keyof IGlobalTestDataMap>(
+    key: K,
+    value: IGlobalTestDataMap[K],
+  ): void => {
+    const currentData = GlobalTestDataUtils._getAllData()
+    currentData[key] = value
+    // eslint-disable-next-line node/no-sync -- required
+    fs.writeFileSync(jsonFilePath, JSON.stringify(currentData, null, 2))
+  }
+
+  public static has = (key: keyof IGlobalTestDataMap): boolean => {
+    const data = GlobalTestDataUtils._getAllData()
+    return Object.prototype.hasOwnProperty.call(data, key)
+  }
+
+  // Private function: retrieve all data from the JSON file
+  private static readonly _getAllData = (): IGlobalTestDataMap => {
+    // eslint-disable-next-line node/no-sync -- required
+    if (fs.existsSync(jsonFilePath)) {
+      // eslint-disable-next-line node/no-sync -- required
+      const rawData = fs.readFileSync(jsonFilePath, 'utf-8')
+      return JSON.parse(rawData) as Record<string, never>
+    }
+    return {}
+  }
+}

--- a/packages/xrpl/test/integration/index.ts
+++ b/packages/xrpl/test/integration/index.ts
@@ -58,6 +58,7 @@ export * from './requests/tx.test'
 export * from './requests/utility.test'
 
 export * from './fundWallet.test'
+export * from './globalTestDataUtils.test'
 export * from './integration.test'
 export * from './onConnect.test'
 export * from './regularKey.test'


### PR DESCRIPTION
## High Level Overview of Change

POC for using global test data in integ tests.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

Since Jest doesn't support global test data to be shared among integ tests, this creates an external JSON file `globalTestData.json` where global test data will be saved/accessed among any test.

I tried using this for AMM integ tests to use one amm pool for all tests but since the test run order is indeterministic, the assertion values fluctuated a lot with many combinations.

However, this can be useful for Sidechains integ tests.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
