### PR TITLE
fix: throw error if `hexToBytes` or `hexToString` is provided a string that is not in hex

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,60 +1,60 @@
 {
-    "editor.tabSize": 2,
-    "cSpell.words": [
-        "altnet",
-        "Autofills",
-        "Clawback",
-        "hostid",
-        "keypair",
-        "keypairs",
-        "multisign",
-        "multisigned",
-        "multisigning",
-        "preauthorization",
-        "rippletest",
-        "secp256k1",
-        "Setf",
-        "Sidechains",
-        "xchain"
-    ],
-    "[javascript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "[javascriptreact]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "[typescript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "[typescriptreact]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "eslint.alwaysShowStatus": true,
-    "eslint.lintTask.enable": true,
-    "eslint.codeAction.showDocumentation": {
-        "enable": true
-    },
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
-    },
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
-    "files.watcherExclude": {
-        "**/.git/objects/**": true,
-        "**/.git/subtree-cache/**": true,
-        "**/.hg/store/**": true
-    },
-    "search.exclude": {
-        "**/.git": true,
-        "**/node_modules": true,
-        "**/tmp": true,
-        "**/docs/**/*.html": true,
-        "**/fixtures/**/*.json": true,
-        "**/docs/assets": true
-    },
+  "editor.tabSize": 2,
+  "cSpell.words": [
+    "altnet",
+    "Autofills",
+    "Clawback",
+    "hostid",
+    "keypair",
+    "keypairs",
+    "multisign",
+    "multisigned",
+    "multisigning",
+    "preauthorization",
+    "rippletest",
+    "secp256k1",
+    "Setf",
+    "Sidechains",
+    "xchain"
+  ],
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "eslint.alwaysShowStatus": true,
+  "eslint.lintTask.enable": true,
+  "eslint.codeAction.showDocumentation": {
+    "enable": true
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/.hg/store/**": true
+  },
+  "search.exclude": {
+    "**/.git": true,
+    "**/node_modules": true,
+    "**/tmp": true,
+    "**/docs/**/*.html": true,
+    "**/fixtures/**/*.json": true,
+    "**/docs/assets": true
+  }
 }

--- a/packages/isomorphic/HISTORY.md
+++ b/packages/isomorphic/HISTORY.md
@@ -1,5 +1,11 @@
 # @xrplf/isomorphic Release History
 
+## Unreleased
+
+### Fixed
+
+* Throw error if `hexToBytes` or `hexToString` is provided a string that is not in hex
+
 ## 1.0.0 (2024-02-01)
 
 Initial release providing isomorphic and tree-shakable implementations of:
@@ -14,21 +20,3 @@ Initial release providing isomorphic and tree-shakable implementations of:
 * randomBytes
 * stringToHex
 * ws
-
-## 1.0.0 Beta 1 (2023-11-30)
-
-## Added
-* hexToString
-* stringToHex
-
-## 1.0.0 Beta 0 (2023-10-19)
-
-Initial release providing isomorphic and tree-shakable implementations of:
-
-* ripemd160
-* sha256
-* sha512
-* bytesToHash
-* hashToBytes
-* randomBytes
-* ws_

--- a/packages/isomorphic/src/utils/index.ts
+++ b/packages/isomorphic/src/utils/index.ts
@@ -64,6 +64,9 @@ export const bytesToHex: typeof BytesToHexFn = (bytes) => {
 }
 
 export const hexToBytes: typeof HexToBytesFn = (hex) => {
+  if (!/^[A-F0-9]*$/iu.test(hex)) {
+    throw new Error('Invalid hex string')
+  }
   return toUint8Array(Buffer.from(hex, 'hex'))
 }
 
@@ -75,6 +78,9 @@ export const hexToString: typeof HexToStringFn = (
   hex: string,
   encoding = 'utf8',
 ): string => {
+  if (!/^[A-F0-9]*$/iu.test(hex)) {
+    throw new Error('Invalid hex string')
+  }
   return new TextDecoder(encoding).decode(hexToBytes(hex))
 }
 

--- a/packages/isomorphic/test/utils.test.ts
+++ b/packages/isomorphic/test/utils.test.ts
@@ -23,8 +23,12 @@ describe('utils', function () {
     expect(hexToBytes('DEADBEEF')).toEqual(new Uint8Array([222, 173, 190, 239]))
   })
 
-  it('bytesToHex - DEADBEEF', () => {
-    expect(bytesToHex([222, 173, 190, 239])).toEqual('DEADBEEF')
+  it('hexToBytes - DEADBEEF', () => {
+    expect(hexToBytes('DEADBEEF')).toEqual(new Uint8Array([222, 173, 190, 239]))
+  })
+
+  it('bytesToHex - bad hex', () => {
+    expect(() => hexToBytes('hello')).toThrow(new Error('Invalid hex string'))
   })
 
   it('bytesToHex - 010203', () => {
@@ -41,6 +45,10 @@ describe('utils', function () {
 
   it('hexToString - deadbeef+infinity symbol (HEX)', () => {
     expect(hexToString('6465616462656566D68D')).toEqual('deadbeef֍')
+  })
+
+  it('hexToString - bad hex', () => {
+    expect(() => hexToString('hello')).toThrow(new Error('Invalid hex string'))
   })
 
   it('stringToHex - deadbeef+infinity symbol (utf8)', () => {

--- a/packages/ripple-address-codec/HISTORY.md
+++ b/packages/ripple-address-codec/HISTORY.md
@@ -15,25 +15,6 @@
 * Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
 * Execute test in a browser in addition to node
 
-## 5.0.0 Beta 1 (2023-11-30)
-
-### Breaking Changes
-* `Buffer` has been replaced with `UInt8Array` for both params and return values. `Buffer` may continue to work with params since they extend `UInt8Arrays`.
-
-### Changes
-* Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
-
-## 5.0.0 Beta 0 (2023-10-19)
-
-### Breaking Changes
-* Bump typescript to 5.x
-* Remove Node 14 support
-* Remove `assert` dependency. If you were catching `AssertionError` you need to change to `Error`.
-* Remove `create-hash` in favor of `@noble/hashes`
-
-### Changes
-* Execute test in a browser in addition to node
-
 ## 4.3.1 (2023-09-27)
 ### Fixed
 * Fix source-maps not finding their designated source

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -19,23 +19,6 @@
   * `Comparable` is now a generic type so that it allows `compareTo` methods to take more that the type itself.
 * Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
 
-## 2.0.0 Beta 1 (2023-11-30)
-
-### Breaking Changes
-* `Buffer` has been replaced with `UInt8Array` for both params and return values. `Buffer` may continue to work with params since they extend `UInt8Arrays`.
-
-### Changes
-* Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
-
-## 2.0.0 Beta 0 (2023-10-19)
-
-### Breaking Changes
-* Bump typescript to 5.x
-* Remove Node 14 support
-* Remove decimal.js and big-integer. Use `BigNumber` from `bignumber.js` instead of `Decimal` and the native `BigInt` instead of `bigInt`.
-* Remove `assert` dependency. If you were catching `AssertionError` you need to change to `Error`.
-* Remove `create-hash` in favor of `@noble/hashes`
-
 ### Changes
 * Update type definitions which causing errors in tests that the code already supported
     * `makeParser` to accept a `Buffer` in addition to `string`

--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -19,29 +19,6 @@
 * Remove `brorand` as a dependency and use `@xrplf/isomorphic` instead.
 * Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
 
-## 2.0.0 Beta 1 (2023-11-30)
-
-### Breaking Changes
-* `Buffer` has been replaced with `UInt8Array` for both params and return values. `Buffer` may continue to work with params since they extend `UInt8Arrays`.
-
-### Changes
-* Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
-
-## 2.0.0 Beta 0 (2023-10-19)
-
-### Breaking Changes
-* Bump typescript to 5.x
-* Remove Node 14 support
-* Remove `assert` dependency. If you were catching `AssertionError` you need to change to `Error`.
-* Fix `deriveKeypair` ignoring manual decoding algorithm. (Specifying algorithm=`ed25519` in `opts` now works on secrets like `sNa1...`)
-* Remove `crypto` polyfills, `create-hash`, `elliptic`, `hash.js`, and their many dependencies in favor of `@noble/hashes` and `@nobel/curves`
-* Remove `bytesToHex` and `hexToBytes`.  They can now be found in `@xrplf/isomorphic/utils`
-* `verifyTransaction` will throw an error if there is no signature
-* Improved key algorithm detection. It will now throw Errors with helpful messages
-
-### Changes
-* Remove `brorand` as a dependency and use `@xrplf/isomorphic` instead.
-
 ## 1.3.1 (2023-09-27)
 ### Fixed
 * Fix source-maps not finding their designated source

--- a/packages/secret-numbers/HISTORY.md
+++ b/packages/secret-numbers/HISTORY.md
@@ -19,24 +19,3 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Unit tests run in a browser and node.
 * Remove `brorand` as a dependency and use `@xrplf/isomorphic` instead.
 * Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
-
-## 1.0.0 Beta 1 (2023-11-30)
-
-### BREAKING CHANGES:
-* Moved all methods that were on `Utils` are now individually exported.
-* `Buffer` has been replaced with `UInt8Array` for both params and return values. `Buffer` may continue to work with params since they extend `UInt8Arrays`.
-
-### Changes
-* Eliminates 4 runtime dependencies: `base-x`, `base64-js`, `buffer`, and `ieee754`.
-
-## 1.0.0 Beta 0 (2023-10-19)
-
-* Add `xrpl-secret-numbers` by @WietseWind  to the mono repo.
-* `unpkg` and `jsdelivr` support was simplified.
-* Unit tests run in a browser and node.
-* Remove `brorand` as a dependency and use `@xrplf/isomorphic` instead.
-
-### BREAKING CHANGES:
-* `xrpl-secret-numbers` is now `@xrplf/secret-numbers`.
-* The bundled file produced changed from  `dist/browerified.js` to `build/xrplf-secret-numbers-latest.js`.
-* Bundle variable is `xrplf_secret_numbers` instead of using browserify's loader.


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

The current methods return an empty bytes object/string if they are not provided a string in hex, which caused an issue.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update `HISTORY.md`?

- [x] Yes
- [ ] No, this change does not impact library users

I also cleaned up the other `HISTORY.md` files.

## Test Plan

Added tests, they pass.
