### PR TITLE
Support issued asset Amount in PaymentChannel* TXs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14896,7 +14896,7 @@
       }
     },
     "packages/ripple-binary-codec": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",
@@ -14929,7 +14929,7 @@
       }
     },
     "packages/xrpl": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.3.1",
@@ -14939,7 +14939,7 @@
         "bignumber.js": "^9.0.0",
         "eventemitter3": "^5.0.1",
         "ripple-address-codec": "^5.0.0",
-        "ripple-binary-codec": "^2.1.0",
+        "ripple-binary-codec": "^2.2.0",
         "ripple-keypairs": "^2.0.0"
       },
       "devDependencies": {

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.2.0 (2024-12-23)
+
 ### Added
 * Support for the Multi-Purpose Token amendment (XLS-33)
 

--- a/packages/ripple-binary-codec/package.json
+++ b/packages/ripple-binary-codec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-binary-codec",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "XRP Ledger binary codec",
   "files": [
     "dist/*",

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,8 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased Changes
 
+## 4.1.0 (2024-12-23)
+
 ### Added
 * Added new MPT transaction definitions (XLS-33)
 * New `MPTAmount` type support for `Payment` and `Clawback` transactions

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [
@@ -29,7 +29,7 @@
     "bignumber.js": "^9.0.0",
     "eventemitter3": "^5.0.1",
     "ripple-address-codec": "^5.0.0",
-    "ripple-binary-codec": "^2.1.0",
+    "ripple-binary-codec": "^2.2.0",
     "ripple-keypairs": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/xrpl/src/models/transactions/paymentChannelClaim.ts
+++ b/packages/xrpl/src/models/transactions/paymentChannelClaim.ts
@@ -114,11 +114,13 @@ export interface PaymentChannelClaim extends BaseTransaction {
    */
   Balance?: string
   /**
-   * The amount of XRP, in drops, authorized by the Signature. This must match
-   * the amount in the signed message. This is the cumulative amount of XRP that
-   * can be dispensed by the channel, including XRP previously redeemed.
+   * The amount of currency authorized by the Signature. Can either be a string
+   * value of XRP in drops or a issued currency dictionary with string
+   * keys and string values.  This must match the amount in the signed message.
+   * This is the cumulative amount of currency that can be dispensed by the
+   * channel, including currency previously redeemed.
    */
-  Amount?: string
+  Amount?: string | Record<string, string>
   /**
    * The signature of this claim, as hexadecimal. The signed message contains
    * the channel ID and the amount of the claim. Required unless the sender of
@@ -140,9 +142,9 @@ export interface PaymentChannelClaim extends BaseTransaction {
 }
 
 /**
- * Verify the form and type of an PaymentChannelClaim at runtime.
+ * Verify the form and type of a PaymentChannelClaim at runtime.
  *
- * @param tx - An PaymentChannelClaim Transaction.
+ * @param tx - A PaymentChannelClaim Transaction.
  * @throws When the PaymentChannelClaim is Malformed.
  */
 export function validatePaymentChannelClaim(tx: Record<string, unknown>): void {
@@ -167,8 +169,19 @@ export function validatePaymentChannelClaim(tx: Record<string, unknown>): void {
     throw new ValidationError('PaymentChannelClaim: Balance must be a string')
   }
 
-  if (tx.Amount !== undefined && typeof tx.Amount !== 'string') {
-    throw new ValidationError('PaymentChannelClaim: Amount must be a string')
+  if (
+    tx.Amount !== undefined &&
+    !(typeof tx.Amount === 'string' ||
+      (typeof tx.Amount === 'object' &&
+        tx.Amount !== null &&
+        !Array.isArray(tx.Amount) &&
+        Object.entries(tx.Amount).every(
+          ([key, value]) => typeof key === 'string' && typeof value === 'string',
+        )))
+  ) {
+    throw new ValidationError(
+      'PaymentChannelClaim: Amount must be a string or an object with string keys and string values',
+    )
   }
 
   if (tx.Signature !== undefined && typeof tx.Signature !== 'string') {

--- a/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
+++ b/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
@@ -19,12 +19,14 @@ import {
 export interface PaymentChannelCreate extends BaseTransaction {
   TransactionType: 'PaymentChannelCreate'
   /**
-   * Amount of XRP, in drops, to deduct from the sender's balance and set aside
-   * in this channel. While the channel is open, the XRP can only go to the
+   * Amount of currency to deduct from the sender's balance and set aside
+   * in this channel. Can either be a string
+   * value of XRP in drops or an issued currency dictionary with string
+   * keys and string values. While the channel is open, the XRP can only go to the
    * Destination address. When the channel closes, any unclaimed XRP is returned
    * to the source address's balance.
    */
-  Amount: string
+  Amount: string | Record<string, string>
   /**
    * Address to receive XRP claims against this channel. This is also known as
    * the "destination address" for the channel.
@@ -57,9 +59,9 @@ export interface PaymentChannelCreate extends BaseTransaction {
 }
 
 /**
- * Verify the form and type of an PaymentChannelCreate at runtime.
+ * Verify the form and type of a PaymentChannelCreate at runtime.
  *
- * @param tx - An PaymentChannelCreate Transaction.
+ * @param tx - A PaymentChannelCreate Transaction.
  * @throws When the PaymentChannelCreate is Malformed.
  */
 export function validatePaymentChannelCreate(
@@ -71,8 +73,16 @@ export function validatePaymentChannelCreate(
     throw new ValidationError('PaymentChannelCreate: missing Amount')
   }
 
-  if (typeof tx.Amount !== 'string') {
-    throw new ValidationError('PaymentChannelCreate: Amount must be a string')
+  if (
+    typeof tx.Amount !== 'string' &&
+    !(typeof tx.Amount === 'object' && tx.Amount !== null && !Array.isArray(tx.Amount) &&
+      Object.entries(tx.Amount).every(
+        ([key, value]) => typeof key === 'string' && typeof value === 'string'
+      ))
+  ) {
+    throw new ValidationError(
+      'PaymentChannelCreate: Amount must be a string or an object with string keys and string values',
+    )
   }
 
   validateRequiredField(tx, 'Destination', isAccount)

--- a/packages/xrpl/src/models/transactions/paymentChannelFund.ts
+++ b/packages/xrpl/src/models/transactions/paymentChannelFund.ts
@@ -17,10 +17,11 @@ export interface PaymentChannelFund extends BaseTransaction {
    */
   Channel: string
   /**
-   * Amount of XRP in drops to add to the channel. Must be a positive amount
-   * of XRP.
+   * Amount of currency to add to the channel. Can either be a string
+   * value of XRP in drops or a issued currency dictionary with string
+   * keys and string values.
    */
-  Amount: string
+  Amount: string | Record<string, string>
   /**
    * New Expiration time to set for the channel in seconds since the Ripple
    * Epoch. This must be later than either the current time plus the SettleDelay
@@ -35,9 +36,9 @@ export interface PaymentChannelFund extends BaseTransaction {
 }
 
 /**
- * Verify the form and type of an PaymentChannelFund at runtime.
+ * Verify the form and type of a PaymentChannelFund at runtime.
  *
- * @param tx - An PaymentChannelFund Transaction.
+ * @param tx - A PaymentChannelFund Transaction.
  * @throws When the PaymentChannelFund is Malformed.
  */
 export function validatePaymentChannelFund(tx: Record<string, unknown>): void {
@@ -55,8 +56,16 @@ export function validatePaymentChannelFund(tx: Record<string, unknown>): void {
     throw new ValidationError('PaymentChannelFund: missing Amount')
   }
 
-  if (typeof tx.Amount !== 'string') {
-    throw new ValidationError('PaymentChannelFund: Amount must be a string')
+  if (
+    typeof tx.Amount !== 'string' &&
+    !(typeof tx.Amount === 'object' && tx.Amount !== null && !Array.isArray(tx.Amount) &&
+      Object.entries(tx.Amount).every(
+        ([key, value]) => typeof key === 'string' && typeof value === 'string'
+      ))
+  ) {
+    throw new ValidationError(
+      'PaymentChannelFund: Amount must be a string or an object with string keys and string values'
+    )
   }
 
   if (tx.Expiration !== undefined && typeof tx.Expiration !== 'number') {


### PR DESCRIPTION
## High Level Overview of Change

This PR extends the `Amount` field in `PaymentChannel*` transactions to support issued asset currencies.

### Context of Change

Using issued assets in payment channels on XRPL is currently unsupported. However, it is supported through Xahau, and there are [ongoing discussions](https://github.com/XRPLF/XRPL-Standards/discussions/133) to support them on XRPL. This PR will:

1. enable wallets like [Crossmark](https://crossmark.io/) and [GemWallet](https://gemwallet.app/) to support issued currencies in Xahau payment channels,
2. enable businesses like [Dhali](https://dhali.io/) to support paying for APIs using issued currencies on Xahau with the above wallets,
3. pave the way for issued assets being supported in XRPL mainnet payment channels.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [ ] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
