### PR TITLE
Support alt. native assets

### DIFF
--- a/packages/ripple-binary-codec/src/index.ts
+++ b/packages/ripple-binary-codec/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from './enums'
 import { XrplDefinitions } from './enums/xrpl-definitions'
 import { coreTypes } from './types'
+import { nativeAsset } from './nativeasset'
 
 const {
   signingData,
@@ -138,4 +139,5 @@ export {
   XrplDefinitionsBase,
   DEFAULT_DEFINITIONS,
   coreTypes,
+  nativeAsset,
 }

--- a/packages/ripple-binary-codec/src/nativeasset.ts
+++ b/packages/ripple-binary-codec/src/nativeasset.ts
@@ -1,0 +1,19 @@
+class NativeAsset {
+  private nativeAsset = 'XRP'
+
+  constructor() {
+    //
+  }
+
+  set(asset: string): void {
+    this.nativeAsset = asset.trim().toUpperCase()
+  }
+
+  get(): string {
+    return this.nativeAsset
+  }
+}
+
+const nativeAsset = new NativeAsset()
+
+export { nativeAsset }

--- a/packages/ripple-binary-codec/src/types/amount.ts
+++ b/packages/ripple-binary-codec/src/types/amount.ts
@@ -15,7 +15,7 @@ const MIN_IOU_EXPONENT = -96
 const MAX_IOU_EXPONENT = 80
 const MAX_IOU_PRECISION = 16
 const MAX_DROPS = new Decimal('1e17')
-const MIN_XRP = new Decimal('1e-6')
+const MIN_NATIVE_ASSET = new Decimal('1e-6')
 const mask = bigInt(0x00000000ffffffff)
 
 /**
@@ -74,7 +74,7 @@ class Amount extends SerializedType {
 
     let amount = Buffer.alloc(8)
     if (typeof value === 'string') {
-      Amount.assertXrpIsValid(value)
+      Amount.assertNativeAssetIsValid(value)
 
       const number = bigInt(value)
 
@@ -135,8 +135,8 @@ class Amount extends SerializedType {
    * @returns An Amount object
    */
   static fromParser(parser: BinaryParser): Amount {
-    const isXRP = parser.peek() & 0x80
-    const numBytes = isXRP ? 48 : 8
+    const isNativeAsset = parser.peek() & 0x80
+    const numBytes = isNativeAsset ? 48 : 8
     return new Amount(parser.read(numBytes))
   }
 
@@ -186,19 +186,19 @@ class Amount extends SerializedType {
   }
 
   /**
-   * Validate XRP amount
+   * Validate Native Asset amount
    *
-   * @param amount String representing XRP amount
+   * @param amount String representing Native Asset amount
    * @returns void, but will throw if invalid amount
    */
-  private static assertXrpIsValid(amount: string): void {
+  private static assertNativeAssetIsValid(amount: string): void {
     if (amount.indexOf('.') !== -1) {
       throw new Error(`${amount.toString()} is an illegal amount`)
     }
 
     const decimal = new Decimal(amount)
     if (!decimal.isZero()) {
-      if (decimal.lt(MIN_XRP) || decimal.gt(MAX_DROPS)) {
+      if (decimal.lt(MIN_NATIVE_ASSET) || decimal.gt(MAX_DROPS)) {
         throw new Error(`${amount.toString()} is an illegal amount`)
       }
     }
@@ -244,9 +244,9 @@ class Amount extends SerializedType {
   }
 
   /**
-   * Test if this amount is in units of Native Currency(XRP)
+   * Test if this amount is in units of Native Currency(Native Asset)
    *
-   * @returns true if Native (XRP)
+   * @returns true if Native (Native Asset)
    */
   private isNative(): boolean {
     return (this.bytes[0] & 0x80) === 0

--- a/packages/ripple-binary-codec/src/types/currency.ts
+++ b/packages/ripple-binary-codec/src/types/currency.ts
@@ -1,7 +1,8 @@
 import { Hash160 } from './hash-160'
 import { Buffer } from 'buffer/'
+import { nativeAsset } from '../nativeasset'
 
-const XRP_HEX_REGEX = /^0{40}$/
+const NATIVE_ASSET_HEX_REGEX = /^0{40}$/
 const ISO_REGEX = /^[A-Z0-9a-z?!@#$%^&*(){}[\]|]{3}$/
 const HEX_REGEX = /^[A-F0-9]{40}$/
 // eslint-disable-next-line no-control-regex
@@ -12,7 +13,7 @@ const STANDARD_FORMAT_HEX_REGEX = /^0{24}[\x00-\x7F]{6}0{10}$/
  */
 function isoToBytes(iso: string): Buffer {
   const bytes = Buffer.alloc(20)
-  if (iso !== 'XRP') {
+  if (iso !== nativeAsset.get()) {
     const isoBytes = iso.split('').map((c) => c.charCodeAt(0))
     bytes.set(isoBytes, 12)
   }
@@ -28,7 +29,7 @@ function isIsoCode(iso: string): boolean {
 
 function isoCodeFromHex(code: Buffer): string | null {
   const iso = code.toString()
-  if (iso === 'XRP') {
+  if (iso === nativeAsset.get()) {
     return null
   }
   if (isIsoCode(iso)) {
@@ -81,15 +82,15 @@ function bytesFromRepresentation(input: string): Buffer {
  * Class defining how to encode and decode Currencies
  */
 class Currency extends Hash160 {
-  static readonly XRP = new Currency(Buffer.alloc(20))
+  static readonly NATIVE_ASSET = new Currency(Buffer.alloc(20))
   private readonly _iso: string | null
 
   constructor(byteBuf: Buffer) {
-    super(byteBuf ?? Currency.XRP.bytes)
+    super(byteBuf ?? Currency.NATIVE_ASSET.bytes)
     const hex = this.bytes.toString('hex')
 
-    if (XRP_HEX_REGEX.test(hex)) {
-      this._iso = 'XRP'
+    if (NATIVE_ASSET_HEX_REGEX.test(hex)) {
+      this._iso = nativeAsset.get()
     } else if (STANDARD_FORMAT_HEX_REGEX.test(hex)) {
       this._iso = isoCodeFromHex(this.bytes.slice(12, 15))
     } else {

--- a/packages/ripple-binary-codec/src/types/issue.ts
+++ b/packages/ripple-binary-codec/src/types/issue.ts
@@ -5,6 +5,8 @@ import { Currency } from './currency'
 import { JsonObject, SerializedType } from './serialized-type'
 import { Buffer } from 'buffer/'
 
+import { nativeAsset } from '../nativeasset'
+
 /**
  * Interface for JSON objects that represent amounts
  */
@@ -66,7 +68,7 @@ class Issue extends SerializedType {
    */
   static fromParser(parser: BinaryParser): Issue {
     const currency = parser.read(20)
-    if (new Currency(currency).toJSON() === 'XRP') {
+    if (new Currency(currency).toJSON() === nativeAsset.get()) {
       return new Issue(currency)
     }
     const currencyAndIssuer = [currency, parser.read(20)]
@@ -81,7 +83,7 @@ class Issue extends SerializedType {
   toJSON(): IssueObject {
     const parser = new BinaryParser(this.toString())
     const currency = Currency.fromParser(parser) as Currency
-    if (currency.toJSON() === 'XRP') {
+    if (currency.toJSON() === nativeAsset.get()) {
       return { currency: currency.toJSON() }
     }
     const issuer = AccountID.fromParser(parser) as AccountID

--- a/packages/ripple-binary-codec/test/native-asset.test.js
+++ b/packages/ripple-binary-codec/test/native-asset.test.js
@@ -1,0 +1,53 @@
+const { encode } = require('./../src/index')
+const { nativeAsset } = require('./../src/nativeasset')
+
+const baseTxXrp = {
+  TransactionType: 'TrustSet',
+  Account: 'ra5nK24KXen9AHvsdFTKHSANinZseWnPcX',
+  LimitAmount: {
+    currency: 'XRP',
+    issuer: 'rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc',
+    value: '100',
+  },
+}
+
+const baseTxXah = {
+  TransactionType: 'TrustSet',
+  Account: 'ra5nK24KXen9AHvsdFTKHSANinZseWnPcX',
+  LimitAmount: {
+    currency: 'XAH',
+    issuer: 'rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc',
+    value: '100',
+  },
+}
+
+describe('XRP Native asset', function () {
+  it('XRP as native to be native', function () {
+    nativeAsset.set('XRP')
+
+    expect(encode(baseTxXrp).slice(24, 64)).toEqual(
+      '0000000000000000000000000000000000000000',
+    )
+  })
+  it('XRP as non-native to be non-native', function () {
+    nativeAsset.set('XAH')
+
+    expect(encode(baseTxXrp).slice(24, 64)).toEqual(
+      '0000000000000000000000005852500000000000',
+    )
+  })
+  it('XAH as native to be native', function () {
+    nativeAsset.set('XAH')
+
+    expect(encode(baseTxXah).slice(24, 64)).toEqual(
+      '0000000000000000000000000000000000000000',
+    )
+  })
+  it('XAH as non-native to be non-native', function () {
+    nativeAsset.set('XRP')
+
+    expect(encode(baseTxXah).slice(24, 64)).toEqual(
+      '0000000000000000000000005841480000000000',
+    )
+  })
+})


### PR DESCRIPTION
## High Level Overview of Change

Support for setting alternative native asset for currency encoding using:

```
nativeAsset.set('XRP')
```

Required when dealing with issued currencies on a network where XRP isn't the native asset, e.g. `XAH` or `USD`.