### PR TITLE
feat: add input check for `OracleSet` params `AssetPrice` and `Scale`

### DIFF
--- a/packages/xrpl/src/models/transactions/oracleSet.ts
+++ b/packages/xrpl/src/models/transactions/oracleSet.ts
@@ -133,13 +133,13 @@ export function validateOracleSet(tx: Record<string, unknown>): void {
       // Either AssetPrice and Scale are both present or both excluded
       if (
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-        ('AssetPrice' in priceData.PriceData &&
+        (priceData.PriceData.AssetPrice != null &&
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-          !('Scale' in priceData.PriceData)) ||
+          priceData.PriceData.Scale == null) ||
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-        ('Scale' in priceData.PriceData &&
+        (priceData.PriceData.Scale != null &&
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-          !('AssetPrice' in priceData.PriceData))
+          priceData.PriceData.AssetPrice == null)
       ) {
         throw new ValidationError(
           'OracleSet: PriceDataSeries must have both `AssetPrice` and `Scale` if any are present',

--- a/packages/xrpl/src/models/transactions/oracleSet.ts
+++ b/packages/xrpl/src/models/transactions/oracleSet.ts
@@ -133,13 +133,9 @@ export function validateOracleSet(tx: Record<string, unknown>): void {
       // Either AssetPrice and Scale are both present or both excluded
       if (
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-        (priceData.PriceData.AssetPrice != null &&
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-          priceData.PriceData.Scale == null) ||
+        (priceData.PriceData.AssetPrice == null) !==
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-        (priceData.PriceData.Scale != null &&
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-          priceData.PriceData.AssetPrice == null)
+        (priceData.PriceData.Scale == null)
       ) {
         throw new ValidationError(
           'OracleSet: PriceDataSeries must have both `AssetPrice` and `Scale` if any are present',

--- a/packages/xrpl/src/models/transactions/oracleSet.ts
+++ b/packages/xrpl/src/models/transactions/oracleSet.ts
@@ -130,6 +130,22 @@ export function validateOracleSet(tx: Record<string, unknown>): void {
         )
       }
 
+      // Either AssetPrice and Scale are both present or both excluded
+      if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
+        ('AssetPrice' in priceData.PriceData &&
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
+          !('Scale' in priceData.PriceData)) ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
+        ('Scale' in priceData.PriceData &&
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
+          !('AssetPrice' in priceData.PriceData))
+      ) {
+        throw new ValidationError(
+          'OracleSet: PriceDataSeries must have both `AssetPrice` and `Scale` if any are present',
+        )
+      }
+
       if (
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
         'AssetPrice' in priceData.PriceData &&

--- a/packages/xrpl/test/models/oracleSet.test.ts
+++ b/packages/xrpl/test/models/oracleSet.test.ts
@@ -150,6 +150,22 @@ describe('OracleSet', function () {
     assert.throws(() => validate(tx), ValidationError, errorMessage)
   })
 
+  it(`throws w/ missing AssetPrice with Scale present of PriceDataSeries`, function () {
+    delete tx.PriceDataSeries[0].PriceData.AssetPrice
+    const errorMessage =
+      'OracleSet: PriceDataSeries must have both `AssetPrice` and `Scale` if any are present'
+    assert.throws(() => validateOracleSet(tx), ValidationError, errorMessage)
+    assert.throws(() => validate(tx), ValidationError, errorMessage)
+  })
+
+  it(`throws w/ missing Scale with AssetPrice present of PriceDataSeries`, function () {
+    delete tx.PriceDataSeries[0].PriceData.Scale
+    const errorMessage =
+      'OracleSet: PriceDataSeries must have both `AssetPrice` and `Scale` if any are present'
+    assert.throws(() => validateOracleSet(tx), ValidationError, errorMessage)
+    assert.throws(() => validate(tx), ValidationError, errorMessage)
+  })
+
   it(`throws w/ invalid AssetPrice of PriceDataSeries`, function () {
     tx.PriceDataSeries[0].PriceData.AssetPrice = '1234'
     const errorMessage = 'OracleSet: invalid field AssetPrice'


### PR DESCRIPTION
## High Level Overview of Change

Add input check for `OracleSet` params `AssetPrice` and `Scale` either being both present or excluded.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

Added unit tests to verify this validation.