### PR TITLE
fix: allow `DeliverMax` in `Payment` transaction

### DIFF
--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -208,12 +208,6 @@ export function validatePayment(tx: Record<string, unknown>): void {
   }
 
   checkPartialPayment(tx)
-
-  if (tx.DeliverMax != null) {
-    throw new ValidationError(
-      'PaymentTransaction: Cannot have DeliverMax in a submitted transaction',
-    )
-  }
 }
 
 function checkPartialPayment(tx: Record<string, unknown>): void {

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -44,6 +44,11 @@ describe('Payment', function () {
     assertValid(payment)
   })
 
+  it(`verifies DeliverMax is valid`, function () {
+    payment.DeliverMax = '1234'
+    assertValid(payment)
+  })
+
   it(`Verifies memos correctly`, function () {
     payment.Memos = [
       {


### PR DESCRIPTION
## High Level Overview of Change

Reverts bug in rejecting `DeliverMax` param in `Payment` transaction

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

Added unit test.
