### PR TITLE
Removed calls to deprecated utils function in tests

### DIFF
--- a/packages/xrpl/snippets/src/multisigning.ts
+++ b/packages/xrpl/snippets/src/multisigning.ts
@@ -1,8 +1,9 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
+
 import {
   multisign,
   Client,
   AccountSet,
-  convertStringToHex,
   SignerListSet,
   Wallet,
 } from '../../src'
@@ -50,7 +51,7 @@ async function multisigning(): Promise<void> {
   const accountSet: AccountSet = {
     TransactionType: 'AccountSet',
     Account: walletMaster.classicAddress,
-    Domain: convertStringToHex('example.com'),
+    Domain: stringToHex('example.com'),
   }
   const accountSetTx = await client.autofill(accountSet, 2)
   console.log('AccountSet transaction is ready to be multisigned:')

--- a/packages/xrpl/src/models/transactions/NFTokenMint.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenMint.ts
@@ -92,7 +92,7 @@ export interface NFTokenMint extends BaseTransaction {
    * opaque issuer-specific encoding. The URI is NOT checked for validity, but
    * the field is limited to a maximum length of 256 bytes.
    *
-   * This field must be hex-encoded. You can use `convertStringToHex` to
+   * This field must be hex-encoded. You can use `@xrplf/isomorphic/utils`'s `stringToHex` to
    * convert this field to the proper encoding.
    *
    * This field must not be an empty string. Omit it from the transaction or

--- a/packages/xrpl/test/integration/integration.test.ts
+++ b/packages/xrpl/test/integration/integration.test.ts
@@ -1,8 +1,8 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import { Client, SubmitResponse } from '../../src'
 import { AccountSet, SignerListSet } from '../../src/models/transactions'
-import { convertStringToHex } from '../../src/utils'
 import { multisign } from '../../src/Wallet/signer'
 
 import serverUrl from './serverUrl'
@@ -74,7 +74,7 @@ describe('integration tests', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const { tx_blob: tx_blob1 } = signerWallet1.sign(accountSetTx, true)

--- a/packages/xrpl/test/integration/regularKey.test.ts
+++ b/packages/xrpl/test/integration/regularKey.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
@@ -10,7 +11,6 @@ import {
   OfferCreate,
   ECDSA,
 } from '../../src'
-import { convertStringToHex } from '../../src/utils'
 import { multisign } from '../../src/Wallet/signer'
 
 import serverUrl from './serverUrl'
@@ -85,7 +85,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: regularKeyWallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       await testTransaction(testContext.client, accountSet, regularKeyWallet)
@@ -103,7 +103,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: masterWallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       await testTransaction(testContext.client, accountSet, masterWallet)
@@ -259,7 +259,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = regularKeyWallet.sign(accountSetTx, true)
@@ -319,7 +319,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = sameKeyDefaultAddressWallet.sign(accountSetTx, true)

--- a/packages/xrpl/test/integration/requests/submit.test.ts
+++ b/packages/xrpl/test/integration/requests/submit.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 import { decode } from 'ripple-binary-codec'
 
@@ -8,7 +9,6 @@ import {
   hashes,
   SubmittableTransaction,
 } from '../../../src'
-import { convertStringToHex } from '../../../src/utils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -35,7 +35,7 @@ describe('submit', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       const autofilledTx = await testContext.client.autofill(accountSet)

--- a/packages/xrpl/test/integration/requests/submitMultisigned.test.ts
+++ b/packages/xrpl/test/integration/requests/submitMultisigned.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 import { decode } from 'ripple-binary-codec'
 
@@ -11,7 +12,6 @@ import {
   SubmitMultisignedRequest,
   SubmitMultisignedV1Response,
 } from '../../../src'
-import { convertStringToHex } from '../../../src/utils'
 import { multisign } from '../../../src/Wallet/signer'
 import serverUrl from '../serverUrl'
 import {
@@ -75,7 +75,7 @@ describe('submit_multisigned', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = signerWallet1.sign(accountSetTx, true)
@@ -148,7 +148,7 @@ describe('submit_multisigned', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = signerWallet1.sign(accountSetTx, true)

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
@@ -8,7 +9,6 @@ import {
   TxResponse,
   TxV1Response,
 } from '../../../src'
-import { convertStringToHex } from '../../../src/utils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -35,7 +35,7 @@ describe('tx', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: account,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       const response: SubmitResponse = await testContext.client.submit(
@@ -82,7 +82,7 @@ describe('tx', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: account,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       const response: SubmitResponse = await testContext.client.submit(

--- a/packages/xrpl/test/integration/submitAndWait.test.ts
+++ b/packages/xrpl/test/integration/submitAndWait.test.ts
@@ -1,6 +1,7 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
-import { AccountSet, convertStringToHex, ValidationError } from '../../src'
+import { AccountSet, ValidationError } from '../../src'
 import { assertRejects } from '../testUtils'
 
 import serverUrl from './serverUrl'
@@ -35,7 +36,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       let retries = 10
@@ -89,7 +90,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       await assertRejects(
@@ -107,7 +108,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const { tx_blob: signedAccountSet } = testContext.wallet.sign(
         await testContext.client.autofill(accountSet),
@@ -130,7 +131,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const { tx_blob: signedAccountSet } = testContext.wallet.sign(
         await testContext.client.autofill(accountSet),

--- a/packages/xrpl/test/integration/transactions/nftokenMint.test.ts
+++ b/packages/xrpl/test/integration/transactions/nftokenMint.test.ts
@@ -1,7 +1,7 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
-  convertStringToHex,
   getNFTokenID,
   NFTokenMint,
   TransactionMetadata,
@@ -33,7 +33,7 @@ describe('NFTokenMint', function () {
       const tx: NFTokenMint = {
         TransactionType: 'NFTokenMint',
         Account: testContext.wallet.address,
-        URI: convertStringToHex('https://www.google.com'),
+        URI: stringToHex('https://www.google.com'),
         NFTokenTaxon: 0,
       }
       const response = await testTransaction(

--- a/packages/xrpl/test/models/NFTokenMint.test.ts
+++ b/packages/xrpl/test/models/NFTokenMint.test.ts
@@ -1,7 +1,7 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
-  convertStringToHex,
   validate,
   ValidationError,
   NFTokenMintFlags,
@@ -25,7 +25,7 @@ describe('NFTokenMint', function () {
       NFTokenTaxon: 0,
       Issuer: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
       TransferFee: 1,
-      URI: convertStringToHex('http://xrpl.org'),
+      URI: stringToHex('http://xrpl.org'),
     } as any
 
     assert.doesNotThrow(() => validate(validNFTokenMint))
@@ -40,7 +40,7 @@ describe('NFTokenMint', function () {
       Flags: NFTokenMintFlags.tfTransferable,
       Issuer: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
       TransferFee: 1,
-      URI: convertStringToHex('http://xrpl.org'),
+      URI: stringToHex('http://xrpl.org'),
     } as any
 
     assert.throws(
@@ -60,7 +60,7 @@ describe('NFTokenMint', function () {
       Issuer: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       TransferFee: 1,
       NFTokenTaxon: 0,
-      URI: convertStringToHex('http://xrpl.org'),
+      URI: stringToHex('http://xrpl.org'),
     } as any
 
     assert.throws(

--- a/packages/xrpl/test/utils/hexConversion.test.ts
+++ b/packages/xrpl/test/utils/hexConversion.test.ts
@@ -1,9 +1,7 @@
-import { stringToHex } from '@xrplf/isomorphic/utils'
+import { stringToHex, hexToString } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
-import { convertHexToString } from '../../src/utils'
-
-describe('convertHexToString and stringToHex', function () {
+describe('hexToString and stringToHex', function () {
   it('converts "example.com"', function () {
     const str = 'example.com'
     const hex = stringToHex(str)
@@ -12,7 +10,7 @@ describe('convertHexToString and stringToHex', function () {
       '6578616D706C652E636F6D',
       'should convert to hex equivalent',
     )
-    const result = convertHexToString(hex)
+    const result = hexToString(hex)
     assert.strictEqual(
       result,
       'example.com',
@@ -24,7 +22,7 @@ describe('convertHexToString and stringToHex', function () {
     const str = '你好'
     const hex = stringToHex(str)
     assert.strictEqual(hex, 'E4BDA0E5A5BD', 'should convert to hex equivalent')
-    const result = convertHexToString(hex)
+    const result = hexToString(hex)
     assert.strictEqual(result, '你好', 'should convert back to 你好')
   })
 })

--- a/packages/xrpl/test/utils/hexConversion.test.ts
+++ b/packages/xrpl/test/utils/hexConversion.test.ts
@@ -1,11 +1,12 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
-import { convertHexToString, convertStringToHex } from '../../src/utils'
+import { convertHexToString } from '../../src/utils'
 
-describe('convertHexToString and convertStringToHex', function () {
+describe('convertHexToString and stringToHex', function () {
   it('converts "example.com"', function () {
     const str = 'example.com'
-    const hex = convertStringToHex(str)
+    const hex = stringToHex(str)
     assert.strictEqual(
       hex,
       '6578616D706C652E636F6D',
@@ -21,7 +22,7 @@ describe('convertHexToString and convertStringToHex', function () {
 
   it('converts "你好"', function () {
     const str = '你好'
-    const hex = convertStringToHex(str)
+    const hex = stringToHex(str)
     assert.strictEqual(hex, 'E4BDA0E5A5BD', 'should convert to hex equivalent')
     const result = convertHexToString(hex)
     assert.strictEqual(result, '你好', 'should convert back to 你好')


### PR DESCRIPTION
## High Level Overview of Change
See #2698 . 
Removed multiple calls to deprecated functions in the tests (convertStringToHex and convertHexToString).
Also updated the models/transactions/NFTokenMint.ts comments to point at the correct functions.

### Context of Change
Simple refactor to follow best practices. The tests could be referenced by a user and he should always have the correct function used by default.

### Type of Change
- [x] Refactor (non-breaking change that only restructures code)

### Did you update HISTORY.md?

- [x] No, this change does not impact library users

