### PR TITLE
fix: add `hash` field to `TransactionStream`

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,10 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 
+### Fixed
+* `TransactionStream` model includes `hash` field in APIv2
+* `TransactionStream` model includes `close_time_iso` field only for APIv2
+
 ## 4.2.0 (2025-2-13)
 
 ### Added

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -275,7 +275,7 @@ interface TransactionStreamBase<
    * The approximate time this ledger was closed, in date time string format.
    * Always uses the UTC time zone.
    */
-  close_time_iso: string
+  close_time_iso: Version extends typeof RIPPLED_API_V2 ? string : never
   /** String Transaction result code. */
   engine_result: string
   /** Numeric transaction response code, if applicable. */

--- a/packages/xrpl/src/models/methods/subscribe.ts
+++ b/packages/xrpl/src/models/methods/subscribe.ts
@@ -283,6 +283,10 @@ interface TransactionStreamBase<
   /** Human-readable explanation for the transaction response. */
   engine_result_message: string
   /**
+   * The unique hash identifier of the transaction.
+   */
+  hash?: Version extends typeof RIPPLED_API_V2 ? string : never
+  /**
    * The ledger index of the current in-progress ledger version for which this
    * transaction is currently proposed.
    */


### PR DESCRIPTION
## High Level Overview of Change

This PR makes a couple of fixes in the `TransactionStream` model:
* Adds the `hash` field (only for APIv2)
* Updates the `close_time_iso` field to only be in APIv2

### Context of Change

Fixes #2938

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes

## Test Plan

Checked docs
