### PR TITLE
fix AMM ledger object's LPTokenBalance type to IssuedCurrencyAmount

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 
+### Fixed
+* Fix `AMM` ledger object's `LPTokenBalance` type to `IssuedCurrencyAmount`.
+
 ## 2.14.0 (2023-11-30)
 
 ### Added

--- a/packages/xrpl/src/models/ledger/AMM.ts
+++ b/packages/xrpl/src/models/ledger/AMM.ts
@@ -60,7 +60,7 @@ export default interface AMM extends BaseLedgerEntry, MissingPreviousTxnID {
    * The holders of these tokens can vote on the AMM's trading fee in proportion to their holdings,
    * or redeem the tokens for a share of the AMM's assets which grows with the trading fees collected.
    */
-  LPTokenBalance: Currency
+  LPTokenBalance: IssuedCurrencyAmount
   /**
    * The percentage fee to be charged for trades against this AMM instance, in units of 1/100,000.
    * The maximum value is 1000, for a 1% fee.


### PR DESCRIPTION
## High Level Overview of Change

Fix `AMM` ledger object's `LPTokenBalance` type to `IssuedCurrencyAmount`. It's incorrectly set to `Currency`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users
