### PR TITLE
Update UINT64 ctor to accept `bigint | string` types

### DIFF
--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### BREAKING CHANGES
+* Use Javascript's `BigInt` type to hold rippled's UINT64 internal type. Previously, `number` type was used to represent these values, this change enforces the use of `bigint(...)` explicit type-cast for such fields.
+
 ## 2.1.0 (2024-06-03)
 
 ### Added

--- a/packages/ripple-binary-codec/src/types/uint-64.ts
+++ b/packages/ripple-binary-codec/src/types/uint-64.ts
@@ -29,26 +29,12 @@ class UInt64 extends UInt {
    * @param val A UInt64, hex-string, bigInt, or number
    * @returns A UInt64 object
    */
-  static from<T extends UInt64 | string | bigint | number>(val: T): UInt64 {
+  static from<T extends UInt64 | string | bigint>(val: T): UInt64 {
     if (val instanceof UInt64) {
       return val
     }
 
     let buf = new Uint8Array(UInt64.width)
-
-    if (typeof val === 'number') {
-      if (val < 0) {
-        throw new Error('value must be an unsigned integer')
-      }
-
-      const number = BigInt(val)
-
-      const intBuf = [new Uint8Array(4), new Uint8Array(4)]
-      writeUInt32BE(intBuf[0], Number(number >> BigInt(32)), 0)
-      writeUInt32BE(intBuf[1], Number(number & BigInt(mask)), 0)
-
-      return new UInt64(concat(intBuf))
-    }
 
     if (typeof val === 'string') {
       if (!HEX_REGEX.test(val)) {
@@ -61,6 +47,10 @@ class UInt64 extends UInt {
     }
 
     if (typeof val === 'bigint') {
+      if (val < 0) {
+        throw new Error('value must be an unsigned integer')
+      }
+
       const intBuf = [new Uint8Array(4), new Uint8Array(4)]
       writeUInt32BE(intBuf[0], Number(Number(val >> BigInt(32))), 0)
       writeUInt32BE(intBuf[1], Number(val & BigInt(mask)), 0)

--- a/packages/ripple-binary-codec/test/binary-serializer.test.ts
+++ b/packages/ripple-binary-codec/test/binary-serializer.test.ts
@@ -145,6 +145,12 @@ function check(type, n, expected) {
   it(`Uint${type.width * 8} serializes ${n} as ${expected}`, function () {
     const bl = new BytesList()
     const serializer = new BinarySerializer(bl)
+
+    // UINT64.from function does not accept number type, it accepts only string | bigint types
+    // Other UINT<bits>.from methods accept number type
+    if (type.width == 8) {
+      n = BigInt(n)
+    }
     if (expected === 'throws') {
       expect(() => serializer.writeType(type, n)).toThrow()
       return
@@ -168,12 +174,11 @@ check(UInt32, 5, [0, 0, 0, 5])
 check(UInt32, 0xffffffff, [255, 255, 255, 255])
 check(UInt8, 0xfeffffff, 'throws')
 check(UInt16, 0xfeffffff, 'throws')
-check(UInt16, 0xfeffffff, 'throws')
+check(UInt32, 0xfeffffff, 'throws')
 check(UInt64, 0xfeffffff, [0, 0, 0, 0, 254, 255, 255, 255])
 check(UInt64, -1, 'throws')
 check(UInt64, 0, [0, 0, 0, 0, 0, 0, 0, 0])
 check(UInt64, 1, [0, 0, 0, 0, 0, 0, 0, 1])
-check(UInt64, BigInt(1), [0, 0, 0, 0, 0, 0, 0, 1])
 
 function deliverMinTest() {
   it('can serialize DeliverMin', () => {

--- a/packages/ripple-binary-codec/test/uint.test.ts
+++ b/packages/ripple-binary-codec/test/uint.test.ts
@@ -97,15 +97,15 @@ const jsonEntry2 = {
 }
 
 it('compareToTests[0]', () => {
-  expect(UInt8.from(124).compareTo(UInt64.from(124))).toBe(0)
+  expect(UInt8.from(124).compareTo(UInt64.from(BigInt(124)))).toBe(0)
 })
 
 it('compareToTest[1]', () => {
-  expect(UInt64.from(124).compareTo(UInt8.from(124))).toBe(0)
+  expect(UInt64.from(BigInt(124)).compareTo(UInt8.from(124))).toBe(0)
 })
 
 it('compareToTest[2]', () => {
-  expect(UInt64.from(124).compareTo(UInt8.from(123))).toBe(1)
+  expect(UInt64.from(BigInt(124)).compareTo(UInt8.from(123))).toBe(1)
 })
 
 it('compareToTest[3]', () => {
@@ -117,11 +117,11 @@ it('compareToTest[4]', () => {
 })
 
 it('compareToTest[5]', () => {
-  expect(UInt64.from(124).compareTo(124)).toBe(0)
+  expect(UInt64.from(BigInt(124)).compareTo(124)).toBe(0)
 })
 
 it('compareToTest[6]', () => {
-  expect(UInt64.from(124).compareTo(123)).toBe(1)
+  expect(UInt64.from(BigInt(124)).compareTo(123)).toBe(1)
 })
 
 it('compareToTest[7]', () => {
@@ -129,7 +129,7 @@ it('compareToTest[7]', () => {
 })
 
 it('UInt64 from string zero', () => {
-  expect(UInt64.from('0')).toEqual(UInt64.from(0))
+  expect(UInt64.from('0')).toEqual(UInt64.from(BigInt(0)))
   expect(encode(json)).toEqual(binary)
 })
 

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased Changes
 
+### BREAKING CHANGE
+* Update certain fields in Requests+Transactions to use `bigint` type, instead of Javascript's `number` type. This change accompanies the updates to UINT64 constructor in the ripple-binary-codec package. These updated fields correspond only with `PriceOracle` and the `XChainBridge` amendments.
+
 ### Added
 * parseTransactionFlags as a utility function in the xrpl package to streamline transactions flags-to-map conversion
 

--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -186,7 +186,7 @@ export interface PriceData {
      * The asset price after applying the Scale precision level. It's not included if the last update transaction didn't include
      * the BaseAsset/QuoteAsset pair.
      */
-    AssetPrice?: number | string
+    AssetPrice?: bigint | string
 
     /**
      * The scaling factor to apply to an asset price. For example, if Scale is 6 and original price is 0.155, then the scaled

--- a/packages/xrpl/src/models/ledger/XChainOwnedCreateAccountClaimID.ts
+++ b/packages/xrpl/src/models/ledger/XChainOwnedCreateAccountClaimID.ts
@@ -26,7 +26,7 @@ export default interface XChainOwnedCreateAccountClaimID
    * cross-chain transfers must be performed. Smaller numbers must execute
    * before larger numbers.
    */
-  XChainAccountCreateCount: number
+  XChainAccountCreateCount: bigint
 
   /**
    * Attestations collected from the witness servers. This includes the parameters

--- a/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
@@ -5,7 +5,6 @@ import {
   BaseTransaction,
   isAccount,
   isAmount,
-  // isNumber,
   isBigInt,
   isString,
   isXChainBridge,

--- a/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
@@ -5,7 +5,8 @@ import {
   BaseTransaction,
   isAccount,
   isAmount,
-  isNumber,
+  // isNumber,
+  isBigInt,
   isString,
   isXChainBridge,
   validateBaseTransaction,
@@ -72,7 +73,7 @@ export interface XChainAddAccountCreateAttestation extends BaseTransaction {
   /**
    * The counter that represents the order that the claims must be processed in.
    */
-  XChainAccountCreateCount: number | string
+  XChainAccountCreateCount: bigint | string
 
   /**
    * The bridge associated with the attestation.
@@ -116,7 +117,7 @@ export function validateXChainAddAccountCreateAttestation(
   validateRequiredField(
     tx,
     'XChainAccountCreateCount',
-    (inp) => isNumber(inp) || isString(inp),
+    (inp) => isBigInt(inp) || isString(inp),
   )
 
   validateRequiredField(tx, 'XChainBridge', isXChainBridge)

--- a/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
@@ -5,7 +5,8 @@ import {
   BaseTransaction,
   isAccount,
   isAmount,
-  isNumber,
+  // isNumber,
+  isBigInt,
   isString,
   isXChainBridge,
   validateBaseTransaction,
@@ -72,8 +73,10 @@ export interface XChainAddClaimAttestation extends BaseTransaction {
   /**
    * The XChainClaimID associated with the transfer, which was included in the
    * {@link XChainCommit} transaction.
+   * rippled uses UINT64 internal type for this field. Javascript's number type is not compatible with
+   * UINT64's range of values, hence use bigint
    */
-  XChainClaimID: number | string
+  XChainClaimID: bigint | string
 }
 
 /**
@@ -112,6 +115,6 @@ export function validateXChainAddClaimAttestation(
   validateRequiredField(
     tx,
     'XChainClaimID',
-    (inp) => isNumber(inp) || isString(inp),
+    (inp) => isBigInt(inp) || isString(inp),
   )
 }

--- a/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
@@ -5,7 +5,6 @@ import {
   BaseTransaction,
   isAccount,
   isAmount,
-  // isNumber,
   isBigInt,
   isString,
   isXChainBridge,

--- a/packages/xrpl/src/models/transactions/XChainClaim.ts
+++ b/packages/xrpl/src/models/transactions/XChainClaim.ts
@@ -6,6 +6,7 @@ import {
   isAccount,
   isAmount,
   isNumber,
+  isBigInt,
   isString,
   isXChainBridge,
   validateBaseTransaction,
@@ -32,7 +33,7 @@ export interface XChainClaim extends BaseTransaction {
    * The unique integer ID for the cross-chain transfer that was referenced in the
    * corresponding {@link XChainCommit} transaction.
    */
-  XChainClaimID: number | string
+  XChainClaimID: bigint | string
 
   /**
    * The destination account on the destination chain. It must exist or the
@@ -68,7 +69,7 @@ export function validateXChainClaim(tx: Record<string, unknown>): void {
   validateRequiredField(
     tx,
     'XChainClaimID',
-    (inp) => isNumber(inp) || isString(inp),
+    (inp) => isBigInt(inp) || isString(inp),
   )
 
   validateRequiredField(tx, 'Destination', isAccount)

--- a/packages/xrpl/src/models/transactions/XChainCommit.ts
+++ b/packages/xrpl/src/models/transactions/XChainCommit.ts
@@ -5,7 +5,7 @@ import {
   BaseTransaction,
   isAccount,
   isAmount,
-  isNumber,
+  isBigInt,
   isString,
   isXChainBridge,
   validateBaseTransaction,
@@ -35,7 +35,7 @@ export interface XChainCommit extends BaseTransaction {
    * checked from a validated ledger before submitting this transaction. If an
    * incorrect sequence number is specified, the funds will be lost.
    */
-  XChainClaimID: number | string
+  XChainClaimID: bigint | string
 
   /**
    * The destination account on the destination chain. If this is not specified,
@@ -67,7 +67,7 @@ export function validateXChainCommit(tx: Record<string, unknown>): void {
   validateRequiredField(
     tx,
     'XChainClaimID',
-    (inp) => isNumber(inp) || isString(inp),
+    (inp) => isBigInt(inp) || isString(inp),
   )
 
   validateOptionalField(tx, 'OtherChainDestination', isAccount)

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -85,6 +85,16 @@ export function isNumber(num: unknown): num is number {
 }
 
 /**
+ * Verify the form and type of a bigint value at runtime.
+ *
+ * @param val - The object to check the form and type of.
+ * @returns Whether the bigint is properly formed.
+ */
+export function isBigInt(val: unknown): boolean {
+  return typeof val === 'bigint'
+}
+
+/**
  * Verify the form and type of an IssuedCurrency at runtime.
  *
  * @param input - The input to check the form and type of.

--- a/packages/xrpl/src/models/transactions/oracleSet.ts
+++ b/packages/xrpl/src/models/transactions/oracleSet.ts
@@ -4,6 +4,7 @@ import { PriceData } from '../common'
 import {
   BaseTransaction,
   isNumber,
+  isBigInt,
   isString,
   validateBaseTransaction,
   validateOptionalField,
@@ -146,11 +147,13 @@ export function validateOracleSet(tx: Record<string, unknown>): void {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
         'AssetPrice' in priceData.PriceData &&
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
-        !isNumber(priceData.PriceData.AssetPrice)
+        !isBigInt(priceData.PriceData.AssetPrice)
       ) {
         throw new ValidationError('OracleSet: invalid field AssetPrice')
       }
 
+      // Note: Although scale is represented as a UINT64 in the rippled codebase, it has an upper bound value of `10`.
+      // Hence using bigint type for this field might be an overkill
       if (
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- we are validating the type
         'Scale' in priceData.PriceData &&

--- a/packages/xrpl/test/integration/requests/getAggregatePrice.test.ts
+++ b/packages/xrpl/test/integration/requests/getAggregatePrice.test.ts
@@ -34,7 +34,7 @@ describe('get_aggregate_price', function () {
             PriceData: {
               BaseAsset: 'XRP',
               QuoteAsset: 'USD',
-              AssetPrice: 740,
+              AssetPrice: BigInt(740),
               Scale: 3,
             },
           },

--- a/packages/xrpl/test/integration/transactions/oracleDelete.test.ts
+++ b/packages/xrpl/test/integration/transactions/oracleDelete.test.ts
@@ -34,7 +34,7 @@ describe('OracleDelete', function () {
             PriceData: {
               BaseAsset: 'XRP',
               QuoteAsset: 'USD',
-              AssetPrice: 740,
+              AssetPrice: BigInt(740),
               Scale: 3,
             },
           },

--- a/packages/xrpl/test/integration/transactions/oracleSet.test.ts
+++ b/packages/xrpl/test/integration/transactions/oracleSet.test.ts
@@ -35,7 +35,7 @@ describe('OracleSet', function () {
             PriceData: {
               BaseAsset: 'XRP',
               QuoteAsset: 'USD',
-              AssetPrice: 740,
+              AssetPrice: BigInt(740),
               Scale: 3,
             },
           },

--- a/packages/xrpl/test/integration/transactions/xchainAddAccountCreateAttestation.test.ts
+++ b/packages/xrpl/test/integration/transactions/xchainAddAccountCreateAttestation.test.ts
@@ -41,7 +41,7 @@ describe('XChainCreateBridge', function () {
         Amount: xrpToDrops(300),
         AttestationRewardAccount: witness.classicAddress,
         WasLockingChainSend: 0,
-        XChainAccountCreateCount: 1,
+        XChainAccountCreateCount: BigInt(1),
         Destination: destination.classicAddress,
         SignatureReward: signatureReward,
       }
@@ -55,7 +55,7 @@ describe('XChainCreateBridge', function () {
         OtherChainSource: otherChainSource.classicAddress,
         Amount: xrpToDrops(300),
         WasLockingChainSend: 0,
-        XChainAccountCreateCount: 1,
+        XChainAccountCreateCount: BigInt(1),
         Destination: destination.classicAddress,
         SignatureReward: signatureReward,
         PublicKey: witness.publicKey,

--- a/packages/xrpl/test/integration/transactions/xchainAddClaimAttestation.test.ts
+++ b/packages/xrpl/test/integration/transactions/xchainAddClaimAttestation.test.ts
@@ -70,7 +70,7 @@ describe('XChainCreateBridge', function () {
         Amount: amount,
         AttestationRewardAccount: witness.classicAddress,
         WasLockingChainSend: 0,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
         Destination: testContext.wallet.classicAddress,
       }
       const encodedAttestation = encode(attestationToSign)
@@ -83,7 +83,7 @@ describe('XChainCreateBridge', function () {
         OtherChainSource: otherChainSource.classicAddress,
         Amount: amount,
         WasLockingChainSend: 0,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
         Destination: testContext.wallet.classicAddress,
         PublicKey: witness.publicKey,
         Signature: attestationSignature,
@@ -233,7 +233,7 @@ describe('XChainCreateBridge', function () {
         Amount: amount,
         AttestationRewardAccount: witness.classicAddress,
         WasLockingChainSend: 1,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
         Destination: destination.classicAddress,
       }
       const encodedAttestation = encode(attestationToSign)
@@ -246,7 +246,7 @@ describe('XChainCreateBridge', function () {
         OtherChainSource: otherChainSource.classicAddress,
         Amount: amount,
         WasLockingChainSend: 1,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
         Destination: destination.classicAddress,
         PublicKey: witness.publicKey,
         Signature: attestationSignature,

--- a/packages/xrpl/test/integration/transactions/xchainClaim.test.ts
+++ b/packages/xrpl/test/integration/transactions/xchainClaim.test.ts
@@ -59,7 +59,7 @@ describe('XChainCreateBridge', function () {
         Amount: amount,
         AttestationRewardAccount: witness.classicAddress,
         WasLockingChainSend: 0,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
       }
       const encodedAttestation = encode(attestationToSign)
       const attestationSignature = sign(encodedAttestation, witness.privateKey)
@@ -71,7 +71,7 @@ describe('XChainCreateBridge', function () {
         OtherChainSource: otherChainSource.classicAddress,
         Amount: amount,
         WasLockingChainSend: 0,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
         PublicKey: witness.publicKey,
         Signature: attestationSignature,
         AttestationRewardAccount: witness.classicAddress,
@@ -93,7 +93,7 @@ describe('XChainCreateBridge', function () {
         Account: destination.classicAddress,
         XChainBridge: xchainBridge,
         Destination: destination.classicAddress,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
         Amount: amount,
       }
       await testTransaction(testContext.client, tx, destination)

--- a/packages/xrpl/test/integration/transactions/xchainCommit.test.ts
+++ b/packages/xrpl/test/integration/transactions/xchainCommit.test.ts
@@ -37,7 +37,7 @@ describe('XChainCommit', function () {
         TransactionType: 'XChainCommit',
         Account: wallet2.classicAddress,
         XChainBridge: xchainBridge,
-        XChainClaimID: 1,
+        XChainClaimID: BigInt(1),
         Amount: amount.toString(),
       }
 

--- a/packages/xrpl/test/models/oracleSet.test.ts
+++ b/packages/xrpl/test/models/oracleSet.test.ts
@@ -23,7 +23,7 @@ describe('OracleSet', function () {
           PriceData: {
             BaseAsset: 'XRP',
             QuoteAsset: 'USD',
-            AssetPrice: 740,
+            AssetPrice: BigInt(740),
             Scale: 3,
           },
         },
@@ -108,7 +108,7 @@ describe('OracleSet', function () {
       PriceData: {
         BaseAsset: 'XRP',
         QuoteAsset: 'USD',
-        AssetPrice: 740,
+        AssetPrice: BigInt(740),
         Scale: 3,
       },
     })

--- a/packages/xrpl/tools/generateModels.js
+++ b/packages/xrpl/tools/generateModels.js
@@ -80,7 +80,7 @@ const typeMap = {
   UINT8: 'number',
   UINT16: 'number',
   UINT32: 'number',
-  UINT64: 'number | string',
+  UINT64: 'string',
   UINT128: 'string',
   UINT160: 'string',
   UINT256: 'string',


### PR DESCRIPTION
## High Level Overview of Change
`UINT64` type must support values in the range of `[0, 18446744073709551615]`, both inclusive. Javascript's `number` type does not have a compatible range of values, due to double-precision floating point format.

If users specify a large input (say `number(18446744073709551615)`, well-beyond the limits of `number` type) into a `UINT64` type field, the `xrpl.js` SDK parses the input as `0` . No error is raised by `xrpl.js` , although the VSCode editor displays a red-squiggly warning about the loss-of-precision. We can prevent such unexpected surprises by enforcing a stricter type `bigint`. 

This PR specifies the change in `UINT64.from` method. It also updates relevant Transaction fields to use `bigint` type, instead of `number` type. These transactions pertain to the `PriceOracle` and the `XChainBridge` amendments.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan
Existing tests should suffice for validating the serialization/de-serialization of the UINT64 type fields.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
