### PR TITLE
Fix: deploy documentation workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -276,8 +276,15 @@ jobs:
       url: ${{ steps.docs-artifact.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: generate-documentation
-    if: success()
     steps:
+      - name: Detect version tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "published_version_tag=true" >> $GITHUB_OUTPUT
+              echo "version tag detected in the github push event"
+          fi
       - name: Deploy to Documentation to GitHub Pages
         id: docs-artifact
+        if: steps.check-tag.outputs.published_version_tag == 'true'
         uses: actions/deploy-pages@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -276,17 +276,8 @@ jobs:
       url: ${{ steps.docs-artifact.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: generate-documentation
-    # Deploy docs only pushes into the main branch
-    if: success() && github.ref == 'refs/heads/main'
+    if: success()
     steps:
-      - name: Detect (non-beta) version tag
-        id: check-tag
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "published_version_tag=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Deploy to Documentation to GitHub Pages
         id: docs-artifact
-        if: steps.check-tag.outputs.published_version_tag == 'true'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## High Level Overview of Change
The current `deploy-docs-pages` Github workflow does not function correctly. The docs at js.xrpl.org have not been updated for the last few months. This PR fixes the conflicting conditional checks in this workflow.

Presently, the PR is configured to deploy documentation, only upon tag pushes. The tags must conform to the regex: `^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$`. Furthermore, the developers need to specify the exact tag name under the Github-Pages: Deployment Tag Protection Rules Section (inside the Github repository settings)

There is an alternative solution: Every commit into the `main` branch can be configured to deploy the documentation. However, developers cannot indicate the pre-release/release-version of the documentation. The docs will reflect the state of affairs in the `main` branch, not the latest released version. If the team prefers this solution, let me know.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->


<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

This workflow has been tested on my personal fork of the xrpl.js repository.
- This is an [example workflow](https://github.com/ckeshava/xrpl.js/actions/runs/18234357697) where documentation is correctly deployed. The below picture shows the Deployment protection rules on my personal fork of the xrpl.js repository. Future release tags will need to be manually added into this list.
<img width="881" height="370" alt="image" src="https://github.com/user-attachments/assets/fb8af9f1-313c-41da-aec6-cc47450fec54" />


This is an [example of a failed workflow](https://github.com/ckeshava/xrpl.js/actions/runs/18234292644) owing to the Tag-Deployment-Rule violation.


<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
