### PR TITLE
fix: add support for pseudo-transactions to `hashSignedTx`

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -56,6 +56,7 @@ Bundler configurations are much more simplified. See [../UNIQUE_STEPS](Unique St
 ### Fixed
 * Fixed Wallet.generate() ignoring the `algorithm` parameter (Only a problem once binary-codec fix for `derive_keypair` is added)
 * Fixed Wallet.fromSeed() ignoring the `algorithm` parameter
+* Added pseudo-transaction support to hash functions and response types
 
 ## Unreleased 2.x
 

--- a/packages/xrpl/src/utils/hashes/hashLedger.ts
+++ b/packages/xrpl/src/utils/hashes/hashLedger.ts
@@ -71,19 +71,25 @@ function addLengthPrefix(hex: string): string {
  * @throws ValidationError if the Transaction is unsigned.\
  * @category Utilities
  */
-export function hashSignedTx(tx: Transaction | string): string {
+export function hashSignedTx(
+  tx: Transaction | PseudoTransaction | string,
+): string {
   let txBlob: string
-  let txObject: Transaction
+  let txObject: Transaction | PseudoTransaction
   if (typeof tx === 'string') {
     txBlob = tx
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Required until updated in binary codec. */
-    txObject = decode(tx) as unknown as Transaction
+    txObject = decode(tx) as unknown as Transaction | PseudoTransaction
   } else {
     txBlob = encode(tx)
     txObject = tx
   }
 
-  if (txObject.TxnSignature === undefined && txObject.Signers === undefined) {
+  if (
+    txObject.TxnSignature === undefined &&
+    txObject.Signers === undefined &&
+    txObject.SigningPubKey === undefined
+  ) {
     throw new ValidationError('The transaction must be signed to hash it.')
   }
 

--- a/packages/xrpl/src/utils/hashes/hashLedger.ts
+++ b/packages/xrpl/src/utils/hashes/hashLedger.ts
@@ -71,15 +71,13 @@ function addLengthPrefix(hex: string): string {
  * @throws ValidationError if the Transaction is unsigned.\
  * @category Utilities
  */
-export function hashSignedTx(
-  tx: Transaction | PseudoTransaction | string,
-): string {
+export function hashSignedTx(tx: Transaction | string): string {
   let txBlob: string
-  let txObject: Transaction | PseudoTransaction
+  let txObject: Transaction
   if (typeof tx === 'string') {
     txBlob = tx
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Required until updated in binary codec. */
-    txObject = decode(tx) as unknown as Transaction | PseudoTransaction
+    txObject = decode(tx) as unknown as Transaction
   } else {
     txBlob = encode(tx)
     txObject = tx

--- a/packages/xrpl/test/utils/hashLedger.test.ts
+++ b/packages/xrpl/test/utils/hashLedger.test.ts
@@ -150,22 +150,4 @@ describe('hashLedger', function () {
       'transactionHash in header does not match computed hash of transactions',
     )
   })
-
-  it('hashSignedTx - pseudo-transaction', function () {
-    const transaction: EnableAmendment = {
-      Account: 'rrrrrrrrrrrrrrrrrrrrrhoLvTp',
-      Amendment:
-        'AE35ABDEFBDE520372B31C957020B34A7A4A9DC3115A69803A44016477C84D6E',
-      Fee: '0',
-      LedgerSequence: 84206081,
-      Sequence: 0,
-      SigningPubKey: '',
-      TransactionType: 'EnableAmendment',
-    }
-
-    assert.equal(
-      hashes.hashSignedTx(transaction),
-      'CA4562711E4679FE9317DD767871E90A404C7A8B84FAFD35EC2CF0231F1F6DAF',
-    )
-  })
 })

--- a/packages/xrpl/test/utils/hashLedger.test.ts
+++ b/packages/xrpl/test/utils/hashLedger.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 
-import { EnableAmendment, ValidationError, XrplError } from '../../src'
+import { ValidationError, XrplError } from '../../src'
 import { hashes } from '../../src/utils'
 import requests from '../fixtures/requests'
 import responses from '../fixtures/responses'

--- a/packages/xrpl/test/utils/hashLedger.test.ts
+++ b/packages/xrpl/test/utils/hashLedger.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 
-import { ValidationError, XrplError } from '../../src'
+import { EnableAmendment, ValidationError, XrplError } from '../../src'
 import { hashes } from '../../src/utils'
 import requests from '../fixtures/requests'
 import responses from '../fixtures/responses'
@@ -148,6 +148,24 @@ describe('hashLedger', function () {
       () => hashLedger(header, { computeTreeHashes: true }),
       ValidationError,
       'transactionHash in header does not match computed hash of transactions',
+    )
+  })
+
+  it('hashSignedTx - pseudo-transaction', function () {
+    const transaction: EnableAmendment = {
+      Account: 'rrrrrrrrrrrrrrrrrrrrrhoLvTp',
+      Amendment:
+        'AE35ABDEFBDE520372B31C957020B34A7A4A9DC3115A69803A44016477C84D6E',
+      Fee: '0',
+      LedgerSequence: 84206081,
+      Sequence: 0,
+      SigningPubKey: '',
+      TransactionType: 'EnableAmendment',
+    }
+
+    assert.equal(
+      hashes.hashSignedTx(transaction),
+      'CA4562711E4679FE9317DD767871E90A404C7A8B84FAFD35EC2CF0231F1F6DAF',
     )
   })
 })

--- a/packages/xrpl/test/utils/hashes.test.ts
+++ b/packages/xrpl/test/utils/hashes.test.ts
@@ -171,6 +171,7 @@ describe('Hashes', function () {
   it('Throw an error when hashing an unsigned transaction', function () {
     const offerCreateWithNoSignature: OfferCreate = {
       ...(fixtures.tx.OfferCreateSell.result as OfferCreate),
+      SigningPubKey: undefined,
       TxnSignature: undefined,
     }
 
@@ -183,7 +184,7 @@ describe('Hashes', function () {
   it('Throw when hashing an unsigned transaction blob', function () {
     const encodedOfferCreateWithNoSignature: string = encode({
       ...fixtures.tx.OfferCreateSell.result,
-      SigningPublicKey: undefined,
+      SigningPubKey: undefined,
       TxnSignature: undefined,
     })
 

--- a/packages/xrpl/test/utils/hashes.test.ts
+++ b/packages/xrpl/test/utils/hashes.test.ts
@@ -4,7 +4,12 @@ import path from 'path'
 import { assert } from 'chai'
 import { encode } from 'ripple-binary-codec'
 
-import { OfferCreate, Transaction, ValidationError } from '../../src'
+import {
+  EnableAmendment,
+  OfferCreate,
+  Transaction,
+  ValidationError,
+} from '../../src'
 import {
   hashStateTree,
   hashTxTree,
@@ -178,12 +183,31 @@ describe('Hashes', function () {
   it('Throw when hashing an unsigned transaction blob', function () {
     const encodedOfferCreateWithNoSignature: string = encode({
       ...fixtures.tx.OfferCreateSell.result,
+      SigningPublicKey: undefined,
       TxnSignature: undefined,
     })
 
     assert.throws(
       () => hashSignedTx(encodedOfferCreateWithNoSignature),
       ValidationError,
+    )
+  })
+
+  it('hashSignedTx - pseudo-transaction', function () {
+    const transaction: EnableAmendment = {
+      Account: 'rrrrrrrrrrrrrrrrrrrrrhoLvTp',
+      Amendment:
+        'AE35ABDEFBDE520372B31C957020B34A7A4A9DC3115A69803A44016477C84D6E',
+      Fee: '0',
+      LedgerSequence: 84206081,
+      Sequence: 0,
+      SigningPubKey: '',
+      TransactionType: 'EnableAmendment',
+    }
+
+    assert.equal(
+      hashSignedTx(transaction),
+      'CA4562711E4679FE9317DD767871E90A404C7A8B84FAFD35EC2CF0231F1F6DAF',
     )
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

I was running the binary codec across a ledger with an `EnableAmendment` transaction and ran into an issue when double checking the transaction hash.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes

## Test Plan

Added a test.
