### PR TITLE
docs: remove Buffer polyfill for react-native

### DIFF
--- a/UNIQUE_SETUPS.md
+++ b/UNIQUE_SETUPS.md
@@ -40,7 +40,6 @@ If you want to use `xrpl.js` with React Native you will need to install polyfill
 3. Create `polyfills.js` and add
 
 ```javascript
-if (typeof Buffer === 'undefined') global.Buffer = require('buffer').Buffer
 // Required for TextEncoder/TextDecoder
 import 'fast-text-encoding'
 // Required for `crypto.getRandomValues`


### PR DESCRIPTION
## High Level Overview of Change

React native no longer needs a polyfill after `xrpl@3.0.0-beta.1`

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users