### PR TITLE
chore(docs): update `definitions.json` generation docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ This updates `docs/` at the top level, where GitHub Pages looks for the docs.
 This should almost always be done using [this script](./packages/ripple-binary-codec/tools/generateDefinitions.js) - if the output needs manual intervention afterwards, consider updating the script instead.
 
 1. Clone / pull the latest changes from [rippled](https://github.com/XRPLF/rippled) - Specifically the `develop` branch is usually the right one.
-2. Run `node packages/ripple-binary-codec/tools/generateDefinitions.js path/to/rippled` (assuming you're calling this file from the directory this file is in).
+2. Run `node packages/ripple-binary-codec/tools/generateDefinitions.js path/to/rippled` (assuming you're calling this file from the root directory of xrpl.js).
 5. Verify that the changes make sense by inspection before submitting, as there may be updates required for the tool depending on the latest amendments we're updating to match.
 
 ## Adding and removing packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ This should almost always be done using [this script](./packages/ripple-binary-c
 
 1. Clone / pull the latest changes from [rippled](https://github.com/XRPLF/rippled) - Specifically the `develop` branch is usually the right one.
 2. Run `node packages/ripple-binary-codec/tools/generateDefinitions.js path/to/rippled` (assuming you're calling this file from the root directory of xrpl.js).
-5. Verify that the changes make sense by inspection before submitting, as there may be updates required for the tool depending on the latest amendments we're updating to match.
+3. Verify that the changes make sense by inspection before submitting, as there may be updates required for the tool depending on the latest amendments we're updating to match.
 
 ## Adding and removing packages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,9 +150,13 @@ npm run docgen
 
 This updates `docs/` at the top level, where GitHub Pages looks for the docs.
 
-## Update `definitions.json`
+## Updating `definitions.json`
 
-Use [this repo](https://github.com/RichardAH/xrpl-codec-gen) to generate a new `definitions.json` file from the rippled source code. Instructions are available in that README.
+This should almost always be done using [this script](./packages/ripple-binary-codec/tools/generateDefinitions.js) - if the output needs manual intervention afterwards, consider updating the script instead.
+
+1. Clone / pull the latest changes from [rippled](https://github.com/XRPLF/rippled) - Specifically the `develop` branch is usually the right one.
+2. Run `node packages/ripple-binary-codec/tools/generateDefinitions.js path/to/rippled` (assuming you're calling this file from the directory this file is in).
+5. Verify that the changes make sense by inspection before submitting, as there may be updates required for the tool depending on the latest amendments we're updating to match.
 
 ## Adding and removing packages
 
@@ -200,16 +204,6 @@ In order to update the list, follow these steps from the top level of the librar
 4. Push your changes
 
 Note: The same updated config can be used to update xrpl-py's CI as well.
-
-## Updating `definitions.json`
-
-This should almost always be done using the [`xrpl-codec-gen`](https://github.com/RichardAH/xrpl-codec-gen) script - if the output needs manual intervention afterwards, consider updating the script instead.
-
-1. Clone / pull the latest changes from [rippled](https://github.com/XRPLF/rippled) - Specifically the `develop` branch is usually the right one.
-2. Clone / pull the latest changes from [`xrpl-codec-gen`](https://github.com/RichardAH/xrpl-codec-gen)
-3. From the `xrpl-codec-gen` tool, follow the steps in the `README.md` to generate a new `definitions.json` file.
-4. Replace the `definitions.json` file in the `ripple-binary-codec` with the newly generated file.
-5. Verify that the changes make sense by inspection before submitting, as there may be updates required for the `xrpl-codec-gen` tool depending on the latest amendments we're updating to match.
 
 
 ## Release process + checklist

--- a/packages/ripple-binary-codec/CONTRIBUTING.md
+++ b/packages/ripple-binary-codec/CONTRIBUTING.md
@@ -18,6 +18,12 @@ For a good example unit test file, look at [test/hash.test.ts](test/hash.test.ts
 
 If you add a new serializable type, please add a new file with tests that ensure it can be encoded / decoded, and that it throws any relevant errors.
 
+# Updating `definitions.json`
+
+The `definitions.json` file contains all the fields within rippled and all the relevant values needed to decode/encode it from the [rippled binary format](https://xrpl.org/es-es/docs/references/protocol/binary-format).
+
+To update it, use the script [here](./tools/generateDefinitions.js). You can run the script with `node path/to/generateDefinitions.js`.
+
 # Adding new serializable types
 To add a new serializable type, first read through `enum`'s [README.md](src/enums/README.md) as it explains how to update `definitions.json` which ties `TransactionType`s and `Field`s to specific ids rippled understands.
 

--- a/packages/ripple-binary-codec/src/enums/README.md
+++ b/packages/ripple-binary-codec/src/enums/README.md
@@ -57,7 +57,7 @@ See:
 - https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/TER.h
 - https://xrpl.org/transaction-results.html
 
-To generate a new definitions file from rippled source code, use this tool: https://github.com/RichardAH/xrpl-codec-gen
+To generate a new definitions file from rippled source code, use [this tool](../../tools/generateDefinitions.js).
 
 ## Transaction Types
 
@@ -69,7 +69,7 @@ If you're building your own sidechain or writing an amendment for the XRPL, you 
 
 To do that there are a couple things you need to do:
 
-1. Generate your own `definitions.json` file from rippled source code using [this tool](https://github.com/RichardAH/xrpl-codec-gen) (The default `definitions.json` for mainnet can be found [here](https://github.com/XRPLF/xrpl.js/blob/main/packages/ripple-binary-codec/src/enums/definitions.json))
+1. Generate your own `definitions.json` file from rippled source code using [this tool](../../tools/generateDefinitions.js). The default `definitions.json` for mainnet can be found [here](https://github.com/XRPLF/xrpl.js/blob/main/packages/ripple-binary-codec/src/enums/definitions.json).
 2. Create new SerializedType classes for any new Types (So that encode/decode behavior is defined). The SerializedType classes correspond to "ST..." classes in Rippled. Note: This is very rarely required.
 
 - For examples of how to implement that you can look at objects in the [`types` folder](../types/), such as `Amount`, `UInt8`, or `STArray`.

--- a/packages/ripple-binary-codec/src/enums/xrpl-definitions-base.ts
+++ b/packages/ripple-binary-codec/src/enums/xrpl-definitions-base.ts
@@ -38,8 +38,9 @@ class XrplDefinitionsBase {
 
   /**
    * Present rippled types in a typed and updatable format.
-   * For an example of the input format see `definitions.json`
-   * To generate a new definitions file from rippled source code, use this tool: https://github.com/RichardAH/xrpl-codec-gen
+   * For an example of the input format see `definitions.json`.
+   * To generate a new definitions file from rippled source code, use the tool at
+   * `packages/ripple-binary-codec/tools/generateDefinitions.js`.
    *
    * See the definitions.test.js file for examples of how to create your own updated definitions.json.
    *

--- a/packages/ripple-binary-codec/src/enums/xrpl-definitions.ts
+++ b/packages/ripple-binary-codec/src/enums/xrpl-definitions.ts
@@ -14,7 +14,8 @@ export class XrplDefinitions extends XrplDefinitionsBase {
   /**
    * Present rippled types in a typed and updatable format.
    * For an example of the input format see `definitions.json`
-   * To generate a new definitions file from rippled source code, use this tool: https://github.com/RichardAH/xrpl-codec-gen
+   * To generate a new definitions file from rippled source code, use the tool at
+   * `packages/ripple-binary-codec/tools/generateDefinitions.js`.
    *
    * See the definitions.test.js file for examples of how to create your own updated definitions.json.
    *


### PR DESCRIPTION
## High Level Overview of Change

This PR adds documentation for how to generate the `definitions.json` output via the new script introduced in #2826, and removes mention of the old script.

### Context of Change

#2826 didn't update contributing docs to tell contributors to use the new flow.

### Type of Change

- [x] Documentation Updates

### Did you update HISTORY.md?

- [x] No, this change does not impact library users