### PR TITLE
feat: default requests to use rippled API v2

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,7 @@
 name: Node.js CI
 
 env:
-  RIPPLED_DOCKER_IMAGE: rippleci/rippled:2.0.0-b4
+  RIPPLED_DOCKER_IMAGE: rippleci/rippled:2.2.0-b3
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ From the top-level xrpl.js folder (one level above `packages`), run the followin
 ```bash
 npm install
 # sets up the rippled standalone Docker container - you can skip this step if you already have it set up
-docker run -p 6006:6006 --interactive -t --volume $PWD/.ci-config:/opt/ripple/etc/ --platform linux/amd64 rippleci/rippled:2.0.0-b4 /opt/ripple/bin/rippled -a --conf /opt/ripple/etc/rippled.cfg
+docker run -p 6006:6006 --interactive -t --volume $PWD/.ci-config:/opt/ripple/etc/ --platform linux/amd64 rippleci/rippled:2.2.0-b3 /opt/ripple/bin/rippled -a --conf /opt/ripple/etc/rippled.cfg
 npm run build
 npm run test:integration
 ```

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 ### BREAKING CHANGES
+* Default requests to use rippled API version 2
 * Small fix in the API to use a new flag name `tfNoDirectRipple` instead of the existing flag name `tfNoRippleDirect`
 
 ### Fixed

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -324,6 +324,7 @@ class Client extends EventEmitter<EventTypes> {
   ): Promise<T> {
     const response = await this.connection.request<R, T>({
       ...req,
+      api_version: req.api_version ?? 2,
       account: req.account
         ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Must be string
           ensureClassicAddress(req.account as string)

--- a/packages/xrpl/src/models/methods/accountInfo.ts
+++ b/packages/xrpl/src/models/methods/accountInfo.ts
@@ -148,7 +148,7 @@ export interface AccountInfoResponse extends BaseResponse {
      * at most one SignerList, this array must have exactly one member if it is
      * present.
      */
-    account_data: AccountRoot & { signer_lists?: SignerList[] }
+    account_data: AccountRoot
 
     /**
      * A map of account flags parsed out.  This will only be available for rippled nodes 1.11.0 and higher.
@@ -173,6 +173,14 @@ export interface AccountInfoResponse extends BaseResponse {
      * queuing mechanism.
      */
     queue_data?: AccountQueueData
+
+    /**
+     * Array of SignerList ledger objects associated with this account for Multi-Signing.
+     * Since an account can own at most one SignerList, this array must have exactly one
+     * member if it is present.
+     */
+    signer_lists?: SignerList[]
+
     /**
      * True if this data is from a validated ledger version; if omitted or set
      * to false, this data is not final.

--- a/packages/xrpl/src/models/methods/baseMethod.ts
+++ b/packages/xrpl/src/models/methods/baseMethod.ts
@@ -12,7 +12,7 @@ export interface BaseRequest {
   id?: number | string
   /** The name of the API method. */
   command: string
-  /** The API version to use. If omitted, use version 1. */
+  /** The API version to use. If omitted, use version 2. */
   api_version?: number
 }
 

--- a/packages/xrpl/test/integration/README.md
+++ b/packages/xrpl/test/integration/README.md
@@ -1,7 +1,7 @@
 To run integration tests:
 1. Run rippled in standalone node, either in a docker container (preferred) or by installing rippled.
   * Go to the top-level of the `xrpl.js` repo, just above the `packages` folder.
-  * With docker, run `docker run -p 6006:6006 --interactive -t --volume $PWD/.ci-config:/config/ xrpllabsofficial/1.12.0-b1 -a --start`
+  * With docker, run `docker run -p 6006:6006 --interactive -t --volume $PWD/.ci-config:/opt/ripple/etc/ --platform linux/amd64 rippleci/rippled:2.2.0-b3 /opt/ripple/bin/rippled -a --conf /opt/ripple/etc/rippled.cfg`
   * Or [download and build rippled](https://xrpl.org/install-rippled.html) and run `./rippled -a --start`
     * If you'd like to use the latest rippled amendments, you should modify your `rippled.cfg` file to enable amendments in the `[amendments]` section. You can view `.ci-config/rippled.cfg` in the top level folder as an example of this.
 2. Run `npm run test:integration` or `npm run test:browser`

--- a/packages/xrpl/test/integration/requests/accountInfo.test.ts
+++ b/packages/xrpl/test/integration/requests/accountInfo.test.ts
@@ -28,6 +28,7 @@ describe('account_info', function () {
         account: testContext.wallet.classicAddress,
         strict: true,
         ledger_index: 'validated',
+        signer_lists: true,
       }
       const response = await testContext.client.request(request)
       const expected = {
@@ -49,6 +50,7 @@ describe('account_info', function () {
           ledger_hash:
             'F0DEEC46A7185BBB535517EE38CF2025973022D5B0532B36407F492521FDB0C6',
           ledger_index: 582,
+          signer_lists: [],
           validated: true,
         },
         type: 'response',
@@ -77,6 +79,7 @@ describe('account_info', function () {
           'index',
         ]),
       )
+      expect(response.result.signer_lists).toEqual([])
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/setup.ts
+++ b/packages/xrpl/test/integration/setup.ts
@@ -158,8 +158,7 @@ export async function setupBridge(client: Client): Promise<TestBridge> {
     account: doorAccount.classicAddress,
     signer_lists: true,
   })
-  const signerListInfo =
-    signerAccountInfoResponse.result.account_data.signer_lists?.[0]
+  const signerListInfo = signerAccountInfoResponse.result.signer_lists?.[0]
   assert.deepEqual(
     signerListInfo?.SignerEntries,
     signerTx.SignerEntries,

--- a/packages/xrpl/test/integration/transactions/signerListSet.test.ts
+++ b/packages/xrpl/test/integration/transactions/signerListSet.test.ts
@@ -50,8 +50,7 @@ describe('SignerListSet', function () {
         account: testContext.wallet.classicAddress,
         signer_lists: true,
       })
-      const signerListInfo =
-        accountInfoResponse.result.account_data.signer_lists?.[0]
+      const signerListInfo = accountInfoResponse.result.signer_lists?.[0]
       assert.deepEqual(
         signerListInfo?.SignerEntries,
         tx.SignerEntries,

--- a/packages/xrpl/test/integration/transactions/xchainAddClaimAttestation.test.ts
+++ b/packages/xrpl/test/integration/transactions/xchainAddClaimAttestation.test.ts
@@ -191,8 +191,7 @@ describe('XChainCreateBridge', function () {
         account: testContext.wallet.classicAddress,
         signer_lists: true,
       })
-      const signerListInfo =
-        signerAccountInfoResponse.result.account_data.signer_lists?.[0]
+      const signerListInfo = signerAccountInfoResponse.result.signer_lists?.[0]
       assert.deepEqual(
         signerListInfo?.SignerEntries,
         signerTx.SignerEntries,


### PR DESCRIPTION
## High Level Overview of Change

Default requests to use rippled API version 2.

### Context of Change

- `api_version` 2 is supported by 100% of rippled servers now that numerous v2 amendments have activated. (as of April 8, 2024.)
- Requests such as `account_info` have a different response data format in rippled API v2.
- Therefore, we should default to using v2 and no longer support response types of v1.
- This feature will be released as a major bump version since it's a significant breaking change.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Update existing tests for `account_info` to match rippled API v2 response data format

<!--
## Future Tasks
For future tasks related to PR.
-->
