### PR TITLE
Set default api_version in requests

### DIFF
--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -199,6 +199,12 @@ class Client extends EventEmitter<EventTypes> {
   public buildVersion: string | undefined
 
   /**
+   * API Version used by the server this client is connected to
+   *
+   */
+  public apiVersion: number | undefined
+
+  /**
    * Creates a new Client with a websocket connection to a rippled server.
    *
    * @param server - URL of the server to connect to.
@@ -313,6 +319,7 @@ class Client extends EventEmitter<EventTypes> {
         ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Must be string
           ensureClassicAddress(req.account as string)
         : undefined,
+      api_version: req.api_version ?? this.apiVersion,
     })
 
     // mutates `response` to add warnings
@@ -489,6 +496,8 @@ class Client extends EventEmitter<EventTypes> {
       })
       this.networkID = response.result.info.network_id ?? undefined
       this.buildVersion = response.result.info.build_version
+      // set this.apiVersion to 1 or 2 based on the buildVersion major version
+      this.apiVersion = parseInt(this.buildVersion.split('.')[0], 10)
     } catch (error) {
       // eslint-disable-next-line no-console -- Print the error to console but allows client to be connected.
       console.error(error)

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -496,7 +496,6 @@ class Client extends EventEmitter<EventTypes> {
       })
       this.networkID = response.result.info.network_id ?? undefined
       this.buildVersion = response.result.info.build_version
-      // set this.apiVersion to 1 or 2 based on the buildVersion major version
       this.apiVersion = parseInt(this.buildVersion.split('.')[0], 10)
     } catch (error) {
       // eslint-disable-next-line no-console -- Print the error to console but allows client to be connected.


### PR DESCRIPTION
## High Level Overview of Change

Set default `api_version` in requests if not supplied. Default api_version will use `buildVersion` of what server the client is connected to.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [ ] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
