### PR TITLE
fix: reduce faucet to 1000

### DIFF
--- a/packages/xrpl/test/integration/fundWallet.test.ts
+++ b/packages/xrpl/test/integration/fundWallet.test.ts
@@ -124,10 +124,10 @@ describe('fundWallet', function () {
 
       await api.connect()
       const { wallet, balance } = await api.fundWallet(null, {
-        amount: '2000',
+        amount: '1000',
         usageContext: 'integration-test',
       })
-      assert.equal(balance, 2000)
+      assert.equal(balance, 1000)
       assert.notStrictEqual(wallet, undefined)
       assert(isValidClassicAddress(wallet.classicAddress))
       assert(isValidXAddress(wallet.getXAddress()))


### PR DESCRIPTION
## High Level Overview of Change

The faucet has been reduced to 1000 XRP per request - https://xrpl.org/blog/2024/testnet-reset

### Context of Change

Reduce from 2000 to 1000 in faucet test

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [X] No, this change does not impact library users

## Test Plan

Tests pass in CI
