### PR TITLE
release workflow fix - skip .github directory from being searched in grep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           exit 1
         fi
 
-        if grep -R --exclude-dir=.git "artifactory.ops.ripple.com" .; then
+        if grep -R --exclude-dir=.git --exclude-dir=.github "artifactory.ops.ripple.com" .; then
           echo "❌ Internal Artifactory URL found"
           exit 1
         else


### PR DESCRIPTION
## High Level Overview of Change

Recent release workflow [failed](https://github.com/XRPLF/xrpl.js/actions/runs/17329502733) because .github directory was being scanned in grep command. This PR adds change to skip it and prevent the workflow from incorrectly failing.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

Fixing release workflow to release a new version of xrpl.js

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

It's not a library change, so releasing a new version of xrpl.js in draft mode should test this fix.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
