### PR TITLE
feat: getXrpBalance and dropsToXRP return number

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -12,6 +12,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
   * `Client.prepareTransaction`
   * `getSignedTx`
   * `isAccountDelete`
+* BREAKING CHANGE: `dropsToXRP` and `Client.getXrpBalance` now return a `number` instead of a `string`
 
 ## 3.0.0 Beta 1 (2023-10-19)
 

--- a/packages/xrpl/snippets/src/bridgeTransfer.ts
+++ b/packages/xrpl/snippets/src/bridgeTransfer.ts
@@ -79,7 +79,7 @@ async function bridgeTransfer(): Promise<void> {
     'Waiting for the attestation to go through... (usually 8-12 seconds)',
   )
   let ledgersWaited = 0
-  let initialBalance = '0'
+  let initialBalance = 0
   while (ledgersWaited < MAX_LEDGERS_WAITED) {
     await sleep(LEDGER_CLOSE_TIME)
     try {
@@ -151,7 +151,7 @@ async function bridgeTransfer(): Promise<void> {
       wallet2.classicAddress,
     )
     console.log(initialBalance, currentBalance)
-    if (parseFloat(currentBalance) > parseFloat(initialBalance)) {
+    if (currentBalance > initialBalance) {
       console.log('Transfer is complete')
       console.log(
         `New balance of ${wallet2.classicAddress} is ${currentBalance} XRP`,

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -831,7 +831,7 @@ class Client extends EventEmitter<EventTypes> {
    * @param [options] - Additional options for fetching the balance (optional).
    * @param [options.ledger_hash] - The hash of the ledger to retrieve the balance from (optional).
    * @param [options.ledger_index] - The index of the ledger to retrieve the balance from (optional).
-   * @returns A promise that resolves with the XRP balance as a string.
+   * @returns A promise that resolves with the XRP balance as a number.
    */
   public async getXrpBalance(
     address: string,
@@ -839,7 +839,7 @@ class Client extends EventEmitter<EventTypes> {
       ledger_hash?: string
       ledger_index?: LedgerIndex
     } = {},
-  ): Promise<string> {
+  ): Promise<number> {
     const xrpRequest: AccountInfoRequest = {
       command: 'account_info',
       account: address,
@@ -913,7 +913,7 @@ class Client extends EventEmitter<EventTypes> {
     const balances: Balance[] = []
 
     // get XRP balance
-    let xrpPromise: Promise<string> = Promise.resolve('')
+    let xrpPromise: Promise<number> = Promise.resolve(0)
     if (!options.peer) {
       xrpPromise = this.getXrpBalance(address, {
         ledger_hash: options.ledger_hash,
@@ -938,8 +938,8 @@ class Client extends EventEmitter<EventTypes> {
         const accountLinesBalance = linesResponses.flatMap((response) =>
           formatBalances(response.result.lines),
         )
-        if (xrpBalance !== '') {
-          balances.push({ currency: 'XRP', value: xrpBalance })
+        if (xrpBalance !== 0) {
+          balances.push({ currency: 'XRP', value: xrpBalance.toString() })
         }
         balances.push(...accountLinesBalance)
       },

--- a/packages/xrpl/src/utils/xrpConversion.ts
+++ b/packages/xrpl/src/utils/xrpConversion.ts
@@ -15,7 +15,7 @@ const SANITY_CHECK = /^-?[0-9.]+$/u
  * @throws When drops amount is invalid.
  * @category Utilities
  */
-export function dropsToXrp(dropsToConvert: BigNumber.Value): string {
+export function dropsToXrp(dropsToConvert: BigNumber.Value): number {
   /*
    * Converting to BigNumber and then back to string should remove any
    * decimal point followed by zeros, e.g. '1.00'.
@@ -50,7 +50,7 @@ export function dropsToXrp(dropsToConvert: BigNumber.Value): string {
     )
   }
 
-  return new BigNumber(drops).dividedBy(DROPS_PER_XRP).toString(BASE_TEN)
+  return new BigNumber(drops).dividedBy(DROPS_PER_XRP).toNumber()
 }
 
 /**

--- a/packages/xrpl/test/client/getXrpBalance.test.ts
+++ b/packages/xrpl/test/client/getXrpBalance.test.ts
@@ -30,7 +30,7 @@ describe('client.getXrpBalance', function () {
         )
         testContext.mockRippled!.addResponse('ledger', rippled.ledger.normal)
         const result = await testContext.client.getXrpBalance(testcase.address)
-        assert.equal(result, '922.913243')
+        assert.equal(result, 922.913243)
       })
     })
   })

--- a/packages/xrpl/test/utils/dropsToXrp.test.ts
+++ b/packages/xrpl/test/utils/dropsToXrp.test.ts
@@ -6,72 +6,72 @@ import { dropsToXrp } from '../../src/utils'
 describe('dropsToXrp', function () {
   it('works with a typical amount', function () {
     const xrp = dropsToXrp('2000000')
-    assert.strictEqual(xrp, '2', '2 million drops equals 2 XRP')
+    assert.strictEqual(xrp, 2, '2 million drops equals 2 XRP')
   })
 
   it('works with fractions', function () {
     let xrp = dropsToXrp('3456789')
-    assert.strictEqual(xrp, '3.456789', '3,456,789 drops equals 3.456789 XRP')
+    assert.strictEqual(xrp, 3.456789, '3,456,789 drops equals 3.456789 XRP')
 
     xrp = dropsToXrp('3400000')
-    assert.strictEqual(xrp, '3.4', '3,400,000 drops equals 3.4 XRP')
+    assert.strictEqual(xrp, 3.4, '3,400,000 drops equals 3.4 XRP')
 
     xrp = dropsToXrp('1')
-    assert.strictEqual(xrp, '0.000001', '1 drop equals 0.000001 XRP')
+    assert.strictEqual(xrp, 0.000001, '1 drop equals 0.000001 XRP')
 
     xrp = dropsToXrp('1.0')
-    assert.strictEqual(xrp, '0.000001', '1.0 drops equals 0.000001 XRP')
+    assert.strictEqual(xrp, 0.000001, '1.0 drops equals 0.000001 XRP')
 
     xrp = dropsToXrp('1.00')
-    assert.strictEqual(xrp, '0.000001', '1.00 drops equals 0.000001 XRP')
+    assert.strictEqual(xrp, 0.000001, '1.00 drops equals 0.000001 XRP')
   })
 
   it('works with zero', function () {
     let xrp = dropsToXrp('0')
-    assert.strictEqual(xrp, '0', '0 drops equals 0 XRP')
+    assert.strictEqual(xrp, 0, '0 drops equals 0 XRP')
 
     // negative zero is equivalent to zero
     xrp = dropsToXrp('-0')
-    assert.strictEqual(xrp, '0', '-0 drops equals 0 XRP')
+    assert.strictEqual(xrp, 0, '-0 drops equals 0 XRP')
 
     xrp = dropsToXrp('0.00')
-    assert.strictEqual(xrp, '0', '0.00 drops equals 0 XRP')
+    assert.strictEqual(xrp, 0, '0.00 drops equals 0 XRP')
 
     xrp = dropsToXrp('000000000')
-    assert.strictEqual(xrp, '0', '000000000 drops equals 0 XRP')
+    assert.strictEqual(xrp, 0, '000000000 drops equals 0 XRP')
   })
 
   it('works with a negative value', function () {
     const xrp = dropsToXrp('-2000000')
-    assert.strictEqual(xrp, '-2', '-2 million drops equals -2 XRP')
+    assert.strictEqual(xrp, -2, '-2 million drops equals -2 XRP')
   })
 
   it('works with a value ending with a decimal point', function () {
     let xrp = dropsToXrp('2000000.')
-    assert.strictEqual(xrp, '2', '2000000. drops equals 2 XRP')
+    assert.strictEqual(xrp, 2, '2000000. drops equals 2 XRP')
 
     xrp = dropsToXrp('-2000000.')
-    assert.strictEqual(xrp, '-2', '-2000000. drops equals -2 XRP')
+    assert.strictEqual(xrp, -2, '-2000000. drops equals -2 XRP')
   })
 
   it('works with BigNumber objects', function () {
     let xrp = dropsToXrp(new BigNumber(2000000))
-    assert.strictEqual(xrp, '2', '(BigNumber) 2 million drops equals 2 XRP')
+    assert.strictEqual(xrp, 2, '(BigNumber) 2 million drops equals 2 XRP')
 
     xrp = dropsToXrp(new BigNumber(-2000000))
-    assert.strictEqual(xrp, '-2', '(BigNumber) -2 million drops equals -2 XRP')
+    assert.strictEqual(xrp, -2, '(BigNumber) -2 million drops equals -2 XRP')
 
     xrp = dropsToXrp(new BigNumber(2345678))
     assert.strictEqual(
       xrp,
-      '2.345678',
+      2.345678,
       '(BigNumber) 2,345,678 drops equals 2.345678 XRP',
     )
 
     xrp = dropsToXrp(new BigNumber(-2345678))
     assert.strictEqual(
       xrp,
-      '-2.345678',
+      -2.345678,
       '(BigNumber) -2,345,678 drops equals -2.345678 XRP',
     )
   })
@@ -79,27 +79,27 @@ describe('dropsToXrp', function () {
   it('works with a number', function () {
     // This is not recommended. Use strings or BigNumber objects to avoid precision errors.
     let xrp = dropsToXrp(2000000)
-    assert.strictEqual(xrp, '2', '(number) 2 million drops equals 2 XRP')
+    assert.strictEqual(xrp, 2, '(number) 2 million drops equals 2 XRP')
     xrp = dropsToXrp(-2000000)
-    assert.strictEqual(xrp, '-2', '(number) -2 million drops equals -2 XRP')
+    assert.strictEqual(xrp, -2, '(number) -2 million drops equals -2 XRP')
   })
 
   it('works with scientific notation', function () {
     const xrp = dropsToXrp('1e6')
     assert.strictEqual(
       xrp,
-      '1',
+      1,
       '(scientific notation string) 1e6 drops equals 1 XRP',
     )
   })
 
   it('throws with an amount with too many decimal places', function () {
     assert.throws(() => {
-      dropsToXrp('1.2')
+      dropsToXrp(1.2)
     }, /has too many decimal places/u)
 
     assert.throws(() => {
-      dropsToXrp('0.10')
+      dropsToXrp(0.1)
     }, /has too many decimal places/u)
   })
 


### PR DESCRIPTION
## High Level Overview of Change

BREAKING CHANGE: `dropsToXRP` and `Client.getXrpBalance` now return a `number` instead of a `string`

### Context of Change

@mvadari requested this be updated in a breaking release.

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users