### PR TITLE
Add hashOracle utility hash function

### DIFF
--- a/packages/xrpl/src/utils/hashes/README.md
+++ b/packages/xrpl/src/utils/hashes/README.md
@@ -60,6 +60,10 @@ Compute the hash of a ledger.
 
 Compute the hash of an escrow, given the owner's classic address (starting with `r`) and the account sequence number of the `EscrowCreate` escrow transaction.
 
+### hashOracle = (address, documentId): string
+
+Compute the hash of an oracle, given the owner's classic address (starting with `r`) and the OracleDocumentID of the `OracleSet` transaction.
+
 ### hashPaymentChannel = (address, dstAddress, sequence): string
 
 Compute the hash of a payment channel, given the owner's classic address (starting with `r`), the classic address of the destination, and the account sequence number of the `PaymentChannelCreate` payment channel transaction.

--- a/packages/xrpl/src/utils/hashes/index.ts
+++ b/packages/xrpl/src/utils/hashes/index.ts
@@ -164,6 +164,22 @@ export function hashEscrow(address: string, sequence: number): string {
 }
 
 /**
+ * Compute the Hash of an Oracle LedgerEntry.
+ *
+ * @param address - Address of the owner of the Oracle.
+ * @param documentId - OracleDocumentID of the Oracle.
+ * @returns The hash of the Oracle LedgerEntry.
+ * @category Utilities
+ */
+export function hashOracle(address: string, documentId: number): string {
+  return sha512Half(
+    ledgerSpaceHex('oracle') +
+      addressToHex(address) +
+      documentId.toString(HEX).padStart(BYTE_LENGTH * 2, '0'),
+  )
+}
+
+/**
  * Compute the hash of a Payment Channel.
  *
  * @param address - Account of the Payment Channel.

--- a/packages/xrpl/src/utils/hashes/ledgerSpaces.ts
+++ b/packages/xrpl/src/utils/hashes/ledgerSpaces.ts
@@ -17,6 +17,7 @@ const ledgerSpaces = {
   offer: 'o',
   // Directory of things owned by an account.
   ownerDir: 'O',
+  oracle: 'R',
   // Directory of order books.
   bookDir: 'B',
   contract: 'c',

--- a/packages/xrpl/src/utils/index.ts
+++ b/packages/xrpl/src/utils/index.ts
@@ -45,6 +45,7 @@ import {
   hashLedger,
   hashLedgerHeader,
   hashEscrow,
+  hashOracle,
   hashPaymentChannel,
 } from './hashes'
 import parseNFTokenID from './parseNFTokenID'
@@ -178,6 +179,7 @@ const hashes = {
   hashLedger,
   hashLedgerHeader,
   hashEscrow,
+  hashOracle,
   hashPaymentChannel,
 }
 

--- a/packages/xrpl/test/utils/hashes.test.ts
+++ b/packages/xrpl/test/utils/hashes.test.ts
@@ -16,6 +16,7 @@ import {
   hashTxTree,
   hashTrustline,
   hashEscrow,
+  hashOracle,
   hashPaymentChannel,
   hashSignedTx,
   hashAccountRoot,
@@ -134,6 +135,16 @@ describe('Hashes', function () {
     const expectedEntryHash =
       '61E8E8ED53FA2CEBE192B23897071E9A75217BF5A410E9CB5B45AAB7AECA567A'
     const actualEntryHash = hashEscrow(account, sequence)
+
+    assert.equal(actualEntryHash, expectedEntryHash)
+  })
+
+  it('calcOracleEntryHash', function () {
+    const account = 'rsNvoAZ9MquZSRhu4cEY9wTv1VqHXpVPPt'
+    const documentId = 1
+    const expectedEntryHash =
+      'D463D13ACF77206306BE891DF410655213FBD2C1F2B58A492E7F556A41A44338'
+    const actualEntryHash = hashOracle(account, documentId)
 
     assert.equal(actualEntryHash, expectedEntryHash)
   })


### PR DESCRIPTION
## High Level Overview of Change

Added `hashOracle` utility hashing function for Oracle objects.

### Context of Change

* Added utility hash function `hashOracle`
* Added oracle space key to `ledgerSpaces.ts`
* Added a test for `hashOracle`

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Did you update HISTORY.md?

- [x] No, this change does not impact library users

## Test Plan

This chance closely follows `hashEscrow` utility function and implements similar tests for `hashOracle` function implementation.