### PR TITLE
fix: add missing `MPTAmount` type to `VaultDeposit` & `VaultWithdraw`

### DIFF
--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -29,6 +29,7 @@ export interface MPTAmount {
   value: string
 }
 
+// TODO: add MPTAmount to Amount once MPTv2 is released
 export type Amount = IssuedCurrencyAmount | string
 
 export type ClawbackAmount = IssuedCurrencyAmount | MPTAmount

--- a/packages/xrpl/src/models/transactions/vaultDeposit.ts
+++ b/packages/xrpl/src/models/transactions/vaultDeposit.ts
@@ -1,4 +1,4 @@
-import { Amount } from '../common'
+import { Amount, MPTAmount } from '../common'
 
 import {
   BaseTransaction,
@@ -24,7 +24,8 @@ export interface VaultDeposit extends BaseTransaction {
   /**
    * Asset amount to deposit.
    */
-  Amount: Amount
+  // TODO: remove MPTAmount when MPTv2 is released
+  Amount: Amount | MPTAmount
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/vaultWithdraw.ts
+++ b/packages/xrpl/src/models/transactions/vaultWithdraw.ts
@@ -1,4 +1,4 @@
-import { Amount } from '../common'
+import { Amount, MPTAmount } from '../common'
 
 import {
   BaseTransaction,
@@ -27,7 +27,8 @@ export interface VaultWithdraw extends BaseTransaction {
   /**
    * The exact amount of Vault asset to withdraw.
    */
-  Amount: Amount
+  // TODO: remove MPTAmount when MPTv2 is released
+  Amount: Amount | MPTAmount
 
   /**
    * An account to receive the assets. It must be able to receive the asset.


### PR DESCRIPTION
## High Level Overview of Change

Adds missing `MPTAmount` type to `VaultDeposit` & `VaultWithdraw`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

No tests needed since it's a TS fix.
