### PR TITLE
Make the simulate response more type-strict

### DIFF
--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -40,10 +40,13 @@ import type {
   MarkerRequest,
   MarkerResponse,
   SubmitResponse,
-  SimulateResponse,
   SimulateRequest,
 } from '../models/methods'
 import type { BookOffer, BookOfferCurrency } from '../models/methods/bookOffers'
+import {
+  SimulateBinaryResponse,
+  SimulateJsonResponse,
+} from '../models/methods/simulate'
 import type {
   EventTypes,
   OnEventToListenerMap,
@@ -782,13 +785,16 @@ class Client extends EventEmitter<EventTypes> {
    * @returns A promise that contains SimulateResponse.
    * @throws RippledError if the simulate request fails.
    */
-  public async simulate(
+  // eslint-disable-next-line max-lines-per-function -- simulate needs a bit complex logic
+  public async simulate<Binary extends boolean = false>(
     transaction: SubmittableTransaction | string,
     opts?: {
       // If true, return the binary-encoded representation of the results.
-      binary?: boolean
+      binary?: Binary
     },
-  ): Promise<SimulateResponse> {
+  ): Promise<
+    Binary extends false ? SimulateJsonResponse : SimulateBinaryResponse
+  > {
     // verify that the transaction isn't signed
     const decodedTx =
       typeof transaction === 'string'


### PR DESCRIPTION
# This is a PR for the simulate branch.

## High Level Overview of Change

Change the type of the Response to`SimulateJsonResponse` or `SimulateBinaryResponse` according to the setting value of the `binary` option.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [ ] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
