### PR TITLE
feat: add support for the simulate RPC (XLS-69d)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,7 @@
 name: Node.js CI
 
 env:
-  RIPPLED_DOCKER_IMAGE: rippleci/rippled:2.3.0-rc1
+  RIPPLED_DOCKER_IMAGE: rippleci/rippled:develop
 
 on:
   push:

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -11,7 +11,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Deprecated `setTransactionFlagsToNumber`. Start using convertTxFlagsToNumber instead
 
 ### Added
-* Support for the `simulate` RPC ([XLS-69d](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069d-simulate))
+* Support for the `simulate` RPC ([XLS-69](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069-simulate))
 
 ## 4.1.0 (2024-12-23)
 

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -11,7 +11,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Deprecated `setTransactionFlagsToNumber`. Start using convertTxFlagsToNumber instead
 
 ### Added
-* Support for the `simulate` RPC
+* Support for the `simulate` RPC ([XLS-69d](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069d-simulate))
 
 ## 4.1.0 (2024-12-23)
 

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased Changes
 
+### Added
+* Support for the `simulate` RPC
+
 ## 4.1.0 (2024-12-23)
 
 ### Added

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -40,10 +40,13 @@ import type {
   MarkerRequest,
   MarkerResponse,
   SubmitResponse,
-  SimulateResponse,
   SimulateRequest,
 } from '../models/methods'
 import type { BookOffer, BookOfferCurrency } from '../models/methods/bookOffers'
+import {
+  SimulateBinaryResponse,
+  SimulateJsonResponse,
+} from '../models/methods/simulate'
 import type {
   EventTypes,
   OnEventToListenerMap,
@@ -782,13 +785,16 @@ class Client extends EventEmitter<EventTypes> {
    * @returns A promise that contains SimulateResponse.
    * @throws RippledError if the simulate request fails.
    */
-  public async simulate(
+  // eslint-disable-next-line max-lines-per-function -- simulate needs a bit complex logic
+  public async simulate<Binary extends boolean = false>(
     transaction: SubmittableTransaction | string,
     opts?: {
       // If true, return the binary-encoded representation of the results.
-      binary?: boolean
+      binary?: Binary
     },
-  ): Promise<SimulateResponse> {
+  ): Promise<
+    Binary extends false ? SimulateJsonResponse : SimulateBinaryResponse
+  > {
     // verify that the transaction isn't signed
     const decodedTx =
       typeof transaction === 'string'

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -793,7 +793,7 @@ class Client extends EventEmitter<EventTypes> {
       binary?: Binary
     },
   ): Promise<
-    Binary extends false ? SimulateJsonResponse : SimulateBinaryResponse
+    Binary extends true ? SimulateBinaryResponse : SimulateJsonResponse
   > {
     // verify that the transaction isn't signed
     const decodedTx =

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -785,7 +785,7 @@ class Client extends EventEmitter<EventTypes> {
    * @returns A promise that contains SimulateResponse.
    * @throws RippledError if the simulate request fails.
    */
-  // eslint-disable-next-line max-lines-per-function -- simulate needs a bit complex logic
+
   public async simulate<Binary extends boolean = false>(
     transaction: SubmittableTransaction | string,
     opts?: {
@@ -795,38 +795,6 @@ class Client extends EventEmitter<EventTypes> {
   ): Promise<
     Binary extends true ? SimulateBinaryResponse : SimulateJsonResponse
   > {
-    // verify that the transaction isn't signed
-    const decodedTx =
-      typeof transaction === 'string'
-        ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- needed for typing
-          (decode(transaction) as unknown as SubmittableTransaction)
-        : transaction
-    if (typeof decodedTx === 'string') {
-      throw new ValidationError(
-        'Provided transaction is not a valid transaction.',
-      )
-    }
-    if (decodedTx.TxnSignature !== '' && decodedTx.TxnSignature != null) {
-      throw new ValidationError('Transaction must not be signed.')
-    }
-    if (
-      decodedTx.Signers?.some(
-        (signer) =>
-          signer.Signer.TxnSignature !== '' &&
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- needed for JS
-          signer.Signer.TxnSignature != null,
-      )
-    ) {
-      throw new ValidationError('Transaction must not be signed.')
-    }
-
-    setValidAddresses(decodedTx)
-    setTransactionFlagsToNumber(decodedTx)
-
-    if (decodedTx.NetworkID == null) {
-      decodedTx.NetworkID = txNeedsNetworkID(this) ? this.networkID : undefined
-    }
-
     // send request
     const binary = opts?.binary ?? false
     const request: SimulateRequest =

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -79,7 +79,7 @@ import {
   separateBuySellOrders,
   sortAndLimitOffers,
 } from '../sugar/getOrderbook'
-import { decode, dropsToXrp, hashes, isValidClassicAddress } from '../utils'
+import { dropsToXrp, hashes, isValidClassicAddress } from '../utils'
 import { Wallet } from '../Wallet'
 import {
   type FaucetRequestBody,

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -148,6 +148,14 @@ import {
   StateAccountingFinal,
 } from './serverInfo'
 import { ServerStateRequest, ServerStateResponse } from './serverState'
+import {
+  SimulateBinaryRequest,
+  SimulateBinaryResponse,
+  SimulateJsonRequest,
+  SimulateJsonResponse,
+  SimulateRequest,
+  SimulateResponse,
+} from './simulate'
 import { SubmitRequest, SubmitResponse } from './submit'
 import {
   SubmitMultisignedRequest,
@@ -398,6 +406,10 @@ export type RequestResponseMap<
   ? LedgerDataResponse
   : T extends LedgerEntryRequest
   ? LedgerEntryResponse
+  : T extends SimulateBinaryRequest
+  ? SimulateBinaryResponse
+  : T extends SimulateJsonRequest
+  ? SimulateJsonResponse
   : T extends SubmitRequest
   ? SubmitResponse
   : T extends SubmitMultisignedRequest
@@ -544,6 +556,8 @@ export {
   LedgerEntryRequest,
   LedgerEntryResponse,
   // transaction methods with types
+  SimulateRequest,
+  SimulateResponse,
   SubmitRequest,
   SubmitResponse,
   SubmitMultisignedRequest,

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -413,7 +413,7 @@ export type RequestResponseMap<
   : T extends SimulateJsonRequest
   ? SimulateJsonResponse
   : T extends SimulateRequest
-  ? SimulateResponse
+  ? SimulateJsonResponse
   : T extends SubmitRequest
   ? SubmitResponse
   : T extends SubmitMultisignedRequest

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -211,6 +211,7 @@ type Request =
   | LedgerDataRequest
   | LedgerEntryRequest
   // transaction methods
+  | SimulateRequest
   | SubmitRequest
   | SubmitMultisignedRequest
   | TransactionEntryRequest
@@ -269,6 +270,7 @@ type Response<Version extends APIVersion = typeof DEFAULT_API_VERSION> =
   | LedgerDataResponse
   | LedgerEntryResponse
   // transaction methods
+  | SimulateResponse
   | SubmitResponse
   | SubmitMultisignedVersionResponseMap<Version>
   | TransactionEntryResponse

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -412,6 +412,8 @@ export type RequestResponseMap<
   ? SimulateBinaryResponse
   : T extends SimulateJsonRequest
   ? SimulateJsonResponse
+  : T extends SimulateRequest
+  ? SimulateResponse
   : T extends SubmitRequest
   ? SubmitResponse
   : T extends SubmitMultisignedRequest

--- a/packages/xrpl/src/models/methods/ledger.ts
+++ b/packages/xrpl/src/models/methods/ledger.ts
@@ -203,13 +203,13 @@ export interface LedgerQueueData {
 }
 
 export interface LedgerBinary
-  extends Omit<Omit<Ledger, 'transactions'>, 'accountState'> {
+  extends Omit<Ledger, 'transactions' | 'accountState'> {
   accountState?: string[]
   transactions?: string[]
 }
 
 export interface LedgerBinaryV1
-  extends Omit<Omit<LedgerV1, 'transactions'>, 'accountState'> {
+  extends Omit<LedgerV1, 'transactions' | 'accountState'> {
   accountState?: string[]
   transactions?: string[]
 }

--- a/packages/xrpl/src/models/methods/simulate.ts
+++ b/packages/xrpl/src/models/methods/simulate.ts
@@ -12,21 +12,20 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export type SimulateRequest = SimulateRequestBase &
-  (
-    | {
-        tx_blob: string
-      }
-    | {
-        tx_json: Transaction
-      }
-  )
-
-export interface SimulateRequestBase extends BaseRequest {
+export type SimulateRequest = BaseRequest & {
   command: 'simulate'
 
   binary?: boolean
-}
+} & (
+    | {
+        tx_blob: string
+        tx_json?: never
+      }
+    | {
+        tx_json: Transaction
+        tx_blob?: never
+      }
+  )
 
 export type SimulateBinaryRequest = SimulateRequest & {
   binary: true
@@ -36,10 +35,23 @@ export type SimulateJsonRequest = SimulateRequest & {
   binary?: false
 }
 
+/**
+ * Response expected from an {@link SimulateRequest}.
+ *
+ * @category Responses
+ */
 export type SimulateResponse = SimulateBinaryResponse | SimulateJsonResponse
 
 export interface SimulateBinaryResponse extends BaseResponse {
   result: {
+    applied: false
+
+    engine_result: string
+
+    engine_result_code: number
+
+    engine_result_message: string
+
     tx_blob: string
 
     meta_blob: string

--- a/packages/xrpl/src/models/methods/simulate.ts
+++ b/packages/xrpl/src/models/methods/simulate.ts
@@ -1,0 +1,80 @@
+import {
+  BaseTransaction,
+  Transaction,
+  TransactionMetadata,
+} from '../transactions'
+
+import { BaseRequest, BaseResponse } from './baseMethod'
+
+/**
+ * The `simulate` method simulates a transaction without submitting it to the network.
+ * Returns a {@link SimulateResponse}.
+ *
+ * @category Requests
+ */
+export type SimulateRequest = SimulateBinaryRequest | SimulateJsonRequest
+
+export type SimulateBinaryRequest = BaseRequest & {
+  command: 'simulate'
+
+  binary: true
+} & (
+    | {
+        tx_blob: string
+      }
+    | {
+        tx_json: Transaction
+      }
+  )
+
+export type SimulateJsonRequest = BaseRequest & {
+  command: 'simulate'
+
+  binary?: false
+} & (
+    | {
+        tx_blob: string
+      }
+    | {
+        tx_json: Transaction
+      }
+  )
+
+export type SimulateResponse = SimulateBinaryResponse | SimulateJsonResponse
+
+export interface SimulateBinaryResponse extends BaseResponse {
+  result: {
+    tx_blob: string
+
+    meta_blob: string
+
+    /**
+     * The ledger index of the ledger version that was used to generate this
+     * response.
+     */
+    ledger_index: number
+  }
+}
+
+export interface SimulateJsonResponse<T extends BaseTransaction = Transaction>
+  extends BaseResponse {
+  result: {
+    applied: false
+
+    engine_result: string
+
+    engine_result_code: number
+
+    engine_result_message: string
+
+    /**
+     * The ledger index of the ledger version that was used to generate this
+     * response.
+     */
+    ledger_index: number
+
+    tx_json: T
+
+    meta?: TransactionMetadata<T>
+  }
+}

--- a/packages/xrpl/src/models/methods/simulate.ts
+++ b/packages/xrpl/src/models/methods/simulate.ts
@@ -40,7 +40,7 @@ export type SimulateJsonRequest = SimulateRequest & {
  *
  * @category Responses
  */
-export type SimulateResponse = SimulateBinaryResponse | SimulateJsonResponse
+export type SimulateResponse = SimulateJsonResponse | SimulateBinaryResponse
 
 export interface SimulateBinaryResponse extends BaseResponse {
   result: {

--- a/packages/xrpl/src/models/methods/simulate.ts
+++ b/packages/xrpl/src/models/methods/simulate.ts
@@ -12,33 +12,29 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export type SimulateRequest = SimulateBinaryRequest | SimulateJsonRequest
+export type SimulateRequest = SimulateRequestBase &
+  (
+    | {
+        tx_blob: string
+      }
+    | {
+        tx_json: Transaction
+      }
+  )
 
-export type SimulateBinaryRequest = BaseRequest & {
+export interface SimulateRequestBase extends BaseRequest {
   command: 'simulate'
 
+  binary?: boolean
+}
+
+export type SimulateBinaryRequest = SimulateRequest & {
   binary: true
-} & (
-    | {
-        tx_blob: string
-      }
-    | {
-        tx_json: Transaction
-      }
-  )
+}
 
-export type SimulateJsonRequest = BaseRequest & {
-  command: 'simulate'
-
+export type SimulateJsonRequest = SimulateRequest & {
   binary?: false
-} & (
-    | {
-        tx_blob: string
-      }
-    | {
-        tx_json: Transaction
-      }
-  )
+}
 
 export type SimulateResponse = SimulateBinaryResponse | SimulateJsonResponse
 

--- a/packages/xrpl/src/sugar/submit.ts
+++ b/packages/xrpl/src/sugar/submit.ts
@@ -1,5 +1,3 @@
-import { decode, encode } from 'ripple-binary-codec'
-
 import type {
   Client,
   SubmitRequest,
@@ -12,6 +10,7 @@ import { ValidationError, XrplError } from '../errors'
 import { Signer } from '../models/common'
 import { TxResponse } from '../models/methods'
 import { BaseTransaction } from '../models/transactions/common'
+import { decode, encode } from '../utils'
 
 /** Approximate time for a ledger to close, in milliseconds */
 const LEDGER_CLOSE_TIME = 1000
@@ -52,7 +51,7 @@ export async function submitRequest(
   failHard = false,
 ): Promise<SubmitResponse> {
   if (!isSigned(signedTransaction)) {
-    throw new ValidationError('Transaction must be signed')
+    throw new ValidationError('Transaction must be signed.')
   }
 
   const signedTxEncoded =

--- a/packages/xrpl/test/integration/requests/serverInfo.test.ts
+++ b/packages/xrpl/test/integration/requests/serverInfo.test.ts
@@ -125,6 +125,7 @@ describe('server_info (rippled)', function () {
         'build_version',
         'node_size',
         'initial_sync_duration_us',
+        'git',
       ]
       assert.deepEqual(
         omit(response.result.info, removeKeys),

--- a/packages/xrpl/test/integration/requests/serverState.test.ts
+++ b/packages/xrpl/test/integration/requests/serverState.test.ts
@@ -116,6 +116,7 @@ describe('server_state', function () {
         'node_size',
         'initial_sync_duration_us',
         'ports',
+        'git',
       ]
       assert.deepEqual(
         omit(response.result.state, removeKeys),

--- a/packages/xrpl/test/integration/requests/simulate.test.ts
+++ b/packages/xrpl/test/integration/requests/simulate.test.ts
@@ -35,7 +35,7 @@ describe('simulate', function () {
 
       assert.equal(simulateResponse.type, 'response')
       assert.typeOf(simulateResponse.result.meta, 'object')
-      assert.equal(simulateResponse.result.tx_json, simulateRequest.tx_json)
+      assert.typeOf(simulateResponse.result.tx_json, 'object')
       assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
       assert.isFalse(simulateResponse.result.applied)
     },
@@ -57,7 +57,7 @@ describe('simulate', function () {
 
       assert.equal(simulateResponse.type, 'response')
       assert.typeOf(simulateResponse.result.meta_blob, 'string')
-      assert.equal(simulateResponse.result.tx_blob, 'string')
+      assert.typeOf(simulateResponse.result.tx_blob, 'string')
       assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
       assert.isFalse(simulateResponse.result.applied)
     },

--- a/packages/xrpl/test/integration/requests/simulate.test.ts
+++ b/packages/xrpl/test/integration/requests/simulate.test.ts
@@ -1,0 +1,64 @@
+import { assert } from 'chai'
+
+import { SimulateRequest } from '../../../src'
+import serverUrl from '../serverUrl'
+import {
+  setupClient,
+  teardownClient,
+  type XrplIntegrationTestContext,
+} from '../setup'
+
+// how long before each test case times out
+const TIMEOUT = 20000
+
+describe('simulate', function () {
+  let testContext: XrplIntegrationTestContext
+
+  beforeEach(async () => {
+    testContext = await setupClient(serverUrl)
+  })
+  afterEach(async () => teardownClient(testContext))
+
+  it(
+    'json',
+    async () => {
+      const simulateRequest: SimulateRequest = {
+        command: 'simulate',
+        tx_json: {
+          TransactionType: 'AccountSet',
+          Account: testContext.wallet.address,
+          NFTokenMinter: testContext.wallet.address,
+        },
+      }
+      const simulateResponse = await testContext.client.request(simulateRequest)
+
+      assert.equal(simulateResponse.type, 'response')
+      assert.typeOf(simulateResponse.result.meta, 'object')
+      assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
+      assert.isFalse(simulateResponse.result.applied)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'binary',
+    async () => {
+      const simulateRequest: SimulateRequest = {
+        command: 'simulate',
+        tx_json: {
+          TransactionType: 'AccountSet',
+          Account: testContext.wallet.address,
+        },
+        binary: true,
+      }
+      const simulateResponse = await testContext.client.request(simulateRequest)
+
+      assert.equal(simulateResponse.type, 'response')
+      assert.typeOf(simulateResponse.result.meta_blob, 'string')
+      assert.equal(simulateResponse.result.tx_blob, 'string')
+      assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
+      assert.isFalse(simulateResponse.result.applied)
+    },
+    TIMEOUT,
+  )
+})

--- a/packages/xrpl/test/integration/requests/simulate.test.ts
+++ b/packages/xrpl/test/integration/requests/simulate.test.ts
@@ -76,7 +76,7 @@ describe('simulate', function () {
 
       assert.equal(simulateResponse.type, 'response')
       assert.typeOf(simulateResponse.result.meta, 'object')
-      assert.equal(simulateResponse.result.tx_json, tx)
+      assert.typeOf(simulateResponse.result.tx_json, 'object')
       assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
       assert.isFalse(simulateResponse.result.applied)
     },

--- a/packages/xrpl/test/integration/requests/simulate.test.ts
+++ b/packages/xrpl/test/integration/requests/simulate.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai'
 
-import { SimulateRequest } from '../../../src'
+import { AccountSet, SimulateRequest } from '../../../src'
+import { SimulateBinaryRequest } from '../../../src/models/methods/simulate'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -34,6 +35,7 @@ describe('simulate', function () {
 
       assert.equal(simulateResponse.type, 'response')
       assert.typeOf(simulateResponse.result.meta, 'object')
+      assert.equal(simulateResponse.result.tx_json, simulateRequest.tx_json)
       assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
       assert.isFalse(simulateResponse.result.applied)
     },
@@ -43,7 +45,7 @@ describe('simulate', function () {
   it(
     'binary',
     async () => {
-      const simulateRequest: SimulateRequest = {
+      const simulateRequest: SimulateBinaryRequest = {
         command: 'simulate',
         tx_json: {
           TransactionType: 'AccountSet',
@@ -56,6 +58,25 @@ describe('simulate', function () {
       assert.equal(simulateResponse.type, 'response')
       assert.typeOf(simulateResponse.result.meta_blob, 'string')
       assert.equal(simulateResponse.result.tx_blob, 'string')
+      assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
+      assert.isFalse(simulateResponse.result.applied)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'sugar',
+    async () => {
+      const tx: AccountSet = {
+        TransactionType: 'AccountSet',
+        Account: testContext.wallet.address,
+        NFTokenMinter: testContext.wallet.address,
+      }
+      const simulateResponse = await testContext.client.simulate(tx)
+
+      assert.equal(simulateResponse.type, 'response')
+      assert.typeOf(simulateResponse.result.meta, 'object')
+      assert.equal(simulateResponse.result.tx_json, tx)
       assert.equal(simulateResponse.result.engine_result, 'tesSUCCESS')
       assert.isFalse(simulateResponse.result.applied)
     },


### PR DESCRIPTION
## High Level Overview of Change

This PR adds support to xrpl-py for the new `simulate` RPC.

### Context of Change

Spec: https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069d-simulate
rippled PR: https://github.com/XRPLF/rippled/pull/5069

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Did you update CHANGELOG.md?

- [x] Yes

## Test Plan

TODO