### PR TITLE
test: run ripple-keypairs tests in the browser

### DIFF
--- a/packages/ripple-keypairs/karma.config.js
+++ b/packages/ripple-keypairs/karma.config.js
@@ -1,0 +1,15 @@
+const baseKarmaConfig = require('../../karma.config')
+const webpackConfig = require('./test/webpack.config')
+delete webpackConfig.entry
+
+module.exports = function (config) {
+  baseKarmaConfig(config)
+
+  config.set({
+    base: '',
+    webpack: webpackConfig,
+
+    // list of files / patterns to load in the browser
+    files: ['test/**/*.test.ts'],
+  })
+}

--- a/packages/ripple-keypairs/package.json
+++ b/packages/ripple-keypairs/package.json
@@ -3,8 +3,9 @@
   "version": "2.0.0-beta.0",
   "description": "Cryptographic key pairs for the XRP Ledger",
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc --build tsconfig.build.json",
     "test": "jest --verbose false --silent=false ./test/*.test.ts",
+    "test:browser": "npm run build && karma start ./karma.config.js",
     "clean": "rm -rf ./dist ./coverage tsconfig.tsbuildinfo",
     "lint": "eslint . --ext .ts",
     "prepublish": "npm run lint && npm test"

--- a/packages/ripple-keypairs/test/api.test.ts
+++ b/packages/ripple-keypairs/test/api.test.ts
@@ -1,5 +1,4 @@
-import assert from 'assert'
-import * as fixtures from './fixtures/api.json'
+import fixtures from './fixtures/api.json'
 import {
   decodeSeed,
   deriveAddress,
@@ -16,64 +15,63 @@ const entropy = new Uint8Array([
 
 describe('api', () => {
   it('generateSeed - secp256k1', () => {
-    assert.strictEqual(generateSeed({ entropy }), fixtures.secp256k1.seed)
+    expect(generateSeed({ entropy })).toEqual(fixtures.secp256k1.seed)
   })
 
   it('generateSeed - secp256k1, random', () => {
     const seed = generateSeed()
-    assert(seed.startsWith('s'))
+    expect(seed.startsWith('s')).toBeTruthy()
     const { type, bytes } = decodeSeed(seed)
-    assert(type === 'secp256k1')
-    assert(bytes.length === 16)
+    expect(type).toEqual('secp256k1')
+    expect(bytes.length).toEqual(16)
   })
 
   it('generateSeed - ed25519', () => {
-    assert.strictEqual(
-      generateSeed({ entropy, algorithm: 'ed25519' }),
+    expect(generateSeed({ entropy, algorithm: 'ed25519' })).toEqual(
       fixtures.ed25519.seed,
     )
   })
 
   it('generateSeed - ed25519, random', () => {
     const seed = generateSeed({ algorithm: 'ed25519' })
-    assert(seed.startsWith('sEd'))
+    expect(seed.startsWith('sEd')).toBeTruthy()
     const { type, bytes } = decodeSeed(seed)
-    assert(type === 'ed25519')
-    assert(bytes.length === 16)
+    expect(type).toEqual('ed25519')
+    expect(bytes.length).toEqual(16)
   })
 
   it('deriveKeypair - secp256k1', () => {
     const keypair = deriveKeypair(fixtures.secp256k1.seed)
-    assert.deepEqual(keypair, fixtures.secp256k1.keypair)
+    expect(keypair).toEqual(fixtures.secp256k1.keypair)
   })
 
   it('deriveKeypair - ed25519', () => {
     const keypair = deriveKeypair(fixtures.ed25519.seed)
-    assert.deepEqual(keypair, fixtures.ed25519.keypair)
+    expect(keypair).toEqual(fixtures.ed25519.keypair)
   })
 
   it('deriveKeypair - secp256k1 - validator', () => {
     const keypair = deriveKeypair(fixtures.secp256k1.seed, {
       validator: true,
     })
-    assert.deepEqual(keypair, fixtures.secp256k1.validatorKeypair)
+    expect(keypair).toEqual(fixtures.secp256k1.validatorKeypair)
   })
 
   it('deriveKeypair - ed25519 - validator', () => {
     const keypair = deriveKeypair(fixtures.ed25519.seed, {
       validator: true,
     })
-    assert.deepEqual(keypair, fixtures.ed25519.validatorKeypair)
+    expect(keypair).toEqual(fixtures.ed25519.validatorKeypair)
   })
 
   it('deriveAddress - secp256k1 public key', () => {
     const address = deriveAddress(fixtures.secp256k1.keypair.publicKey)
-    assert.strictEqual(address, fixtures.secp256k1.address)
+    expect(address).toEqual(fixtures.secp256k1.address)
   })
 
   it('deriveAddress - ed25519 public key', () => {
     const address = deriveAddress(fixtures.ed25519.keypair.publicKey)
-    assert.strictEqual(address, fixtures.ed25519.address)
+    expect(address).toEqual(fixtures.ed25519.address)
   })
 
   it('sign - secp256k1', () => {
@@ -81,7 +79,7 @@ describe('api', () => {
     const message = fixtures.secp256k1.message
     const messageHex = Buffer.from(message, 'utf8').toString('hex')
     const signature = sign(messageHex, privateKey)
-    assert.strictEqual(signature, fixtures.secp256k1.signature)
+    expect(signature).toEqual(fixtures.secp256k1.signature)
   })
 
   it('verify - secp256k1', () => {
@@ -89,7 +87,7 @@ describe('api', () => {
     const publicKey = fixtures.secp256k1.keypair.publicKey
     const message = fixtures.secp256k1.message
     const messageHex = Buffer.from(message, 'utf8').toString('hex')
-    assert(verify(messageHex, signature, publicKey))
+    expect(verify(messageHex, signature, publicKey)).toBeTruthy()
   })
 
   it('sign - ed25519', () => {
@@ -97,7 +95,7 @@ describe('api', () => {
     const message = fixtures.ed25519.message
     const messageHex = Buffer.from(message, 'utf8').toString('hex')
     const signature = sign(messageHex, privateKey)
-    assert.strictEqual(signature, fixtures.ed25519.signature)
+    expect(signature).toEqual(fixtures.ed25519.signature)
   })
 
   it('verify - ed25519', () => {
@@ -105,19 +103,19 @@ describe('api', () => {
     const publicKey = fixtures.ed25519.keypair.publicKey
     const message = fixtures.ed25519.message
     const messageHex = Buffer.from(message, 'utf8').toString('hex')
-    assert(verify(messageHex, signature, publicKey))
+    expect(verify(messageHex, signature, publicKey)).toBeTruthy()
   })
 
   it('deriveNodeAddress', () => {
     const addrX = 'n9KHn8NfbBsZV5q8bLfS72XyGqwFt5mgoPbcTV4c6qKiuPTAtXYk'
     const addrY = 'rU7bM9ENDkybaxNrefAVjdLTyNLuue1KaJ'
-    assert.strictEqual(deriveNodeAddress(addrX), addrY)
+    expect(deriveNodeAddress(addrX)).toEqual(addrY)
   })
 
   it('Random Address', () => {
     const seed = generateSeed()
     const keypair = deriveKeypair(seed)
     const address = deriveAddress(keypair.publicKey)
-    assert(address.startsWith('r'))
+    expect(address.startsWith('r')).toBeTruthy()
   })
 })

--- a/packages/ripple-keypairs/test/getAlgorithmFromKey.test.ts
+++ b/packages/ripple-keypairs/test/getAlgorithmFromKey.test.ts
@@ -5,6 +5,11 @@ function hexData(count: number) {
   return 'a'.repeat(count)
 }
 
+// Remove leading tabs
+function dedent(str) {
+  return `${str}`.replace(/(?<tabs>\n)\s+/gu, '$1')
+}
+
 describe('getAlgorithmFromKey', () => {
   it('should return ed25519 for valid ed25519 private key', () => {
     const privateKey = `ed${hexData(64)}`
@@ -41,29 +46,37 @@ describe('getAlgorithmFromKey', () => {
   it('should throw error for invalid private key format', () => {
     // Invalid tag and length
     const privateKey = `ff${hexData(60)}`
-    expect(() => getAlgorithmFromKey(privateKey, 'private'))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "invalid_key:
-
-      Type: private
-      Key: ffaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      Prefix: 0xff 
-      Length: 31 bytes
-
-      Acceptable private formats are:
-      ecdsa-secp256k1   - Prefix: None   Length: 32 bytes
-      ecdsa-secp256k1   - Prefix: 0x00   Length: 33 bytes
-      ed25519           - Prefix: 0xed   Length: 33 bytes
-      "
-    `)
+    try {
+      getAlgorithmFromKey(privateKey, 'private')
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(dedent(error.message)).toEqual(
+          dedent(`invalid_key:
+  
+        Type: private
+        Key: ffaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        Prefix: 0xff 
+        Length: 31 bytes
+  
+        Acceptable private formats are:
+        ecdsa-secp256k1   - Prefix: None   Length: 32 bytes
+        ecdsa-secp256k1   - Prefix: 0x00   Length: 33 bytes
+        ed25519           - Prefix: 0xed   Length: 33 bytes
+    `),
+        )
+      }
+    }
   })
 
   it('should throw error for invalid public key format', () => {
     // Invalid tag and length
     const publicKey = `ff${hexData(60)}`
-    expect(() => getAlgorithmFromKey(publicKey, 'public'))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "invalid_key:
+    try {
+      getAlgorithmFromKey(publicKey, 'public')
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(dedent(error.message)).toEqual(
+          dedent(`invalid_key:
 
       Type: public
       Key: ffaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -75,7 +88,9 @@ describe('getAlgorithmFromKey', () => {
       ecdsa-secp256k1   - Prefix: 0x02   Length: 33 bytes
       ecdsa-secp256k1   - Prefix: 0x03   Length: 33 bytes
       ecdsa-secp256k1   - Prefix: 0x04   Length: 65 bytes
-      "
-    `)
+    `),
+        )
+      }
+    }
   })
 })

--- a/packages/ripple-keypairs/test/webpack.config.js
+++ b/packages/ripple-keypairs/test/webpack.config.js
@@ -1,0 +1,9 @@
+'use strict'
+const { merge } = require('webpack-merge')
+const { webpackForTest } = require('../../../weback.test.config')
+const { getDefaultConfiguration } = require('../../../webpack.config')
+
+module.exports = merge(
+  getDefaultConfiguration(),
+  webpackForTest('./test/index.ts', __dirname),
+)

--- a/packages/ripple-keypairs/tsconfig.build.json
+++ b/packages/ripple-keypairs/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.json"]
+}

--- a/packages/ripple-keypairs/tsconfig.json
+++ b/packages/ripple-keypairs/tsconfig.json
@@ -5,7 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "noImplicitAny": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## High Level Overview of Change

- Update tests to use jasmine compatible functions. This means removing `toThrowErrorMatchingInlineSnapshot` and manually removing indention to compare some of the complexly formatted error messages.
- Remove usages of `assert` library in keypairs tests.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)


### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users