### PR TITLE
fix(rbc): throw error instead of throwing away unknown fields

### DIFF
--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+* Throw an error if a field is unknown, rather than silently throwing it away.
+
 ## 2.3.0 (2025-2-13)
 
 ### Added

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 ### Fixed
-* add `MPTAmount` support in `Issue` (rippled internal type)
-* Throw an error if a field is unknown, rather than silently throwing it away.
+* add `MPTCurrency` support in `Issue` (rippled internal type)
+* Throw an error during serialization if a field is unknown, rather than silently throwing it away.
 
 ## 2.3.0 (2025-2-13)
 

--- a/packages/ripple-binary-codec/src/types/st-object.ts
+++ b/packages/ripple-binary-codec/src/types/st-object.ts
@@ -116,14 +116,25 @@ class STObject extends SerializedType {
       return Object.assign(acc, handled ?? { [key]: val })
     }, {})
 
-    let sorted = Object.keys(xAddressDecoded)
-      .map((f: string): FieldInstance => definitions.field[f] as FieldInstance)
-      .filter(
-        (f: FieldInstance): boolean =>
-          f !== undefined &&
-          xAddressDecoded[f.name] !== undefined &&
-          f.isSerialized,
+    function isValidFieldInstance(
+      f: FieldInstance | undefined,
+    ): f is FieldInstance {
+      return (
+        f !== undefined &&
+        xAddressDecoded[f.name] !== undefined &&
+        f.isSerialized
       )
+    }
+
+    let sorted = Object.keys(xAddressDecoded)
+      .map((f: string): FieldInstance | undefined => {
+        if (!(f in definitions.field)) {
+          if (f[0] === f[0].toLowerCase()) return undefined
+          throw new Error(`Field ${f} is not defined in the definitions`)
+        }
+        return definitions.field[f] as FieldInstance
+      })
+      .filter(isValidFieldInstance)
       .sort((a, b) => {
         return a.ordinal - b.ordinal
       })

--- a/packages/ripple-binary-codec/test/definitions.test.ts
+++ b/packages/ripple-binary-codec/test/definitions.test.ts
@@ -34,8 +34,8 @@ describe('encode and decode using new types as a parameter', function () {
   it('can encode and decode a new Field', function () {
     const tx = { ...txJson, NewFieldDefinition: 10 }
 
-    // Before updating the types, undefined fields will be ignored on encode
-    expect(decode(encode(tx))).not.toEqual(tx)
+    // Before updating the types, undefined fields will throw an error
+    expect(() => encode(tx)).toThrow()
 
     // Normally this would be generated directly from rippled with something like `server_definitions`.
     // Added here to make it easier to see what is actually changing in the definitions.json file.
@@ -72,8 +72,8 @@ describe('encode and decode using new types as a parameter', function () {
       ],
     }
 
-    // Before updating the types, undefined fields will be ignored on encode
-    expect(decode(encode(tx))).not.toEqual(tx)
+    // Before updating the types, undefined fields will throw an error
+    expect(() => encode(tx)).toThrow()
 
     // Normally this would be generated directly from rippled with something like `server_definitions`.
     // Added here to make it easier to see what is actually changing in the definitions.json file.
@@ -141,8 +141,8 @@ describe('encode and decode using new types as a parameter', function () {
       },
     ])
 
-    // Test that before updating the types this tx fails to decode correctly. Note that undefined fields are ignored on encode.
-    expect(decode(encode(tx))).not.toEqual(tx)
+    // Test that before updating the types this tx fails to decode correctly. Note that undefined fields will throw an error.
+    expect(() => encode(tx)).toThrow()
 
     class NewType extends UInt32 {
       // Should be the same as UInt32

--- a/packages/ripple-binary-codec/test/tx-encode-decode.test.ts
+++ b/packages/ripple-binary-codec/test/tx-encode-decode.test.ts
@@ -116,4 +116,13 @@ describe('encoding and decoding tx_json', function () {
       encode(my_tx)
     }).toThrow()
   })
+
+  it('throws when there is an unknown field', function () {
+    const my_tx = Object.assign({}, tx_json, {
+      BadField: 1,
+    })
+    expect(() => {
+      encode(my_tx)
+    }).toThrow()
+  })
 })


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes an issue in ripple-binary-codec to throw an error instead of silently throwing away unknown fields and their values when serializing transactions.

It only errors on `CapitalizedFields` and still silently ignores `lowercaseFields`, as the latter are likely from copy-pasting `tx` outputs or something, rather than an actual error (since all rippled fields must be Capitalized).

### Context of Change

I came across this issue when working on a separate PR for a new feature, where my tests would fail for unknown reasons. I had to go into the rippled logs and decode the transaction rippled was receiving to figure out what was happening.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes

## Test Plan

Added a test to make sure this works properly, and fixed existing tests that had the previous assumption.
