### PR TITLE
fix: add `PreviousFields` to `DeletedNode` metadata type

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -7,6 +7,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ### Fixed
 * Typo in `Channel` type `source_tab` -> `source_tag`
 * Fix `client.requestAll` to handle filters better
+* Add `PreviousFields` to `DeletedNode` metadata type
 
 ## 3.0.0 (2024-02-01)
 

--- a/packages/xrpl/src/models/transactions/metadata.ts
+++ b/packages/xrpl/src/models/transactions/metadata.ts
@@ -40,6 +40,7 @@ export interface DeletedNode {
   DeletedNode: {
     LedgerEntryType: string
     LedgerIndex: string
+    PreviousFields?: { [field: string]: unknown }
     FinalFields: { [field: string]: unknown }
   }
 }


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

Example transaction where a `DeletedNode` has both `PreviousFields` and `FinalFields`: https://livenet.xrpl.org/transactions/424661CF1FD3675D11EC910CF161979553B6D135F9BD03E6F8D4611D88D27581/raw

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes

## Test Plan

N/A
