### PR TITLE
feat: remove `assert` library as a testing dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@typescript-eslint/parser": "^5.28.0",
         "@xrplf/eslint-config": "^1.9.1",
         "@xrplf/prettier-config": "^1.9.1",
-        "assert": "^2.0.0",
         "buffer": "^6.0.2",
         "chai": "^4.3.4",
         "copyfiles": "^2.4.1",
@@ -4009,19 +4008,6 @@
       "dev": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-nan": "^1.3.2",
-        "object-is": "^1.1.5",
-        "object.assign": "^4.1.4",
-        "util": "^0.12.5"
       }
     },
     "node_modules/assert-plus": {
@@ -8118,22 +8104,6 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -8312,6 +8282,7 @@
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -8346,22 +8317,6 @@
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
       "dev": true,
       "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11320,22 +11275,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14668,19 +14607,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15495,9 +15421,6 @@
         "bignumber.js": "^9.0.0",
         "buffer": "6.0.3",
         "ripple-address-codec": "^5.0.0-beta.0"
-      },
-      "devDependencies": {
-        "assert": "^2.0.0"
       },
       "engines": {
         "node": ">= 16"
@@ -18821,19 +18744,6 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "assert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "is-nan": "^1.3.2",
-        "object-is": "^1.1.5",
-        "object.assign": "^4.1.4",
-        "util": "^0.12.5"
-      }
-    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -21951,16 +21861,6 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
-    "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -22090,6 +21990,7 @@
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -22115,16 +22016,6 @@
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
       "dev": true,
       "peer": true
-    },
-    "is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      }
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -24479,16 +24370,6 @@
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "dev": true
     },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -25657,7 +25538,6 @@
       "version": "file:packages/ripple-binary-codec",
       "requires": {
         "@xrplf/isomorphic": "^1.0.0-beta.0",
-        "assert": "^2.0.0",
         "bignumber.js": "^9.0.0",
         "buffer": "6.0.3",
         "ripple-address-codec": "^5.0.0-beta.0"
@@ -26962,19 +26842,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@typescript-eslint/parser": "^5.28.0",
     "@xrplf/eslint-config": "^1.9.1",
     "@xrplf/prettier-config": "^1.9.1",
-    "assert": "^2.0.0",
     "buffer": "^6.0.2",
     "chai": "^4.3.4",
     "copyfiles": "^2.4.1",

--- a/packages/ripple-binary-codec/package.json
+++ b/packages/ripple-binary-codec/package.json
@@ -16,9 +16,6 @@
     "buffer": "6.0.3",
     "ripple-address-codec": "^5.0.0-beta.0"
   },
-  "devDependencies": {
-    "assert": "^2.0.0"
-  },
   "scripts": {
     "build": "tsc -b && copyfiles ./src/enums/definitions.json ./dist/enums/",
     "clean": "rm -rf ./dist ./coverage tsconfig.tsbuildinfo",

--- a/packages/ripple-binary-codec/test/signing-data-encoding.test.js
+++ b/packages/ripple-binary-codec/test/signing-data-encoding.test.js
@@ -1,4 +1,3 @@
-const { throws } = require('assert')
 const {
   encodeForSigning,
   encodeForSigningClaim,
@@ -123,7 +122,9 @@ describe('Signing data', function () {
       TransactionType: 'NotAPayment',
     }
 
-    throws(() => encodeForSigning(invalidTransactionType), /NotAPayment/u)
+    expect(() => encodeForSigning(invalidTransactionType)).toThrow(
+      /NotAPayment/u,
+    )
   })
 
   test('can create multi signing blobs', function () {

--- a/packages/xrpl/test/integration/finalTest.test.ts
+++ b/packages/xrpl/test/integration/finalTest.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { assert } from 'chai'
 
 // how long before each test case times out
 const TIMEOUT = 20000

--- a/packages/xrpl/test/integration/fundWallet.test.ts
+++ b/packages/xrpl/test/integration/fundWallet.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { assert } from 'chai'
 
 import {
   Client,
@@ -31,7 +31,7 @@ async function generate_faucet_wallet_and_fund_again(
     account: wallet.classicAddress,
   })
 
-  assert.equal(dropsToXrp(info.result.account_data.Balance), balance)
+  assert.equal(dropsToXrp(info.result.account_data.Balance), balance.toString())
 
   const { balance: newBalance } = await api.fundWallet(wallet, {
     faucetHost,
@@ -45,7 +45,10 @@ async function generate_faucet_wallet_and_fund_again(
   })
 
   assert(newBalance > balance)
-  assert.equal(dropsToXrp(afterSent.result.account_data.Balance), newBalance)
+  assert.equal(
+    dropsToXrp(afterSent.result.account_data.Balance),
+    newBalance.toString(),
+  )
 
   await api.disconnect()
 }
@@ -113,7 +116,10 @@ describe('fundWallet', function () {
         account: wallet.classicAddress,
       })
 
-      assert.equal(dropsToXrp(info.result.account_data.Balance), balance)
+      assert.equal(
+        dropsToXrp(info.result.account_data.Balance),
+        balance.toString(),
+      )
       assert.equal(balance, 10000)
 
       /*
@@ -137,7 +143,7 @@ describe('fundWallet', function () {
         amount: '2000',
         usageContext: 'integration-test',
       })
-      assert.equal(balance, '2000')
+      assert.equal(balance, 2000)
       assert.notStrictEqual(wallet, undefined)
       assert(isValidClassicAddress(wallet.classicAddress))
       assert(isValidXAddress(wallet.getXAddress()))
@@ -146,7 +152,10 @@ describe('fundWallet', function () {
         command: 'account_info',
         account: wallet.classicAddress,
       })
-      assert.equal(dropsToXrp(info.result.account_data.Balance), balance)
+      assert.equal(
+        dropsToXrp(info.result.account_data.Balance),
+        balance.toString(),
+      )
       await api.disconnect()
     },
     TIMEOUT,

--- a/packages/xrpl/test/integration/integration.test.ts
+++ b/packages/xrpl/test/integration/integration.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { assert } from 'chai'
 
 import { Client, SubmitResponse } from '../../src'
 import { AccountSet, SignerListSet } from '../../src/models/transactions'

--- a/packages/xrpl/test/shamap.test.ts
+++ b/packages/xrpl/test/shamap.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { assert } from 'chai'
 
 import SHAMap, { NodeType } from '../src/utils/hashes/SHAMap'
 


### PR DESCRIPTION
## High Level Overview of Change

Right now we have 5 testing library dependencies. This eliminates `assert`. `jest`, `jasmine`, `chai` and `karma` are the remaining ones.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)