### PR TITLE
Support for XLS-82D MPT-DEX

### DIFF
--- a/.ci-config/xrpld.cfg
+++ b/.ci-config/xrpld.cfg
@@ -190,6 +190,7 @@ TokenEscrow
 SingleAssetVault
 LendingProtocol
 PermissionDelegationV1_1
+MPTokensV2
 
 # This section can be used to simulate various FeeSettings scenarios for rippled node in standalone mode
 [voting]

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -13,6 +13,7 @@
 ### Added
 * Add `Int32` serialized type.
 * Introduce unit tests for the `PathSet` rippled type
+* Update the serialization of `PathSet` rippled type to accommodate `mpt_issuance_id` PathElement. This update is a part of the XLS-82d MPT-DEX amendment.
 
 ### Fixed
 * Fix STNumber serialization logic to work with large mantissa scale [10^18, 10^19-1].

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -12,6 +12,7 @@
 
 ### Added
 * Add `Int32` serialized type.
+* Introduce unit tests for the `PathSet` rippled type
 
 ### Fixed
 * Fix STNumber serialization logic to work with large mantissa scale [10^18, 10^19-1].

--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -7,6 +7,7 @@
 * Fix: Validate the input of non-numeric values for `Amount` field.
 * Fix: Add validation checks for negative inputs to `read`, `peek` and `skip` methods in the binary-codec.
 * Fix: `Amount.toJSON()` no longer mutates the internal buffer for native XRP amounts; subsequent calls and re-serializations now return consistent values (#3319).
+* Fix: `Amount.fromParser` and `Amount.toJSON` now reject non-canonical MPT amounts (mantissa above `maxMPTokenAmount` and negative-zero encodings), matching the validation already enforced on the JSON construction path.
 
 ## 2.7.0 (2026-02-12)
 

--- a/packages/ripple-binary-codec/src/enums/definitions.json
+++ b/packages/ripple-binary-codec/src/enums/definitions.json
@@ -3321,6 +3321,26 @@
       }
     ],
     [
+      "TakerPaysMPT",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
+        "type": "Hash192"
+      }
+    ],
+    [
+      "TakerGetsMPT",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
+        "type": "Hash192"
+      }
+    ],
+    [
       "LockingChainIssue",
       {
         "isSerialized": true,

--- a/packages/ripple-binary-codec/src/types/amount.ts
+++ b/packages/ripple-binary-codec/src/types/amount.ts
@@ -165,7 +165,9 @@ class Amount extends SerializedType {
       amount = concat(intBuf)
 
       const mptIssuanceID = Hash192.from(value.mpt_issuance_id).toBytes()
-      return new Amount(concat([leadingByte, amount, mptIssuanceID]))
+      const mptBytes = concat([leadingByte, amount, mptIssuanceID])
+      Amount.assertMptBytesAreCanonical(mptBytes)
+      return new Amount(mptBytes)
     }
 
     throw new Error('Invalid type to construct an Amount')
@@ -183,8 +185,12 @@ class Amount extends SerializedType {
 
     // the amount can be either MPT or XRP at this point
     const isMPT = parser.peek() & 0x20
-    const numBytes = isMPT ? 33 : 8
-    return new Amount(parser.read(numBytes))
+    if (isMPT) {
+      const bytes = parser.read(33)
+      Amount.assertMptBytesAreCanonical(bytes)
+      return new Amount(bytes)
+    }
+    return new Amount(parser.read(8))
   }
 
   /**
@@ -234,6 +240,7 @@ class Amount extends SerializedType {
     }
 
     if (this.isMPT()) {
+      Amount.assertMptBytesAreCanonical(this.bytes)
       const parser = new BinaryParser(this.toString())
       const leadingByte = parser.read(1)
       const amount = parser.read(8)
@@ -324,6 +331,36 @@ class Amount extends SerializedType {
 
       if (Number(BigInt(amount) & BigInt(mptMask)) != 0) {
         throw new Error(`${amount.toString()} is an illegal amount`)
+      }
+    }
+  }
+
+  /**
+   * Validate the canonical form of an MPT amount on its 33-byte wire layout
+   * (leadingByte ‖ mantissa ‖ MPTID). Mirrors the bounds enforced on the JSON
+   * construction path so non-canonical blobs are rejected at deserialization.
+   *
+   * @param bytes 33-byte MPT amount blob
+   * @returns void, throws if the mantissa exceeds maxMPTokenAmount (high bit
+   *   set) or the value is encoded as negative zero.
+   */
+  private static assertMptBytesAreCanonical(bytes: Uint8Array): void {
+    const isPositive = (bytes[0] & 0x40) !== 0
+    if ((bytes[1] & 0x80) !== 0) {
+      throw new Error(
+        'non-canonical MPT amount: mantissa exceeds maxMPTokenAmount',
+      )
+    }
+    if (!isPositive) {
+      let mantissaIsZero = true
+      for (let i = 1; i <= 8; i++) {
+        if (bytes[i] !== 0) {
+          mantissaIsZero = false
+          break
+        }
+      }
+      if (mantissaIsZero) {
+        throw new Error('non-canonical MPT amount: negative-zero encoding')
       }
     }
   }

--- a/packages/ripple-binary-codec/src/types/amount.ts
+++ b/packages/ripple-binary-codec/src/types/amount.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Amount serializes three currency variants (XRP, IOU, MPT) plus shared validators in one type. */
 import { BinaryParser } from '../serdes/binary-parser'
 
 import { AccountID } from './account-id'
@@ -18,6 +19,20 @@ const MAX_DROPS = new BigNumber('1e17')
 const MIN_XRP = new BigNumber('1e-6')
 const mask = BigInt(0x00000000ffffffff)
 const mptMask = BigInt(0x8000000000000000)
+
+// Reject non-canonical MPT wire blobs: high-bit mantissa or negative-zero.
+function assertMptBytesAreCanonical(bytes: Uint8Array): void {
+  if ((bytes[1] & 0x80) !== 0) {
+    throw new Error(
+      'non-canonical MPT amount: mantissa exceeds maxMPTokenAmount',
+    )
+  }
+  const isPositive = (bytes[0] & 0x40) !== 0
+  const mantissaIsZero = bytes.subarray(1, 9).every((b) => b === 0)
+  if (!isPositive && mantissaIsZero) {
+    throw new Error('non-canonical MPT amount: negative-zero encoding')
+  }
+}
 
 /**
  * BigNumber configuration for Amount IOUs
@@ -166,7 +181,7 @@ class Amount extends SerializedType {
 
       const mptIssuanceID = Hash192.from(value.mpt_issuance_id).toBytes()
       const mptBytes = concat([leadingByte, amount, mptIssuanceID])
-      Amount.assertMptBytesAreCanonical(mptBytes)
+      assertMptBytesAreCanonical(mptBytes)
       return new Amount(mptBytes)
     }
 
@@ -187,7 +202,7 @@ class Amount extends SerializedType {
     const isMPT = parser.peek() & 0x20
     if (isMPT) {
       const bytes = parser.read(33)
-      Amount.assertMptBytesAreCanonical(bytes)
+      assertMptBytesAreCanonical(bytes)
       return new Amount(bytes)
     }
     return new Amount(parser.read(8))
@@ -240,7 +255,7 @@ class Amount extends SerializedType {
     }
 
     if (this.isMPT()) {
-      Amount.assertMptBytesAreCanonical(this.bytes)
+      assertMptBytesAreCanonical(this.bytes)
       const parser = new BinaryParser(this.toString())
       const leadingByte = parser.read(1)
       const amount = parser.read(8)
@@ -331,36 +346,6 @@ class Amount extends SerializedType {
 
       if (Number(BigInt(amount) & BigInt(mptMask)) != 0) {
         throw new Error(`${amount.toString()} is an illegal amount`)
-      }
-    }
-  }
-
-  /**
-   * Validate the canonical form of an MPT amount on its 33-byte wire layout
-   * (leadingByte ‖ mantissa ‖ MPTID). Mirrors the bounds enforced on the JSON
-   * construction path so non-canonical blobs are rejected at deserialization.
-   *
-   * @param bytes 33-byte MPT amount blob
-   * @returns void, throws if the mantissa exceeds maxMPTokenAmount (high bit
-   *   set) or the value is encoded as negative zero.
-   */
-  private static assertMptBytesAreCanonical(bytes: Uint8Array): void {
-    const isPositive = (bytes[0] & 0x40) !== 0
-    if ((bytes[1] & 0x80) !== 0) {
-      throw new Error(
-        'non-canonical MPT amount: mantissa exceeds maxMPTokenAmount',
-      )
-    }
-    if (!isPositive) {
-      let mantissaIsZero = true
-      for (let i = 1; i <= 8; i++) {
-        if (bytes[i] !== 0) {
-          mantissaIsZero = false
-          break
-        }
-      }
-      if (mantissaIsZero) {
-        throw new Error('non-canonical MPT amount: negative-zero encoding')
       }
     }
   }

--- a/packages/ripple-binary-codec/src/types/index.ts
+++ b/packages/ripple-binary-codec/src/types/index.ts
@@ -9,7 +9,7 @@ import { Hash256 } from './hash-256'
 import { Int32 } from './int-32'
 import { Issue } from './issue'
 import { STNumber } from './st-number'
-import { PathSet } from './path-set'
+import { PathSet, HopObject } from './path-set'
 import { STArray } from './st-array'
 import { STObject } from './st-object'
 import { UInt16 } from './uint-16'
@@ -68,4 +68,5 @@ export {
   UInt32,
   UInt64,
   Vector256,
+  HopObject,
 }

--- a/packages/ripple-binary-codec/src/types/issue.ts
+++ b/packages/ripple-binary-codec/src/types/issue.ts
@@ -36,7 +36,7 @@ function isIssueObject(arg): arg is IssueObject {
   return isXRP || isIOU || isMPT
 }
 
-const MPT_WIDTH = 44
+export const MPT_WIDTH = 44
 const NO_ACCOUNT = AccountID.from('0000000000000000000000000000000000000001')
 
 /**

--- a/packages/ripple-binary-codec/src/types/path-set.ts
+++ b/packages/ripple-binary-codec/src/types/path-set.ts
@@ -20,7 +20,8 @@ const TYPE_ISSUER = 0x20
 const TYPE_MPT = 0x40
 
 /**
- * The object representation of a Hop, an issuer AccountID, an account AccountID, and a Currency. Alternatively, this could also contain an MPTIssuanceID
+ * The object representation of a Hop, an issuer AccountID, an account AccountID, and a Currency.
+ * Alternatively, this could also contain an MPTIssuanceID
  */
 interface HopObject extends JsonObject {
   issuer?: string
@@ -34,9 +35,10 @@ interface HopObject extends JsonObject {
  */
 function isHopObject(arg): arg is HopObject {
   return (
-    (arg.issuer !== undefined ||
+    arg.issuer !== undefined ||
     arg.account !== undefined ||
-    arg.currency !== undefined) || arg.mpt_issuance_id !== undefined
+    arg.currency !== undefined ||
+    arg.mpt_issuance_id !== undefined
   )
 }
 
@@ -79,7 +81,9 @@ class Hop extends SerializedType {
       bytes.push(Currency.from(value.currency).toBytes())
       bytes[0][0] |= TYPE_CURRENCY
     } else if (value.mpt_issuance_id) {
-      bytes.push(Issue.from({mpt_issuance_id: value.mpt_issuance_id}).toBytes())
+      bytes.push(
+        Issue.from({ mpt_issuance_id: value.mpt_issuance_id }).toBytes(),
+      )
       bytes[0][0] |= TYPE_MPT
     }
 
@@ -305,4 +309,4 @@ class PathSet extends SerializedType {
   }
 }
 
-export { PathSet }
+export { PathSet, HopObject }

--- a/packages/ripple-binary-codec/src/types/path-set.ts
+++ b/packages/ripple-binary-codec/src/types/path-set.ts
@@ -53,8 +53,6 @@ function isPathSet(arg): arg is Array<Array<HopObject>> {
   )
 }
 
-// Keshava TODO: Add unit tests for validating the behavior of Hop class, over and above the integ tests
-
 /**
  * Serialize and Deserialize a Hop
  */

--- a/packages/ripple-binary-codec/src/types/path-set.ts
+++ b/packages/ripple-binary-codec/src/types/path-set.ts
@@ -109,7 +109,7 @@ class Hop extends SerializedType {
 
     if (type & TYPE_CURRENCY && type & TYPE_MPT) {
       throw new Error(
-        'Invalid binary input: Currency and mpt_issuance_id are mutually exclusive in a path hop',
+        'Currency and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Currency and mpt_issuance_id elements',
       )
     }
 

--- a/packages/ripple-binary-codec/src/types/path-set.ts
+++ b/packages/ripple-binary-codec/src/types/path-set.ts
@@ -81,6 +81,12 @@ class Hop extends SerializedType {
       )
     }
 
+    if (value.issuer && value.mpt_issuance_id) {
+      throw new Error(
+        'issuer and mpt_issuance_id are mutually exclusive in a path hop (the issuer is encoded inside the MPTIssuanceID)',
+      )
+    }
+
     if (value.currency) {
       bytes.push(Currency.from(value.currency).toBytes())
       bytes[0][0] |= TYPE_CURRENCY
@@ -110,6 +116,12 @@ class Hop extends SerializedType {
     if (type & TYPE_CURRENCY && type & TYPE_MPT) {
       throw new Error(
         'Currency and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Currency and mpt_issuance_id elements',
+      )
+    }
+
+    if (type & TYPE_ISSUER && type & TYPE_MPT) {
+      throw new Error(
+        'Issuer and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Issuer and mpt_issuance_id elements',
       )
     }
 

--- a/packages/ripple-binary-codec/test/amount.test.ts
+++ b/packages/ripple-binary-codec/test/amount.test.ts
@@ -88,7 +88,7 @@ describe('Amount', function () {
       '8000000000000001' +
       '00002403C84A0A28E0190E208E982C352BBD5006600555CF'
     expect(() => Amount.fromParser(makeParser(blob))).toThrow(
-      'non-canonical MPT amount: mantissa exceeds maxMPTokenAmount',
+      new Error('non-canonical MPT amount: mantissa exceeds maxMPTokenAmount'),
     )
   })
 
@@ -99,7 +99,7 @@ describe('Amount', function () {
       '0000000000000000' +
       '00002403C84A0A28E0190E208E982C352BBD5006600555CF'
     expect(() => Amount.fromParser(makeParser(blob))).toThrow(
-      'non-canonical MPT amount: negative-zero encoding',
+      new Error('non-canonical MPT amount: negative-zero encoding'),
     )
   })
 

--- a/packages/ripple-binary-codec/test/amount.test.ts
+++ b/packages/ripple-binary-codec/test/amount.test.ts
@@ -80,6 +80,29 @@ describe('Amount', function () {
       })
     }
   })
+  it('rejects MPT amount blob with mantissa above maxMPTokenAmount', function () {
+    // flag 0x60 (MPT, positive) ‖ mantissa 0x8000000000000001 (high bit set,
+    // i.e. one above maxMPTokenAmount) ‖ 24-byte MPTID
+    const blob =
+      '60' +
+      '8000000000000001' +
+      '00002403C84A0A28E0190E208E982C352BBD5006600555CF'
+    expect(() => Amount.fromParser(makeParser(blob))).toThrow(
+      'non-canonical MPT amount: mantissa exceeds maxMPTokenAmount',
+    )
+  })
+
+  it('rejects MPT amount blob with negative-zero encoding', function () {
+    // flag 0x20 (MPT, negative) ‖ mantissa 0 ‖ 24-byte MPTID
+    const blob =
+      '20' +
+      '0000000000000000' +
+      '00002403C84A0A28E0190E208E982C352BBD5006600555CF'
+    expect(() => Amount.fromParser(makeParser(blob))).toThrow(
+      'non-canonical MPT amount: negative-zero encoding',
+    )
+  })
+
   it('rejects non-numeric MPT amount values with a validation error', function () {
     const mpt = {
       value: 'abc',

--- a/packages/ripple-binary-codec/test/path-set.test.ts
+++ b/packages/ripple-binary-codec/test/path-set.test.ts
@@ -107,4 +107,144 @@ describe('Path-Set binary-codec unit tests', () => {
       coreTypes.PathSet.from(path),
     )
   })
+
+  it(`PathSet: One path with one MPT hop`, () => {
+    const mptIssuanceId = '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8'
+    const path = [[{ mpt_issuance_id: mptIssuanceId } as HopObject]]
+
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+    expect(serializedHexRepr).toEqual(
+      '40' /* MPT has a type code of 40 */ +
+        mptIssuanceId.toUpperCase() /* raw 24-byte MPTID */ +
+        '00' /* PathSet elements end with 00 code */,
+    )
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`Two paths with mpt_issaunce_id hops`, () => {
+    const mptIssuanceId1 = '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8'
+    const mptIssuanceId2 = '000004C463C52827307480341125DA0577DEFC38405B0E3E'
+    const path = [
+      [{ mpt_issuance_id: mptIssuanceId1 } as HopObject],
+      [{ mpt_issuance_id: mptIssuanceId2 } as HopObject],
+    ]
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+
+    expect(serializedHexRepr).toEqual(
+      '40' /* MPT has a type code of 40 */ +
+        mptIssuanceId1.toUpperCase() /* raw 24-byte MPTID */ +
+        'FF' /* Two path elements are separated by 0xFF type code */ +
+        '40' /* MPT has a type code of 40 */ +
+        mptIssuanceId2.toUpperCase() /* raw 24-byte MPTID */ +
+        '00' /* PathSet elements end with 00 code */,
+    )
+
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`Path with mpt_issuance_id and Currency PathElements`, () => {
+    const mptIssuanceId = '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8'
+    const currencyCode = 'ABC'
+    const path = [
+      [
+        { mpt_issuance_id: mptIssuanceId } as HopObject,
+        { currency: currencyCode } as HopObject,
+      ],
+    ]
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+
+    expect(serializedHexRepr).toEqual(
+      '40' /* MPT has a type code of 40 */ +
+        mptIssuanceId.toUpperCase() /* raw 24-byte MPTID */ +
+        '10' /* Currency has a type code of 0x10 */ +
+        Currency.from(currencyCode)
+          .toHex()
+          .toUpperCase() /* serialized repr of Currency type */ +
+        '00' /* PathSet elements end with 00 code */,
+    )
+
+    // test the round-trip equivalence
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`Path with mpt_issuance_id and issuer PathElements`, () => {
+    const mptIssuanceId = '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8'
+    const issuerAccount = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const path = [
+      [
+        { mpt_issuance_id: mptIssuanceId } as HopObject,
+        { issuer: issuerAccount } as HopObject,
+      ],
+    ]
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+
+    expect(serializedHexRepr).toEqual(
+      '40' /* MPT has a type code of 40 */ +
+        mptIssuanceId.toUpperCase() /* raw 24-byte MPTID */ +
+        '20' /* Issuer has a type code of 20 */ +
+        AccountID.from(issuerAccount)
+          .toHex()
+          .toUpperCase() /* 20-byte issuer */ +
+        '00' /* PathSet elements end with 00 code */,
+    )
+
+    // test the round-trip equivalence
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`PathSet: Currency and MPT are mutually exclusive in a hop`, () => {
+    const currencyCode = 'ABC'
+    const mptIssuanceId = '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8'
+
+    const path = [
+      [
+        {
+          currency: currencyCode,
+          mpt_issuance_id: mptIssuanceId,
+        } as HopObject,
+      ],
+    ]
+
+    expect(() => coreTypes.PathSet.from(path)).toThrow(
+      'Currency and mpt_issuance_id are mutually exclusive in a path hop',
+    )
+  })
+
+  it(`PathSet: Deserialization rejects a hop with both Currency and MPT flags`, () => {
+    // Type byte 0x50 = TYPE_CURRENCY (0x10) | TYPE_MPT (0x40)
+    const invalidHex =
+      '50' +
+      Currency.from('ABC').toHex().toUpperCase() +
+      '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8' +
+      '00'
+
+    const parser = new BinaryParser(invalidHex)
+    expect(() => coreTypes.PathSet.fromParser(parser)).toThrow(
+      'Currency and mpt_issuance_id are mutually exclusive',
+    )
+  })
 })

--- a/packages/ripple-binary-codec/test/path-set.test.ts
+++ b/packages/ripple-binary-codec/test/path-set.test.ts
@@ -1,0 +1,110 @@
+import { BinaryParser } from '../src/binary'
+import { coreTypes, HopObject, AccountID, Currency } from '../src/types'
+
+describe('Path-Set binary-codec unit tests', () => {
+  it(`PathSet: one path with one account hop`, () => {
+    const genesisAccountID = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const path = [[{ account: genesisAccountID } as HopObject]]
+
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+    expect(serializedHexRepr).toEqual(
+      '01' /* Account has a type code of 01 */ +
+        AccountID.from(genesisAccountID).toHex().toUpperCase() +
+        '00' /* PathSet elements end with 00 code */,
+    )
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`PathSet: One path with one Currency hop`, () => {
+    const currencyCode = 'ABC'
+    const path = [[{ currency: currencyCode } as HopObject]]
+
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+    expect(serializedHexRepr).toEqual(
+      '10' /* Currency has a type code of 10 */ +
+        Currency.from(currencyCode).toHex().toUpperCase() +
+        '00' /* PathSet elements end with 00 code */,
+    )
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`PathSet: One path with one Issuer hop`, () => {
+    const issuerAccount = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const path = [[{ issuer: issuerAccount } as HopObject]]
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+
+    expect(serializedHexRepr).toEqual(
+      '20' /* Issuer has a type code of 20 */ +
+        AccountID.from(issuerAccount).toHex().toUpperCase() +
+        '00' /* PathSet elements end with 00 code */,
+    )
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`PathSet: One path with Currency+Issuer hop`, () => {
+    const issuerAccount = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const currencyCode = 'ABC'
+    const path = [
+      [{ issuer: issuerAccount, currency: currencyCode } as HopObject],
+    ]
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+
+    expect(serializedHexRepr).toEqual(
+      '30' /* bitwise OR of the two appropriate type codes */ +
+        Currency.from(currencyCode).toHex().toUpperCase() +
+        AccountID.from(issuerAccount).toHex().toUpperCase() +
+        '00' /* PathSet elements end with 00 code */,
+    )
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+
+  it(`PathSet: Two hops inside a Path`, () => {
+    const issuerAccount = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const currencyCode = 'ABC'
+    const path = [
+      [{ issuer: issuerAccount } as HopObject],
+      [{ currency: currencyCode } as HopObject],
+    ]
+    const serializedHexRepr = coreTypes.PathSet.from(path).toHex().toUpperCase()
+
+    expect(serializedHexRepr).toEqual(
+      '20' /* Issuer has a type code of 20 */ +
+        AccountID.from(issuerAccount).toHex().toUpperCase() +
+        'FF' /* Two path elements are seperated by 0xFF type code */ +
+        '10' /* Currency has a type code of 10 */ +
+        Currency.from(currencyCode).toHex().toUpperCase() +
+        '00' /* PathSet elements end with 00 code */,
+    )
+    expect(coreTypes.PathSet.from(path).toJSON()).toEqual(path)
+
+    // validate the de-serialization via the BinaryParser
+    const parser = new BinaryParser(serializedHexRepr)
+    expect(coreTypes.PathSet.fromParser(parser)).toEqual(
+      coreTypes.PathSet.from(path),
+    )
+  })
+})

--- a/packages/ripple-binary-codec/test/path-set.test.ts
+++ b/packages/ripple-binary-codec/test/path-set.test.ts
@@ -82,7 +82,7 @@ describe('Path-Set binary-codec unit tests', () => {
     )
   })
 
-  it(`PathSet: Two hops inside a Path`, () => {
+  it(`PathSet: Two paths inside a PathSet`, () => {
     const issuerAccount = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
     const currencyCode = 'ABC'
     const path = [

--- a/packages/ripple-binary-codec/test/path-set.test.ts
+++ b/packages/ripple-binary-codec/test/path-set.test.ts
@@ -127,7 +127,7 @@ describe('Path-Set binary-codec unit tests', () => {
     )
   })
 
-  it(`Two paths with mpt_issaunce_id hops`, () => {
+  it(`Two paths with mpt_issuance_id hops`, () => {
     const mptIssuanceId1 = '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8'
     const mptIssuanceId2 = '000004C463C52827307480341125DA0577DEFC38405B0E3E'
     const path = [

--- a/packages/ripple-binary-codec/test/path-set.test.ts
+++ b/packages/ripple-binary-codec/test/path-set.test.ts
@@ -265,7 +265,9 @@ describe('Path-Set binary-codec unit tests', () => {
     ]
 
     expect(() => coreTypes.PathSet.from(path)).toThrow(
-      'Currency and mpt_issuance_id are mutually exclusive in a path hop',
+      new Error(
+        'Currency and mpt_issuance_id are mutually exclusive in a path hop',
+      ),
     )
   })
 
@@ -279,7 +281,9 @@ describe('Path-Set binary-codec unit tests', () => {
 
     const parser = new BinaryParser(invalidHex)
     expect(() => coreTypes.PathSet.fromParser(parser)).toThrow(
-      'Currency and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Currency and mpt_issuance_id elements',
+      new Error(
+        'Currency and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Currency and mpt_issuance_id elements',
+      ),
     )
   })
 
@@ -296,7 +300,9 @@ describe('Path-Set binary-codec unit tests', () => {
 
     const parser = new BinaryParser(invalidHex)
     expect(() => coreTypes.PathSet.fromParser(parser)).toThrow(
-      'Currency and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Currency and mpt_issuance_id elements',
+      new Error(
+        'Currency and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Currency and mpt_issuance_id elements',
+      ),
     )
   })
 })

--- a/packages/ripple-binary-codec/test/path-set.test.ts
+++ b/packages/ripple-binary-codec/test/path-set.test.ts
@@ -305,4 +305,60 @@ describe('Path-Set binary-codec unit tests', () => {
       ),
     )
   })
+
+  it(`PathSet: Issuer and MPT are mutually exclusive in a hop`, () => {
+    const issuerAccount = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const mptIssuanceId = '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8'
+
+    const invalidPath = [
+      [
+        {
+          issuer: issuerAccount,
+          mpt_issuance_id: mptIssuanceId,
+        } as HopObject,
+      ],
+    ]
+
+    expect(() => coreTypes.PathSet.from(invalidPath)).toThrow(
+      new Error(
+        'issuer and mpt_issuance_id are mutually exclusive in a path hop (the issuer is encoded inside the MPTIssuanceID)',
+      ),
+    )
+  })
+
+  it(`PathSet: Deserialization rejects a hop with both Issuer and MPT flags`, () => {
+    // Type byte 0x60 = TYPE_ISSUER (0x20) | TYPE_MPT (0x40)
+    const invalidHex =
+      '60' +
+      '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8' +
+      AccountID.from('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh')
+        .toHex()
+        .toUpperCase() +
+      '00'
+
+    const parser = new BinaryParser(invalidHex)
+    expect(() => coreTypes.PathSet.fromParser(parser)).toThrow(
+      new Error(
+        'Issuer and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Issuer and mpt_issuance_id elements',
+      ),
+    )
+  })
+
+  it(`PathSet: Deserialization rejects type byte 0x61 (Account + Issuer + MPT)`, () => {
+    // Type byte 0x61 = TYPE_ACCOUNT (0x01) | TYPE_ISSUER (0x20) | TYPE_MPT (0x40)
+    const accountId = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const invalidHex =
+      '61' +
+      AccountID.from(accountId).toHex().toUpperCase() +
+      '00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8' +
+      AccountID.from(accountId).toHex().toUpperCase() +
+      '00'
+
+    const parser = new BinaryParser(invalidHex)
+    expect(() => coreTypes.PathSet.fromParser(parser)).toThrow(
+      new Error(
+        'Issuer and mpt_issuance_id are mutually exclusive in a path hop. The BinaryParser has a bitmask containing both Issuer and mpt_issuance_id elements',
+      ),
+    )
+  })
 })

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -10,12 +10,14 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ### Added
 * Add new fields to `ServerDefinitionsResponse`: `ACCOUNT_SET_FLAGS`, `LEDGER_ENTRY_FLAGS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, and `TRANSACTION_FORMATS`, reflecting new sections returned by `server_definitions` in rippled.
+* Support XLS-82D MPT-DEX amendment in the xrpl.js client library. This work also involves associated updates to `PathSet` type in the ripple-binary-codec package.
 
 ### Fixed
 * Fix event listener accumulation bug where `'connected'` event handlers would fire multiple times after each reconnection. The fix cleans up stale listeners from previous reconnect attempts to prevent duplicate event emissions on flaky connections with multiple sequential reconnect attempts.
 * Disallow the input of Authorization Credentials over insecure WebSocket connections (`ws[+unix]?://`) to prevent MITM eavesdropping of sensitive data.
 * Fix incorrect `MPTAmount` field type to `string` instead of `MPTAmount`.
 * Fix `Client.getServerInfo()` swallowing errors from the underlying `server_info` request, which left `client.networkID` undefined and caused `autofill()` to silently omit the `NetworkID` field — producing signed transactions valid on the wrong network (cross-network replay risk). The method now throws on request failure or when the response is missing `network_id`. ([#3321](https://github.com/XRPLF/xrpl.js/issues/3321))
+
 
 ## 4.6.0 (2026-02-12)
 

--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -29,8 +29,7 @@ export interface MPTAmount {
   value: string
 }
 
-// TODO: add MPTAmount to Amount once MPTv2 is released
-export type Amount = IssuedCurrencyAmount | string
+export type Amount = IssuedCurrencyAmount | string | MPTAmount
 
 export type ClawbackAmount = IssuedCurrencyAmount | MPTAmount
 

--- a/packages/xrpl/src/models/common/index.ts
+++ b/packages/xrpl/src/models/common/index.ts
@@ -69,6 +69,7 @@ export interface PathStep {
   account?: string
   currency?: string
   issuer?: string
+  mpt_issuance_id?: string
 }
 
 export type Path = PathStep[]

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -42,18 +42,22 @@ export interface LedgerEntryRequest extends BaseRequest, LookupByLedgerRequest {
    * This is similar to amm_info method, but the ledger_entry version returns only the ledger entry as stored.
    */
   amm?: {
-    asset: {
-      currency: string
-      issuer?: string
-    } | {
-      mpt_issuance_id: string
-    }
-    asset2: {
-      currency: string
-      issuer?: string
-    } | {
-      mpt_issuance_id: string
-    }
+    asset:
+      | {
+          currency: string
+          issuer?: string
+        }
+      | {
+          mpt_issuance_id: string
+        }
+    asset2:
+      | {
+          currency: string
+          issuer?: string
+        }
+      | {
+          mpt_issuance_id: string
+        }
   }
   /**
    * (Optional) If set to true and the queried object has been deleted,

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -45,10 +45,14 @@ export interface LedgerEntryRequest extends BaseRequest, LookupByLedgerRequest {
     asset: {
       currency: string
       issuer?: string
+    } | {
+      mpt_issuance_id: string
     }
     asset2: {
       currency: string
       issuer?: string
+    } | {
+      mpt_issuance_id: string
     }
   }
   /**

--- a/packages/xrpl/src/models/transactions/AMMClawback.ts
+++ b/packages/xrpl/src/models/transactions/AMMClawback.ts
@@ -16,6 +16,7 @@ import {
   isIssuedCurrency,
   isIssuedCurrencyAmount,
   isMPTAmount,
+  isMPTCurrency,
   validateBaseTransaction,
   validateOptionalField,
   validateRequiredField,
@@ -92,6 +93,7 @@ function isClawbackAmountValid(
   return isIssuedCurrencyAmount(input) || isMPTAmount(input)
 }
 
+/* eslint-disable max-lines-per-function -- this method needs to validate many nested field structures */
 /**
  * Validates an AMMClawback transaction.
  *
@@ -142,4 +144,19 @@ export function validateAMMClawback(tx: Record<string, unknown>): void {
       )
     }
   }
+
+  if (isMPTCurrency(asset) && tx.Amount != null) {
+    if (!isMPTAmount(tx.Amount)) {
+      throw new ValidationError(
+        'AMMClawback: Amount must be an MPTAmount when Asset is an MPTCurrency',
+      )
+    }
+
+    if (tx.Amount.mpt_issuance_id !== asset.mpt_issuance_id) {
+      throw new ValidationError(
+        'AMMClawback: Amount.mpt_issuance_id must match Asset.mpt_issuance_id',
+      )
+    }
+  }
 }
+/* eslint-enable max-lines-per-function */

--- a/packages/xrpl/src/models/transactions/AMMClawback.ts
+++ b/packages/xrpl/src/models/transactions/AMMClawback.ts
@@ -1,9 +1,5 @@
 import { ValidationError } from '../../errors'
-import {
-  Currency,
-  IssuedCurrencyAmount,
-  MPTAmount,
-} from '../common'
+import { Currency, IssuedCurrencyAmount, MPTAmount } from '../common'
 
 import {
   Account,
@@ -79,10 +75,10 @@ export interface AMMClawback extends BaseTransaction {
 }
 
 /**
- * Verify the form and type of an AMMClawback at runtime.
+ * Verify the form and type of Clawback Amount at runtime.
  *
- * @param tx - An AMMClawback Transaction.
- * @throws {ValidationError} When the transaction is malformed.
+ * @param input - The amount expected to be Clawed back.
+ * @returns True if the input is an IssuedCurrencyAmount or MPTAmount.
  */
 function isClawbackAmountValid(
   input: unknown,
@@ -90,6 +86,12 @@ function isClawbackAmountValid(
   return isIssuedCurrencyAmount(input) || isMPTAmount(input)
 }
 
+/**
+ * Validates an AMMClawback transaction.
+ *
+ * @param tx - The AMMClawback transaction to validate.
+ * @throws {ValidationError} When the transaction fields are invalid.
+ */
 export function validateAMMClawback(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 

--- a/packages/xrpl/src/models/transactions/AMMClawback.ts
+++ b/packages/xrpl/src/models/transactions/AMMClawback.ts
@@ -67,8 +67,8 @@ export interface AMMClawback extends BaseTransaction {
   Asset: IssuedCurrency | MPTCurrency
 
   /**
-   * Specifies the other asset in the AMM's pool. In JSON, this is an object with currency and
-   * issuer fields (omit issuer for XRP), or mpt_issuance_id for MPT.
+   * Specifies the other asset in the AMM's pool. In JSON, this can be XRP (no issuer),
+   * an issued currency (with issuer), or an MPT (with mpt_issuance_id).
    */
   Asset2: Currency
 

--- a/packages/xrpl/src/models/transactions/AMMClawback.ts
+++ b/packages/xrpl/src/models/transactions/AMMClawback.ts
@@ -1,5 +1,11 @@
 import { ValidationError } from '../../errors'
-import { Currency, IssuedCurrencyAmount, MPTAmount } from '../common'
+import {
+  Currency,
+  IssuedCurrency,
+  IssuedCurrencyAmount,
+  MPTAmount,
+  MPTCurrency,
+} from '../common'
 
 import {
   Account,
@@ -57,7 +63,7 @@ export interface AMMClawback extends BaseTransaction {
    * In JSON, this is an object with currency and issuer fields (or mpt_issuance_id for MPT).
    * For issued currencies, the issuer field must match with Account.
    */
-  Asset: Currency
+  Asset: IssuedCurrency | MPTCurrency
 
   /**
    * Specifies the other asset in the AMM's pool. In JSON, this is an object with currency and

--- a/packages/xrpl/src/models/transactions/AMMDeposit.ts
+++ b/packages/xrpl/src/models/transactions/AMMDeposit.ts
@@ -5,7 +5,7 @@ import {
   BaseTransaction,
   GlobalFlagsInterface,
   isAmount,
-  isIssuedCurrency,
+  isCurrency,
   isIssuedCurrencyAmount,
   validateBaseTransaction,
 } from './common'
@@ -89,7 +89,7 @@ export function validateAMMDeposit(tx: Record<string, unknown>): void {
     throw new ValidationError('AMMDeposit: missing field Asset')
   }
 
-  if (!isIssuedCurrency(tx.Asset)) {
+  if (!isCurrency(tx.Asset)) {
     throw new ValidationError('AMMDeposit: Asset must be a Currency')
   }
 
@@ -97,7 +97,7 @@ export function validateAMMDeposit(tx: Record<string, unknown>): void {
     throw new ValidationError('AMMDeposit: missing field Asset2')
   }
 
-  if (!isIssuedCurrency(tx.Asset2)) {
+  if (!isCurrency(tx.Asset2)) {
     throw new ValidationError('AMMDeposit: Asset2 must be a Currency')
   }
 

--- a/packages/xrpl/src/models/transactions/AMMWithdraw.ts
+++ b/packages/xrpl/src/models/transactions/AMMWithdraw.ts
@@ -5,7 +5,7 @@ import {
   BaseTransaction,
   GlobalFlagsInterface,
   isAmount,
-  isIssuedCurrency,
+  isCurrency,
   isIssuedCurrencyAmount,
   validateBaseTransaction,
 } from './common'
@@ -87,7 +87,7 @@ export function validateAMMWithdraw(tx: Record<string, unknown>): void {
     throw new ValidationError('AMMWithdraw: missing field Asset')
   }
 
-  if (!isIssuedCurrency(tx.Asset)) {
+  if (!isCurrency(tx.Asset)) {
     throw new ValidationError('AMMWithdraw: Asset must be a Currency')
   }
 
@@ -95,7 +95,7 @@ export function validateAMMWithdraw(tx: Record<string, unknown>): void {
     throw new ValidationError('AMMWithdraw: missing field Asset2')
   }
 
-  if (!isIssuedCurrency(tx.Asset2)) {
+  if (!isCurrency(tx.Asset2)) {
     throw new ValidationError('AMMWithdraw: Asset2 must be a Currency')
   }
 

--- a/packages/xrpl/src/models/transactions/checkCreate.ts
+++ b/packages/xrpl/src/models/transactions/checkCreate.ts
@@ -4,7 +4,7 @@ import { Amount } from '../common'
 import {
   BaseTransaction,
   validateBaseTransaction,
-  isIssuedCurrencyAmount,
+  isAmount,
   isAccount,
   validateRequiredField,
   validateOptionalField,
@@ -64,7 +64,7 @@ export function validateCheckCreate(tx: Record<string, unknown>): void {
   validateRequiredField(tx, 'Destination', isAccount)
   validateOptionalField(tx, 'DestinationTag', isNumber)
 
-  if (typeof tx.SendMax !== 'string' && !isIssuedCurrencyAmount(tx.SendMax)) {
+  if (!isAmount(tx.SendMax)) {
     throw new ValidationError('CheckCreate: invalid SendMax')
   }
 

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -258,7 +258,7 @@ export function isMPTAmount(input: unknown): input is MPTAmount {
     Object.keys(input).length === MPT_CURRENCY_AMOUNT_SIZE &&
     typeof input.value === 'string' &&
     typeof input.mpt_issuance_id === 'string' &&
-    isValidMPTIssuanceId(input.mpt_issuance_id as string)
+    isValidMPTIssuanceId(input.mpt_issuance_id)
   )
 }
 

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -84,6 +84,9 @@ const ISSUE_CURRENCY_SIZE = 2
 const MPT_CURRENCY_AMOUNT_SIZE = 2
 const ISSUED_CURRENCY_AMOUNT_SIZE = 3
 
+// MPT Issuance ID length (Hash192 = 24 bytes = 48 hex chars)
+const MPT_ISSUANCE_ID_LENGTH = 48
+
 const XCHAIN_BRIDGE_SIZE = 4
 const AUTHORIZE_CREDENTIAL_SIZE = 1
 
@@ -234,6 +237,16 @@ export function isAuthorizeCredential(
 }
 
 /**
+ * Verify that a string is a valid MPT Issuance ID (48 hex characters).
+ *
+ * @param id - The string to validate.
+ * @returns Whether the string is a properly formed MPT Issuance ID.
+ */
+function isValidMPTIssuanceId(id: string): boolean {
+  return id.length === MPT_ISSUANCE_ID_LENGTH && HEX_REGEX.test(id)
+}
+
+/**
  * Verify the form and type of an MPT at runtime.
  *
  * @param input - The input to check the form and type of.
@@ -244,7 +257,8 @@ export function isMPTAmount(input: unknown): input is MPTAmount {
     isRecord(input) &&
     Object.keys(input).length === MPT_CURRENCY_AMOUNT_SIZE &&
     typeof input.value === 'string' &&
-    typeof input.mpt_issuance_id === 'string'
+    typeof input.mpt_issuance_id === 'string' &&
+    isValidMPTIssuanceId(input.mpt_issuance_id as string)
   )
 }
 

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -12,6 +12,7 @@ import {
   IssuedCurrency,
   IssuedCurrencyAmount,
   MPTAmount,
+  MPTCurrency,
   Memo,
   Signer,
   XChainBridge,
@@ -197,6 +198,20 @@ export function isIssuedCurrency(input: unknown): input is IssuedCurrency {
       isString(input.currency)) ||
       (Object.keys(input).length === XRP_CURRENCY_SIZE &&
         input.currency === 'XRP'))
+  )
+}
+
+/**
+ * Verify the form and type of an MPTCurrency at runtime.
+ *
+ * @param input - The input to check the form and type of.
+ * @returns Whether the MPTCurrency is properly formed.
+ */
+export function isMPTCurrency(input: unknown): input is MPTCurrency {
+  return (
+    isRecord(input) &&
+    Object.keys(input).length === MPT_CURRENCY_SIZE &&
+    isString(input.mpt_issuance_id)
   )
 }
 

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -211,7 +211,8 @@ export function isMPTCurrency(input: unknown): input is MPTCurrency {
   return (
     isRecord(input) &&
     Object.keys(input).length === MPT_CURRENCY_SIZE &&
-    isString(input.mpt_issuance_id)
+    typeof input.mpt_issuance_id === 'string' &&
+    isValidMPTIssuanceId(input.mpt_issuance_id)
   )
 }
 

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -180,7 +180,8 @@ export function isCurrency(input: unknown): input is Currency {
       (Object.keys(input).length === XRP_CURRENCY_SIZE &&
         input.currency === 'XRP') ||
       (Object.keys(input).length === MPT_CURRENCY_SIZE &&
-        isString(input.mpt_issuance_id)))
+        isString(input.mpt_issuance_id) &&
+        isValidMPTIssuanceId(input.mpt_issuance_id)))
   )
 }
 

--- a/packages/xrpl/src/models/transactions/metadata.ts
+++ b/packages/xrpl/src/models/transactions/metadata.ts
@@ -1,4 +1,4 @@
-import { Amount, MPTAmount } from '../common'
+import { Amount } from '../common'
 
 import { BaseTransaction } from './common'
 import {
@@ -83,9 +83,9 @@ export function isDeletedNode(node: Node): node is DeletedNode {
 
 export interface TransactionMetadataBase {
   AffectedNodes: Node[]
-  DeliveredAmount?: Amount | MPTAmount
+  DeliveredAmount?: Amount
   // "unavailable" possible for transactions before 2014-01-20
-  delivered_amount?: Amount | MPTAmount | 'unavailable'
+  delivered_amount?: Amount | 'unavailable'
   TransactionIndex: number
   TransactionResult: string
 

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -279,11 +279,13 @@ function isPathStep(pathStep: Record<string, unknown>): boolean {
     return true
   }
   if (pathStep.mpt_issuance_id !== undefined) {
-    if (typeof pathStep.mpt_issuance_id !== 'string')
+    if (typeof pathStep.mpt_issuance_id !== 'string') {
       return false
+    }
 
-    if(! /^[A-F0-9]{48}$/iu.test(pathStep.mpt_issuance_id))
+    if (!/^[A-F0-9]{48}$/iu.test(pathStep.mpt_issuance_id)) {
       return false
+    }
 
     return true
   }

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -268,17 +268,13 @@ function isPathStep(pathStep: Record<string, unknown>): boolean {
   if (pathStep.issuer !== undefined && typeof pathStep.issuer !== 'string') {
     return false
   }
-  if (
-    pathStep.account !== undefined &&
-    pathStep.currency === undefined &&
-    pathStep.issuer === undefined
-  ) {
-    return true
-  }
-  if (pathStep.currency !== undefined || pathStep.issuer !== undefined) {
-    return true
-  }
+
+  // mpt_issuance_id is mutually exclusive with account and currency
   if (pathStep.mpt_issuance_id !== undefined) {
+    if (pathStep.account !== undefined || pathStep.currency !== undefined) {
+      return false
+    }
+
     if (typeof pathStep.mpt_issuance_id !== 'string') {
       return false
     }
@@ -287,6 +283,17 @@ function isPathStep(pathStep: Record<string, unknown>): boolean {
       return false
     }
 
+    return true
+  }
+
+  if (
+    pathStep.account !== undefined &&
+    pathStep.currency === undefined &&
+    pathStep.issuer === undefined
+  ) {
+    return true
+  }
+  if (pathStep.currency !== undefined || pathStep.issuer !== undefined) {
     return true
   }
   return false

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -278,6 +278,15 @@ function isPathStep(pathStep: Record<string, unknown>): boolean {
   if (pathStep.currency !== undefined || pathStep.issuer !== undefined) {
     return true
   }
+  if (pathStep.mpt_issuance_id !== undefined) {
+    if (typeof pathStep.mpt_issuance_id !== 'string')
+      return false
+
+    if(! /^[A-F0-9]{48}$/iu.test(pathStep.mpt_issuance_id))
+      return false
+
+    return true
+  }
   return false
 }
 

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '../../errors'
-import { Amount, Path, MPTAmount } from '../common'
+import { Amount, Path } from '../common'
 import { isFlagEnabled } from '../utils'
 
 import {
@@ -120,9 +120,9 @@ export interface Payment extends BaseTransaction {
    * names MUST be lower-case. If the tfPartialPayment flag is set, deliver up
    * to this amount instead.
    */
-  Amount: Amount | MPTAmount
+  Amount: Amount
 
-  DeliverMax?: Amount | MPTAmount
+  DeliverMax?: Amount
 
   /** The unique address of the account receiving the payment. */
   Destination: Account
@@ -149,13 +149,13 @@ export interface Payment extends BaseTransaction {
    * cross-currency/cross-issue payments. Must be omitted for XRP-to-XRP
    * Payments.
    */
-  SendMax?: Amount | MPTAmount
+  SendMax?: Amount
   /**
    * Minimum amount of destination currency this transaction should deliver.
    * Only valid if this is a partial payment. For non-XRP amounts, the nested
    * field names are lower-case.
    */
-  DeliverMin?: Amount | MPTAmount
+  DeliverMin?: Amount
   /**
    * Credentials associated with the sender of this transaction.
    * The credentials included must not be expired.
@@ -177,8 +177,8 @@ export interface Payment extends BaseTransaction {
 }
 
 export interface PaymentMetadata extends TransactionMetadataBase {
-  DeliveredAmount?: Amount | MPTAmount
-  delivered_amount?: Amount | MPTAmount | 'unavailable'
+  DeliveredAmount?: Amount
+  delivered_amount?: Amount | 'unavailable'
 }
 
 /**

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -255,6 +255,7 @@ function checkPartialPayment(tx: Record<string, unknown>): void {
   }
 }
 
+// eslint-disable-next-line max-lines-per-function -- distinct validation branches per PathStep shape
 function isPathStep(pathStep: Record<string, unknown>): boolean {
   if (pathStep.account !== undefined && typeof pathStep.account !== 'string') {
     return false
@@ -269,17 +270,20 @@ function isPathStep(pathStep: Record<string, unknown>): boolean {
     return false
   }
 
-  // mpt_issuance_id is mutually exclusive with account and currency
+  // mpt_issuance_id is mutually exclusive with account, currency, and issuer
   if (pathStep.mpt_issuance_id !== undefined) {
-    if (pathStep.account !== undefined || pathStep.currency !== undefined) {
+    if (
+      pathStep.account !== undefined ||
+      pathStep.currency !== undefined ||
+      pathStep.issuer !== undefined
+    ) {
       return false
     }
 
-    if (typeof pathStep.mpt_issuance_id !== 'string') {
-      return false
-    }
-
-    if (!/^[A-F0-9]{48}$/iu.test(pathStep.mpt_issuance_id)) {
+    if (
+      typeof pathStep.mpt_issuance_id !== 'string' ||
+      !/^[A-F0-9]{48}$/iu.test(pathStep.mpt_issuance_id)
+    ) {
       return false
     }
 

--- a/packages/xrpl/test/integration/mptUtils.ts
+++ b/packages/xrpl/test/integration/mptUtils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-bitwise -- bitwise necessary for combining MPT flags */
 import {
   Client,
   MPTokenIssuanceCreate,
@@ -29,7 +28,7 @@ export async function createMPTIssuance(
   const createTx: MPTokenIssuanceCreate = {
     TransactionType: 'MPTokenIssuanceCreate',
     Account: issuerWallet.classicAddress,
-    ...(flags == null ? {} : { Flags: flags }),
+    Flags: flags ?? 0,
   }
 
   const mptCreateRes = await testTransaction(client, createTx, issuerWallet)
@@ -62,11 +61,12 @@ export async function createMPTIssuance(
  * @param fundAmount - Amount of MPT to send to the holder (defaults to '100000').
  * @returns The mpt_issuance_id of the newly created issuance.
  */
-// eslint-disable-next-line max-params -- test helper accepts optional flag/fund overrides
+// eslint-disable-next-line max-params -- all params are distinct and necessary
 export async function createMPTIssuanceAndAuthorize(
   client: Client,
   issuerWallet: Wallet,
   holderWallet: Wallet,
+  // eslint-disable-next-line no-bitwise -- combining flags requires bitwise OR
   flags: number = MPTokenIssuanceCreateFlags.tfMPTCanTrade |
     MPTokenIssuanceCreateFlags.tfMPTCanTransfer,
   fundAmount = '100000',
@@ -118,10 +118,12 @@ export async function createAMMPoolWithMPT(
   const issuerWallet2 = await generateFundedWallet(client)
   const lpWallet = await generateFundedWallet(client)
 
+  /* eslint-disable no-bitwise -- combining flags requires bitwise OR */
   const mptFlags =
     MPTokenIssuanceCreateFlags.tfMPTCanTransfer |
     MPTokenIssuanceCreateFlags.tfMPTCanTrade |
     MPTokenIssuanceCreateFlags.tfMPTCanClawback
+  /* eslint-enable no-bitwise */
 
   const mptIssuanceId1 = await createMPTIssuanceAndAuthorize(
     client,

--- a/packages/xrpl/test/integration/mptUtils.ts
+++ b/packages/xrpl/test/integration/mptUtils.ts
@@ -8,7 +8,7 @@ import {
   TransactionMetadata,
   Wallet,
 } from '../../src'
-import type { MPTAmount, MPTCurrency } from '../../src/models/common'
+import type { MPTCurrency } from '../../src/models/common'
 
 import { generateFundedWallet, testTransaction } from './utils'
 
@@ -145,11 +145,11 @@ export async function createAMMPoolWithMPT(
     Amount: {
       mpt_issuance_id: mptIssuanceId1,
       value: '250',
-    } as unknown as MPTAmount,
+    },
     Amount2: {
       mpt_issuance_id: mptIssuanceId2,
       value: '250',
-    } as unknown as MPTAmount,
+    },
     TradingFee: 12,
   }
 

--- a/packages/xrpl/test/integration/mptUtils.ts
+++ b/packages/xrpl/test/integration/mptUtils.ts
@@ -1,0 +1,166 @@
+/* eslint-disable no-bitwise -- bitwise necessary for combining MPT flags */
+import {
+  Client,
+  MPTokenIssuanceCreate,
+  MPTokenIssuanceCreateFlags,
+  MPTokenAuthorize,
+  Payment,
+  AMMCreate,
+  TransactionMetadata,
+  Wallet,
+} from '../../src'
+import type { MPTAmount, MPTCurrency } from '../../src/models/common'
+
+import { generateFundedWallet, testTransaction } from './utils'
+
+/**
+ * Creates an MPT issuance and returns the mpt_issuance_id.
+ *
+ * @param client - The XRPL client.
+ * @param issuerWallet - The wallet that will issue the MPT.
+ * @param flags - Optional flags for the issuance.
+ * @returns The mpt_issuance_id of the newly created issuance.
+ */
+export async function createMPTIssuance(
+  client: Client,
+  issuerWallet: Wallet,
+  flags?: number,
+): Promise<string> {
+  const createTx: MPTokenIssuanceCreate = {
+    TransactionType: 'MPTokenIssuanceCreate',
+    Account: issuerWallet.classicAddress,
+    ...(flags == null ? {} : { Flags: flags }),
+  }
+
+  const mptCreateRes = await testTransaction(client, createTx, issuerWallet)
+
+  const txHash = mptCreateRes.result.tx_json.hash
+
+  const txResponse = await client.request({
+    command: 'tx',
+    transaction: txHash,
+  })
+
+  const meta = txResponse.result
+    .meta as TransactionMetadata<MPTokenIssuanceCreate>
+
+  const mptID = meta.mpt_issuance_id
+  if (!mptID) {
+    throw new Error('Failed to get mpt_issuance_id from transaction metadata')
+  }
+
+  return mptID
+}
+
+/**
+ * Creates an MPT issuance, authorizes a holder, and funds them with MPT tokens.
+ *
+ * @param client - The XRPL client.
+ * @param issuerWallet - The wallet that will issue the MPT.
+ * @param holderWallet - The wallet that will hold the MPT.
+ * @param flags - Optional flags for the issuance (defaults to tfMPTCanTrade | tfMPTCanTransfer).
+ * @param fundAmount - Amount of MPT to send to the holder (defaults to '100000').
+ * @returns The mpt_issuance_id of the newly created issuance.
+ */
+// eslint-disable-next-line max-params -- test helper accepts optional flag/fund overrides
+export async function createMPTIssuanceAndAuthorize(
+  client: Client,
+  issuerWallet: Wallet,
+  holderWallet: Wallet,
+  flags: number = MPTokenIssuanceCreateFlags.tfMPTCanTrade |
+    MPTokenIssuanceCreateFlags.tfMPTCanTransfer,
+  fundAmount = '100000',
+): Promise<string> {
+  const mptIssuanceId = await createMPTIssuance(client, issuerWallet, flags)
+
+  // Authorize the holder
+  const authTx: MPTokenAuthorize = {
+    TransactionType: 'MPTokenAuthorize',
+    Account: holderWallet.classicAddress,
+    MPTokenIssuanceID: mptIssuanceId,
+  }
+  await testTransaction(client, authTx, holderWallet)
+
+  // Fund the holder with MPT
+  const payTx: Payment = {
+    TransactionType: 'Payment',
+    Account: issuerWallet.classicAddress,
+    Destination: holderWallet.classicAddress,
+    Amount: {
+      mpt_issuance_id: mptIssuanceId,
+      value: fundAmount,
+    },
+  }
+  await testTransaction(client, payTx, issuerWallet)
+
+  return mptIssuanceId
+}
+
+export interface TestMPTAMMPool {
+  asset: MPTCurrency
+  asset2: MPTCurrency
+  issuerWallet1: Wallet
+  issuerWallet2: Wallet
+  lpWallet: Wallet
+}
+
+/**
+ * Creates a full MPT/MPT AMM pool with two issuers and one LP.
+ * Each MPT is created with tfMPTCanTransfer | tfMPTCanTrade | tfMPTCanClawback.
+ *
+ * @param client - The XRPL client.
+ * @returns An object containing both MPT assets, issuer wallets, and the LP wallet.
+ */
+export async function createAMMPoolWithMPT(
+  client: Client,
+): Promise<TestMPTAMMPool> {
+  const issuerWallet1 = await generateFundedWallet(client)
+  const issuerWallet2 = await generateFundedWallet(client)
+  const lpWallet = await generateFundedWallet(client)
+
+  const mptFlags =
+    MPTokenIssuanceCreateFlags.tfMPTCanTransfer |
+    MPTokenIssuanceCreateFlags.tfMPTCanTrade |
+    MPTokenIssuanceCreateFlags.tfMPTCanClawback
+
+  const mptIssuanceId1 = await createMPTIssuanceAndAuthorize(
+    client,
+    issuerWallet1,
+    lpWallet,
+    mptFlags,
+  )
+
+  const mptIssuanceId2 = await createMPTIssuanceAndAuthorize(
+    client,
+    issuerWallet2,
+    lpWallet,
+    mptFlags,
+  )
+
+  const ammCreateTx: AMMCreate = {
+    TransactionType: 'AMMCreate',
+    Account: lpWallet.classicAddress,
+    Amount: {
+      mpt_issuance_id: mptIssuanceId1,
+      value: '250',
+    } as unknown as MPTAmount,
+    Amount2: {
+      mpt_issuance_id: mptIssuanceId2,
+      value: '250',
+    } as unknown as MPTAmount,
+    TradingFee: 12,
+  }
+
+  await testTransaction(client, ammCreateTx, lpWallet)
+
+  const asset: MPTCurrency = { mpt_issuance_id: mptIssuanceId1 }
+  const asset2: MPTCurrency = { mpt_issuance_id: mptIssuanceId2 }
+
+  return {
+    asset,
+    asset2,
+    issuerWallet1,
+    issuerWallet2,
+    lpWallet,
+  }
+}

--- a/packages/xrpl/test/integration/requests/ammInfo.test.ts
+++ b/packages/xrpl/test/integration/requests/ammInfo.test.ts
@@ -47,6 +47,11 @@ describe('AMMInfo', function () {
   it('amm_info with MPT assets', async function () {
     const mptPool = await createAMMPoolWithMPT(testContext.client)
     const { asset, asset2 } = mptPool
+    const ammInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
     const { amm } = ammInfoRes.result
 
     assert.isTrue(isValidClassicAddress(amm.account))

--- a/packages/xrpl/test/integration/requests/ammInfo.test.ts
+++ b/packages/xrpl/test/integration/requests/ammInfo.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai'
 import { isValidClassicAddress } from 'xrpl'
 
 import { AMMInfoResponse } from '../../../src'
+import { createAMMPoolWithMPT } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupAMMPool,
@@ -41,6 +42,24 @@ describe('AMMInfo', function () {
       value: '250',
     })
     assert.equal(amm.trading_fee, 12)
+  })
+
+  it('amm_info with MPT assets', async function () {
+    const mptPool = await createAMMPoolWithMPT(testContext.client)
+    const { asset, asset2 } = mptPool
+    const { amm } = ammInfoRes.result
+
+    assert.isTrue(isValidClassicAddress(amm.account))
+    assert.deepEqual(amm.amount, {
+      mpt_issuance_id: asset.mpt_issuance_id,
+      value: '250',
+    })
+    assert.deepEqual(amm.amount2, {
+      mpt_issuance_id: asset2.mpt_issuance_id,
+      value: '250',
+    })
+    assert.equal(amm.trading_fee, 12)
+    assert.ok(amm.lp_token)
   })
 
   it('with account field', async function () {

--- a/packages/xrpl/test/integration/requests/bookOffers.test.ts
+++ b/packages/xrpl/test/integration/requests/bookOffers.test.ts
@@ -1,12 +1,19 @@
 import { assert } from 'chai'
 
-import { BookOffersRequest, BookOffersResponse } from '../../../src'
+import {
+  BookOffersRequest,
+  BookOffersResponse,
+  MPTokenIssuanceCreateFlags,
+  OfferCreate,
+} from '../../../src'
+import { createMPTIssuanceAndAuthorize } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
   teardownClient,
   type XrplIntegrationTestContext,
 } from '../setup'
+import { generateFundedWallet, testTransaction } from '../utils'
 
 // how long before each test case times out
 const TIMEOUT = 20000
@@ -46,6 +53,59 @@ describe('book_offers', function () {
       }
 
       assert.deepEqual(response, expectedResponse)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'book_offers with MPT',
+    async () => {
+      const issuerWallet = await generateFundedWallet(testContext.client)
+      const sourceWallet = await generateFundedWallet(testContext.client)
+
+      const mptIssuanceId = await createMPTIssuanceAndAuthorize(
+        testContext.client,
+        issuerWallet,
+        sourceWallet,
+        // eslint-disable-next-line no-bitwise -- combining MPT issuance flags
+        MPTokenIssuanceCreateFlags.tfMPTCanTrade |
+          MPTokenIssuanceCreateFlags.tfMPTCanTransfer,
+      )
+
+      // Create an offer: sell 10 MPT for 100000 XRP drops
+      const offerTx: OfferCreate = {
+        TransactionType: 'OfferCreate',
+        Account: sourceWallet.classicAddress,
+        // @ts-expect-error -- MPTAmount support will be added to OfferCreate.TakerGets
+        TakerGets: {
+          mpt_issuance_id: mptIssuanceId,
+          value: '10',
+        },
+        TakerPays: '100000',
+      }
+      await testTransaction(testContext.client, offerTx, sourceWallet)
+
+      // Query book_offers with MPT
+      const bookOffer: BookOffersRequest = {
+        command: 'book_offers',
+        // @ts-expect-error -- MPTCurrency support will be added to BookOffersRequest
+        taker_gets: { mpt_issuance_id: mptIssuanceId },
+        taker_pays: { currency: 'XRP' },
+      }
+      const response = await testContext.client.request(bookOffer)
+
+      assert.equal(response.type, 'response')
+      assert.isAtLeast(response.result.offers.length, 1)
+
+      const matchingOffer = response.result.offers.find(
+        (offer) => offer.Account === sourceWallet.classicAddress,
+      )
+      assert.ok(matchingOffer, 'Should find an offer from the source wallet')
+      assert.deepEqual(matchingOffer.TakerGets, {
+        mpt_issuance_id: mptIssuanceId,
+        value: '10',
+      })
+      assert.equal(matchingOffer.TakerPays, '100000')
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/requests/bookOffers.test.ts
+++ b/packages/xrpl/test/integration/requests/bookOffers.test.ts
@@ -67,7 +67,7 @@ describe('book_offers', function () {
         testContext.client,
         issuerWallet,
         sourceWallet,
-        // eslint-disable-next-line no-bitwise -- combining MPT issuance flags
+        // eslint-disable-next-line no-bitwise -- combining flags requires bitwise OR
         MPTokenIssuanceCreateFlags.tfMPTCanTrade |
           MPTokenIssuanceCreateFlags.tfMPTCanTransfer,
       )

--- a/packages/xrpl/test/integration/requests/bookOffers.test.ts
+++ b/packages/xrpl/test/integration/requests/bookOffers.test.ts
@@ -76,7 +76,6 @@ describe('book_offers', function () {
       const offerTx: OfferCreate = {
         TransactionType: 'OfferCreate',
         Account: sourceWallet.classicAddress,
-        // @ts-expect-error -- MPTAmount support will be added to OfferCreate.TakerGets
         TakerGets: {
           mpt_issuance_id: mptIssuanceId,
           value: '10',

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 
-import { LedgerEntryRequest, LedgerEntryResponse } from '../../../src'
+import { LedgerEntryRequest } from '../../../src'
 import type AMM from '../../../src/models/ledger/AMM'
 import { createAMMPoolWithMPT } from '../mptUtils'
 import serverUrl from '../serverUrl'

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai'
 
-import type { LedgerEntryRequest } from '../../../src'
+import { LedgerEntryRequest } from '../../../src'
+import { createAMMPoolWithMPT } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -92,20 +93,54 @@ describe('ledger_entry', function () {
     TIMEOUT,
   )
 
+  it('binary = true', async () => {
+    const wallet = await generateFundedWallet(testContext.client)
+
+    const ledgerEntryResponse = await testContext.client.request({
+      command: 'ledger_entry',
+      account_root: wallet.address,
+      binary: true,
+    })
+
+    // @ts-expect-error - node is not present in the response
+    assert.isUndefined(ledgerEntryResponse.result.node)
+    assert.isDefined(ledgerEntryResponse.result.node_binary)
+  })
+
   it(
-    'binary = true',
+    'ledger_entry for AMM with MPT assets',
     async () => {
-      const wallet = await generateFundedWallet(testContext.client)
+      const mptPool = await createAMMPoolWithMPT(testContext.client)
+      const { asset, asset2 } = mptPool
 
       const ledgerEntryResponse = await testContext.client.request({
         command: 'ledger_entry',
-        account_root: wallet.address,
-        binary: true,
+        // @ts-expect-error -- AMM field with MPTCurrency support will be added to LedgerEntryRequest
+        amm: {
+          asset,
+          asset2,
+        },
       })
 
-      // @ts-expect-error - node is not present in the response
-      assert.isUndefined(ledgerEntryResponse.result.node)
-      assert.isDefined(ledgerEntryResponse.result.node_binary)
+      assert.equal(ledgerEntryResponse.type, 'response')
+
+      const node = ledgerEntryResponse.result.node
+      // @ts-expect-error -- node type will be updated
+      assert.equal(node.LedgerEntryType, 'AMM')
+      // @ts-expect-error -- node type will be updated
+      assert.deepEqual(node.Asset, {
+        mpt_issuance_id: asset.mpt_issuance_id,
+      })
+      // @ts-expect-error -- node type will be updated
+      assert.deepEqual(node.Asset2, {
+        mpt_issuance_id: asset2.mpt_issuance_id,
+      })
+      // @ts-expect-error -- node type will be updated
+      assert.equal(node.TradingFee, 12)
+      // @ts-expect-error -- node type will be updated
+      assert.ok(node.LPTokenBalance)
+      // @ts-expect-error -- node type will be updated
+      assert.ok(node.Account)
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai'
 
-import { LedgerEntryRequest } from '../../../src'
+import { LedgerEntryRequest, LedgerEntryResponse } from '../../../src'
+import type AMM from '../../../src/models/ledger/AMM'
 import { createAMMPoolWithMPT } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
@@ -115,7 +116,6 @@ describe('ledger_entry', function () {
 
       const ledgerEntryResponse = await testContext.client.request({
         command: 'ledger_entry',
-        // @ts-expect-error -- AMM field with MPTCurrency support will be added to LedgerEntryRequest
         amm: {
           asset,
           asset2,
@@ -124,22 +124,16 @@ describe('ledger_entry', function () {
 
       assert.equal(ledgerEntryResponse.type, 'response')
 
-      const node = ledgerEntryResponse.result.node
-      // @ts-expect-error -- node type will be updated
+      const node = ledgerEntryResponse.result.node as unknown as AMM
       assert.equal(node.LedgerEntryType, 'AMM')
-      // @ts-expect-error -- node type will be updated
       assert.deepEqual(node.Asset, {
         mpt_issuance_id: asset.mpt_issuance_id,
       })
-      // @ts-expect-error -- node type will be updated
       assert.deepEqual(node.Asset2, {
         mpt_issuance_id: asset2.mpt_issuance_id,
       })
-      // @ts-expect-error -- node type will be updated
       assert.equal(node.TradingFee, 12)
-      // @ts-expect-error -- node type will be updated
       assert.ok(node.LPTokenBalance)
-      // @ts-expect-error -- node type will be updated
       assert.ok(node.Account)
     },
     TIMEOUT,

--- a/packages/xrpl/test/integration/requests/pathFind.test.ts
+++ b/packages/xrpl/test/integration/requests/pathFind.test.ts
@@ -141,7 +141,6 @@ describe('path_find', function () {
         subcommand: 'create',
         source_account: issuerWallet.classicAddress,
         destination_account: paymentDestinationWallet.classicAddress,
-        // @ts-expect-error -- MPTAmount support will be added to PathFindRequest.destination_amount
         destination_amount: {
           mpt_issuance_id: mptIssuanceId,
           value: '100',

--- a/packages/xrpl/test/integration/requests/ripplePathFind.test.ts
+++ b/packages/xrpl/test/integration/requests/ripplePathFind.test.ts
@@ -76,7 +76,6 @@ describe('ripple_path_find', function () {
         subcommand: 'create',
         source_account: issuerWallet.classicAddress,
         destination_account: paymentDestinationWallet.classicAddress,
-        // @ts-expect-error -- MPTAmount support will be added to RipplePathFindRequest.destination_amount
         destination_amount: {
           mpt_issuance_id: mptIssuanceId,
           value: '100',

--- a/packages/xrpl/test/integration/transactions/ammClawback.test.ts
+++ b/packages/xrpl/test/integration/transactions/ammClawback.test.ts
@@ -78,10 +78,8 @@ describe('AMMClawback', function () {
       TransactionType: 'AMMClawback',
       Account: issuerWallet1.classicAddress,
       Holder: lpWallet.classicAddress,
-      // @ts-expect-error -- MPTCurrency support will be added to AMMClawback.Asset
       Asset: asset,
       Asset2: asset2,
-      // @ts-expect-error -- MPTAmount support will be added to AMMClawback.Amount
       Amount: {
         mpt_issuance_id: asset.mpt_issuance_id,
         value: '10',

--- a/packages/xrpl/test/integration/transactions/ammClawback.test.ts
+++ b/packages/xrpl/test/integration/transactions/ammClawback.test.ts
@@ -1,5 +1,9 @@
+import { assert } from 'chai'
 import { AMMClawback, AMMDeposit, AMMDepositFlags, XRP } from 'xrpl'
 
+import { AMMInfoResponse } from '../../../src'
+import type { MPTAmount } from '../../../src/models/common'
+import { createAMMPoolWithMPT, type TestMPTAMMPool } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -53,5 +57,50 @@ describe('AMMClawback', function () {
     }
 
     await testTransaction(testContext.client, ammClawback, issuerWallet)
+  })
+
+  it('clawback MPT from AMM pool', async function () {
+    const mptPool: TestMPTAMMPool = await createAMMPoolWithMPT(
+      testContext.client,
+    )
+    const { asset, asset2, issuerWallet1, lpWallet } = mptPool
+
+    // Record pre-clawback pool balance
+    const preAmmInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
+    const preAmount = preAmmInfoRes.result.amm.amount as MPTAmount
+
+    // Issuer claws back MPT from the AMM holder
+    const ammClawbackMPT: AMMClawback = {
+      TransactionType: 'AMMClawback',
+      Account: issuerWallet1.classicAddress,
+      Holder: lpWallet.classicAddress,
+      // @ts-expect-error -- MPTCurrency support will be added to AMMClawback.Asset
+      Asset: asset,
+      Asset2: asset2,
+      // @ts-expect-error -- MPTAmount support will be added to AMMClawback.Amount
+      Amount: {
+        mpt_issuance_id: asset.mpt_issuance_id,
+        value: '10',
+      },
+    }
+
+    await testTransaction(testContext.client, ammClawbackMPT, issuerWallet1)
+
+    // Verify pool balance decreased
+    const postAmmInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
+    const postAmount = postAmmInfoRes.result.amm.amount as MPTAmount
+
+    assert.isBelow(
+      parseInt(postAmount.value, 10),
+      parseInt(preAmount.value, 10),
+    )
   })
 })

--- a/packages/xrpl/test/integration/transactions/ammCreate.test.ts
+++ b/packages/xrpl/test/integration/transactions/ammCreate.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai'
 import { isValidClassicAddress } from 'xrpl'
 
 import { AMMInfoResponse } from '../../../src'
+import { createAMMPoolWithMPT } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -37,6 +38,29 @@ describe('AMMCreate', function () {
     assert.deepEqual(amm.amount2, {
       currency: asset2.currency,
       issuer: asset2.issuer,
+      value: '250',
+    })
+    assert.equal(amm.trading_fee, 12)
+  })
+
+  it('creates AMM pool with two MPT assets', async function () {
+    const ammPool = await createAMMPoolWithMPT(testContext.client)
+    const { asset, asset2 } = ammPool
+
+    const ammInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
+    const { amm } = ammInfoRes.result
+
+    assert.isTrue(isValidClassicAddress(amm.account))
+    assert.deepEqual(amm.amount, {
+      mpt_issuance_id: asset.mpt_issuance_id,
+      value: '250',
+    })
+    assert.deepEqual(amm.amount2, {
+      mpt_issuance_id: asset2.mpt_issuance_id,
       value: '250',
     })
     assert.equal(amm.trading_fee, 12)

--- a/packages/xrpl/test/integration/transactions/ammDeposit.test.ts
+++ b/packages/xrpl/test/integration/transactions/ammDeposit.test.ts
@@ -311,7 +311,6 @@ describe('AMMDeposit', function () {
       Account: lpWallet.classicAddress,
       Asset: asset,
       Asset2: asset2,
-      // @ts-expect-error -- MPTAmount support will be added to AMMDeposit.Amount
       Amount: {
         mpt_issuance_id: asset.mpt_issuance_id,
         value: '100',

--- a/packages/xrpl/test/integration/transactions/ammDeposit.test.ts
+++ b/packages/xrpl/test/integration/transactions/ammDeposit.test.ts
@@ -3,6 +3,8 @@ import { assert } from 'chai'
 import { AMMDeposit, AMMDepositFlags } from 'xrpl'
 
 import { AMMInfoResponse } from '../../../src'
+import type { MPTAmount } from '../../../src/models/common'
+import { createAMMPoolWithMPT, type TestMPTAMMPool } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupAMMPool,
@@ -285,5 +287,60 @@ describe('AMMDeposit', function () {
     assert.equal(afterAmountDrops, expectedAmountDrops)
     assert.equal(afterAmount2Value, expectedAmount2Value)
     assert.equal(afterLPTokenValue, expectedLPTokenValue)
+  })
+
+  it('deposit single MPT asset', async function () {
+    const mptPool: TestMPTAMMPool = await createAMMPoolWithMPT(
+      testContext.client,
+    )
+    const { asset, asset2, lpWallet } = mptPool
+
+    // Get pre-deposit state
+    const preAmmInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
+    const { amm: preAmm } = preAmmInfoRes.result
+    const preAmount = preAmm.amount as MPTAmount
+    const preAmount2 = preAmm.amount2 as MPTAmount
+
+    // Deposit single MPT asset from the LP wallet
+    const ammDepositTx: AMMDeposit = {
+      TransactionType: 'AMMDeposit',
+      Account: lpWallet.classicAddress,
+      Asset: asset,
+      Asset2: asset2,
+      // @ts-expect-error -- MPTAmount support will be added to AMMDeposit.Amount
+      Amount: {
+        mpt_issuance_id: asset.mpt_issuance_id,
+        value: '100',
+      },
+      Flags: AMMDepositFlags.tfSingleAsset,
+    }
+
+    await testTransaction(testContext.client, ammDepositTx, lpWallet)
+
+    // Get post-deposit state
+    const ammInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
+    const { amm } = ammInfoRes.result
+    const postAmount = amm.amount as MPTAmount
+    const postAmount2 = amm.amount2 as MPTAmount
+
+    // Pool balance of deposited asset should increase by 100
+    assert.equal(
+      parseInt(postAmount.value, 10),
+      parseInt(preAmount.value, 10) + 100,
+    )
+    // Other asset should remain unchanged
+    assert.equal(postAmount2.value, preAmount2.value)
+    // LP token supply should increase
+    const postLPTokenValue = parseInt(amm.lp_token.value, 10)
+    const preLPTokenValue = parseInt(preAmm.lp_token.value, 10)
+    assert.isAbove(postLPTokenValue, preLPTokenValue)
   })
 })

--- a/packages/xrpl/test/integration/transactions/ammWithdraw.test.ts
+++ b/packages/xrpl/test/integration/transactions/ammWithdraw.test.ts
@@ -319,7 +319,6 @@ describe('AMMWithdraw', function () {
       Account: lpWallet.classicAddress,
       Asset: asset,
       Asset2: asset2,
-      // @ts-expect-error -- MPTAmount support will be added to AMMWithdraw.Amount
       Amount: {
         mpt_issuance_id: asset.mpt_issuance_id,
         value: '50',

--- a/packages/xrpl/test/integration/transactions/ammWithdraw.test.ts
+++ b/packages/xrpl/test/integration/transactions/ammWithdraw.test.ts
@@ -3,6 +3,8 @@ import { assert } from 'chai'
 import { AMMWithdraw, AMMWithdrawFlags } from 'xrpl'
 
 import { AMMInfoResponse } from '../../../src'
+import type { MPTAmount } from '../../../src/models/common'
+import { createAMMPoolWithMPT, type TestMPTAMMPool } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupAMMPool,
@@ -293,5 +295,91 @@ describe('AMMWithdraw', function () {
     assert.equal(afterAmountDrops, expectedAmountDrops)
     assert.equal(afterAmount2Value, expectedAmount2Value)
     assert.equal(afterLPTokenValue, expectedLPTokenValue)
+  })
+
+  it('withdraw single MPT asset', async function () {
+    const mptPool: TestMPTAMMPool = await createAMMPoolWithMPT(
+      testContext.client,
+    )
+    const { asset, asset2, lpWallet } = mptPool
+
+    // Get pre-withdraw state
+    const preAmmInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
+    const { amm: preAmm } = preAmmInfoRes.result
+    const preAmount = preAmm.amount as MPTAmount
+    const preAmount2 = preAmm.amount2 as MPTAmount
+
+    // Withdraw single MPT asset
+    const ammWithdrawTx: AMMWithdraw = {
+      TransactionType: 'AMMWithdraw',
+      Account: lpWallet.classicAddress,
+      Asset: asset,
+      Asset2: asset2,
+      // @ts-expect-error -- MPTAmount support will be added to AMMWithdraw.Amount
+      Amount: {
+        mpt_issuance_id: asset.mpt_issuance_id,
+        value: '50',
+      },
+      Flags: AMMWithdrawFlags.tfSingleAsset,
+    }
+
+    await testTransaction(testContext.client, ammWithdrawTx, lpWallet)
+
+    // Get post-withdraw state
+    const ammInfoRes: AMMInfoResponse = await testContext.client.request({
+      command: 'amm_info',
+      asset,
+      asset2,
+    })
+    const { amm } = ammInfoRes.result
+    const postAmount = amm.amount as MPTAmount
+    const postAmount2 = amm.amount2 as MPTAmount
+
+    // Pool balance of withdrawn asset should decrease by 50
+    assert.equal(
+      parseInt(postAmount.value, 10),
+      parseInt(preAmount.value, 10) - 50,
+    )
+    // Other asset should remain unchanged
+    assert.equal(postAmount2.value, preAmount2.value)
+    // LP token supply should decrease
+    const postLPTokenValue = parseInt(amm.lp_token.value, 10)
+    const preLPTokenValue = parseInt(preAmm.lp_token.value, 10)
+    assert.isBelow(postLPTokenValue, preLPTokenValue)
+  })
+
+  it('withdraw all MPT (AMM delete)', async function () {
+    const mptPool: TestMPTAMMPool = await createAMMPoolWithMPT(
+      testContext.client,
+    )
+    const { asset, asset2, lpWallet } = mptPool
+
+    // Withdraw all to delete the AMM
+    const ammWithdrawTx: AMMWithdraw = {
+      TransactionType: 'AMMWithdraw',
+      Account: lpWallet.classicAddress,
+      Asset: asset,
+      Asset2: asset2,
+      Flags: AMMWithdrawFlags.tfWithdrawAll,
+    }
+
+    await testTransaction(testContext.client, ammWithdrawTx, lpWallet)
+
+    // Verify the AMM no longer exists
+    try {
+      await testContext.client.request({
+        command: 'amm_info',
+        asset,
+        asset2,
+      })
+      assert.fail('Expected amm_info to fail for deleted AMM')
+    } catch (error: unknown) {
+      const err = error as { data?: { error?: string } }
+      assert.equal(err.data?.error, 'actNotFound')
+    }
   })
 })

--- a/packages/xrpl/test/integration/transactions/checkCash.test.ts
+++ b/packages/xrpl/test/integration/transactions/checkCash.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 
-import { CheckCreate, CheckCash } from '../../../src'
+import { CheckCreate, CheckCash, LedgerEntry } from '../../../src'
 import { createMPTIssuanceAndAuthorize } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
@@ -111,7 +111,21 @@ describe('CheckCash', function () {
         1,
         'Should be exactly one check on the ledger',
       )
-      const checkId = response1.result.account_objects[0].index
+
+      const checkObject = response1.result
+        .account_objects[0] as LedgerEntry.Check
+      const checkId = checkObject.index
+
+      // Verify the check ledger object contents
+      assert.equal(checkObject.Account, testContext.wallet.classicAddress)
+      assert.equal(
+        checkObject.Destination,
+        checkDestinationWallet.classicAddress,
+      )
+      assert.deepEqual(checkObject.SendMax, {
+        mpt_issuance_id: mptIssuanceId,
+        value: '50',
+      })
 
       // Cash the check with MPT
       const tx: CheckCash = {

--- a/packages/xrpl/test/integration/transactions/checkCash.test.ts
+++ b/packages/xrpl/test/integration/transactions/checkCash.test.ts
@@ -92,7 +92,6 @@ describe('CheckCash', function () {
         TransactionType: 'CheckCreate',
         Account: testContext.wallet.classicAddress,
         Destination: checkDestinationWallet.classicAddress,
-        // @ts-expect-error -- MPTAmount support will be added to CheckCreate.SendMax
         SendMax: {
           mpt_issuance_id: mptIssuanceId,
           value: '50',
@@ -119,7 +118,6 @@ describe('CheckCash', function () {
         TransactionType: 'CheckCash',
         Account: checkDestinationWallet.classicAddress,
         CheckID: checkId,
-        // @ts-expect-error -- MPTAmount support will be added to CheckCash.Amount
         Amount: {
           mpt_issuance_id: mptIssuanceId,
           value: '50',

--- a/packages/xrpl/test/integration/transactions/checkCreate.test.ts
+++ b/packages/xrpl/test/integration/transactions/checkCreate.test.ts
@@ -66,7 +66,6 @@ describe('CheckCreate', function () {
         TransactionType: 'CheckCreate',
         Account: testContext.wallet.classicAddress,
         Destination: checkDestinationWallet.classicAddress,
-        // @ts-expect-error -- MPTAmount support will be added to CheckCreate.SendMax
         SendMax: {
           mpt_issuance_id: mptIssuanceId,
           value: '50',

--- a/packages/xrpl/test/integration/transactions/checkCreate.test.ts
+++ b/packages/xrpl/test/integration/transactions/checkCreate.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai'
 
 import { CheckCreate } from '../../../src'
+import { createMPTIssuanceAndAuthorize } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -43,6 +44,57 @@ describe('CheckCreate', function () {
         accountOffersResponse.result.account_objects,
         1,
         'Should be exactly one check on the ledger',
+      )
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'CheckCreate with MPT',
+    async () => {
+      const checkDestinationWallet = await generateFundedWallet(
+        testContext.client,
+      )
+
+      const mptIssuanceId = await createMPTIssuanceAndAuthorize(
+        testContext.client,
+        testContext.wallet,
+        checkDestinationWallet,
+      )
+
+      const tx: CheckCreate = {
+        TransactionType: 'CheckCreate',
+        Account: testContext.wallet.classicAddress,
+        Destination: checkDestinationWallet.classicAddress,
+        // @ts-expect-error -- MPTAmount support will be added to CheckCreate.SendMax
+        SendMax: {
+          mpt_issuance_id: mptIssuanceId,
+          value: '50',
+        },
+      }
+
+      await testTransaction(testContext.client, tx, testContext.wallet)
+
+      // Confirm the check exists on the ledger
+      const accountObjectsResponse = await testContext.client.request({
+        command: 'account_objects',
+        account: testContext.wallet.classicAddress,
+        type: 'check',
+      })
+      assert.lengthOf(
+        accountObjectsResponse.result.account_objects,
+        1,
+        'Should be exactly one check on the ledger',
+      )
+
+      const checkNode = accountObjectsResponse.result.account_objects[0]
+      assert.deepEqual(
+        // @ts-expect-error -- SendMax type will support MPTAmount
+        checkNode.SendMax,
+        {
+          mpt_issuance_id: mptIssuanceId,
+          value: '50',
+        },
       )
     },
     TIMEOUT,

--- a/packages/xrpl/test/integration/transactions/offerCreate.test.ts
+++ b/packages/xrpl/test/integration/transactions/offerCreate.test.ts
@@ -1,6 +1,12 @@
 import { assert } from 'chai'
 
-import { OfferCreate, TrustSet, Wallet } from '../../../src'
+import {
+  MPTokenIssuanceCreateFlags,
+  OfferCreate,
+  TrustSet,
+  Wallet,
+} from '../../../src'
+import { createMPTIssuanceAndAuthorize } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -104,6 +110,56 @@ describe('OfferCreate', function () {
       })
 
       assert.equal(response.result.engine_result, 'tecFROZEN')
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'OfferCreate with MPT',
+    async () => {
+      const issuerWallet = await generateFundedWallet(testContext.client)
+      const sourceWallet = await generateFundedWallet(testContext.client)
+
+      const mptIssuanceId = await createMPTIssuanceAndAuthorize(
+        testContext.client,
+        issuerWallet,
+        sourceWallet,
+        // eslint-disable-next-line no-bitwise -- combining MPT issuance flags
+        MPTokenIssuanceCreateFlags.tfMPTCanTrade |
+          MPTokenIssuanceCreateFlags.tfMPTCanTransfer,
+      )
+
+      // Create an offer: sell 10 MPT for 100000 XRP drops
+      const tx: OfferCreate = {
+        TransactionType: 'OfferCreate',
+        Account: sourceWallet.classicAddress,
+        // @ts-expect-error -- MPTAmount support will be added to OfferCreate.TakerGets
+        TakerGets: {
+          mpt_issuance_id: mptIssuanceId,
+          value: '10',
+        },
+        TakerPays: '100000',
+      }
+
+      await testTransaction(testContext.client, tx, sourceWallet)
+
+      // Confirm the offer exists on the ledger
+      const accountOffersResponse = await testContext.client.request({
+        command: 'account_offers',
+        account: sourceWallet.classicAddress,
+      })
+      assert.lengthOf(
+        accountOffersResponse.result.offers!,
+        1,
+        'Should be exactly one offer on the ledger',
+      )
+
+      const offer = accountOffersResponse.result.offers![0]
+      assert.deepEqual(offer.taker_gets, {
+        mpt_issuance_id: mptIssuanceId,
+        value: '10',
+      })
+      assert.equal(offer.taker_pays, '100000')
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/transactions/offerCreate.test.ts
+++ b/packages/xrpl/test/integration/transactions/offerCreate.test.ts
@@ -133,7 +133,6 @@ describe('OfferCreate', function () {
       const tx: OfferCreate = {
         TransactionType: 'OfferCreate',
         Account: sourceWallet.classicAddress,
-        // @ts-expect-error -- MPTAmount support will be added to OfferCreate.TakerGets
         TakerGets: {
           mpt_issuance_id: mptIssuanceId,
           value: '10',

--- a/packages/xrpl/test/integration/transactions/offerCreate.test.ts
+++ b/packages/xrpl/test/integration/transactions/offerCreate.test.ts
@@ -124,7 +124,7 @@ describe('OfferCreate', function () {
         testContext.client,
         issuerWallet,
         sourceWallet,
-        // eslint-disable-next-line no-bitwise -- combining MPT issuance flags
+        // eslint-disable-next-line no-bitwise -- combining flags requires bitwise OR
         MPTokenIssuanceCreateFlags.tfMPTCanTrade |
           MPTokenIssuanceCreateFlags.tfMPTCanTransfer,
       )

--- a/packages/xrpl/test/integration/transactions/payment.test.ts
+++ b/packages/xrpl/test/integration/transactions/payment.test.ts
@@ -210,9 +210,11 @@ describe('Payment', function () {
       const lpWallet = await generateFundedWallet(testContext.client)
       const destination = await generateFundedWallet(testContext.client)
 
+      /* eslint-disable no-bitwise -- combining flags requires bitwise OR */
       const mptFlags =
         MPTokenIssuanceCreateFlags.tfMPTCanTrade |
         MPTokenIssuanceCreateFlags.tfMPTCanTransfer
+      /* eslint-enable no-bitwise */
 
       // Create MPT_B (issuer2) and authorize + fund LP
       const mptIdB = await createMPTIssuanceAndAuthorize(
@@ -249,7 +251,11 @@ describe('Payment', function () {
         Account: testContext.wallet.classicAddress,
         MPTokenIssuanceID: mptIdB,
       }
-      await testTransaction(testContext.client, authSenderMptB, testContext.wallet)
+      await testTransaction(
+        testContext.client,
+        authSenderMptB,
+        testContext.wallet,
+      )
 
       // Cross-currency payment: XRP → MPT_B with two alternative paths
       // Path 1: XRP → MPT_A → MPT_B (via XRP/MPT_A and MPT_A/MPT_B pools)
@@ -263,9 +269,7 @@ describe('Payment', function () {
           value: '5',
         },
         SendMax: '500000',
-        Paths: [
-          [{ mpt_issuance_id: mptIdB }]
-        ],
+        Paths: [[{ mpt_issuance_id: mptIdB }]],
       }
 
       await testTransaction(testContext.client, payTx, testContext.wallet)

--- a/packages/xrpl/test/integration/transactions/payment.test.ts
+++ b/packages/xrpl/test/integration/transactions/payment.test.ts
@@ -295,7 +295,6 @@ describe('Payment', function () {
           value: '5',
         },
         SendMax: '500000',
-        // @ts-expect-error -- mpt_issuance_id not yet in PathStep type
         Paths: [[{ mpt_issuance_id: mptIdA }], [{ mpt_issuance_id: mptIdB }]],
       }
 

--- a/packages/xrpl/test/integration/transactions/payment.test.ts
+++ b/packages/xrpl/test/integration/transactions/payment.test.ts
@@ -258,7 +258,6 @@ describe('Payment', function () {
       )
 
       // Cross-currency payment: XRP → MPT_B with two alternative paths
-      // Path 1: XRP → MPT_A → MPT_B (via XRP/MPT_A and MPT_A/MPT_B pools)
       // Path 2: XRP → MPT_B (via XRP/MPT_B pool)
       const payTx: Payment = {
         TransactionType: 'Payment',

--- a/packages/xrpl/test/integration/transactions/payment.test.ts
+++ b/packages/xrpl/test/integration/transactions/payment.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai'
 
 import {
   Payment,
+  PaymentFlags,
   Wallet,
   MPTokenIssuanceCreate,
   MPTokenIssuanceCreateFlags,
@@ -12,6 +13,7 @@ import {
   TransactionMetadata,
   TrustSet,
 } from '../../../src'
+import type { PaymentMetadata } from '../../../src/models/transactions/payment'
 import { createMPTIssuanceAndAuthorize } from '../mptUtils'
 import serverUrl from '../serverUrl'
 import {
@@ -361,6 +363,174 @@ describe('Payment', function () {
       }
 
       await testTransaction(testContext.client, payTx, testContext.wallet)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'delivered_amount is populated with MPT for a direct MPT payment',
+    async () => {
+      const holder = await generateFundedWallet(testContext.client)
+
+      /* eslint-disable no-bitwise -- combining flags requires bitwise OR */
+      const mptFlags =
+        MPTokenIssuanceCreateFlags.tfMPTCanTrade |
+        MPTokenIssuanceCreateFlags.tfMPTCanTransfer
+      /* eslint-enable no-bitwise */
+
+      const mptIssuanceId = await createMPTIssuanceAndAuthorize(
+        testContext.client,
+        testContext.wallet,
+        holder,
+        mptFlags,
+        '10000',
+      )
+
+      // Send MPT from holder back to a new authorized recipient
+      const recipient = await generateFundedWallet(testContext.client)
+      const authTx: MPTokenAuthorize = {
+        TransactionType: 'MPTokenAuthorize',
+        Account: recipient.classicAddress,
+        MPTokenIssuanceID: mptIssuanceId,
+      }
+      await testTransaction(testContext.client, authTx, recipient)
+
+      const payTx: Payment = {
+        TransactionType: 'Payment',
+        Account: holder.classicAddress,
+        Destination: recipient.classicAddress,
+        Amount: {
+          mpt_issuance_id: mptIssuanceId,
+          value: '500',
+        },
+      }
+
+      const payResponse = await testTransaction(
+        testContext.client,
+        payTx,
+        holder,
+      )
+
+      const txHash = payResponse.result.tx_json.hash
+      const txResponse = await testContext.client.request({
+        command: 'tx',
+        transaction: txHash,
+      })
+
+      const meta = txResponse.result.meta as PaymentMetadata
+
+      assert.exists(
+        meta.delivered_amount,
+        'delivered_amount should exist in metadata',
+      )
+      assert.isObject(
+        meta.delivered_amount,
+        'delivered_amount should be an MPT object',
+      )
+
+      const deliveredAmount = meta.delivered_amount as {
+        mpt_issuance_id: string
+        value: string
+      }
+
+      assert.equal(
+        deliveredAmount.mpt_issuance_id,
+        mptIssuanceId,
+        'delivered_amount mpt_issuance_id should match',
+      )
+      assert.equal(
+        deliveredAmount.value,
+        '500',
+        'delivered_amount value should match the payment amount',
+      )
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'delivered_amount reflects actual amount for partial MPT payment',
+    async () => {
+      const holder = await generateFundedWallet(testContext.client)
+
+      /* eslint-disable no-bitwise -- combining flags requires bitwise OR */
+      const mptFlags =
+        MPTokenIssuanceCreateFlags.tfMPTCanTrade |
+        MPTokenIssuanceCreateFlags.tfMPTCanTransfer
+      /* eslint-enable no-bitwise */
+
+      // Fund holder with only 500 MPT
+      const mptIssuanceId = await createMPTIssuanceAndAuthorize(
+        testContext.client,
+        testContext.wallet,
+        holder,
+        mptFlags,
+        '500',
+      )
+
+      const recipient = await generateFundedWallet(testContext.client)
+      const authTx: MPTokenAuthorize = {
+        TransactionType: 'MPTokenAuthorize',
+        Account: recipient.classicAddress,
+        MPTokenIssuanceID: mptIssuanceId,
+      }
+      await testTransaction(testContext.client, authTx, recipient)
+
+      // Send partial payment: request 1000 but holder only has 500
+      const payTx: Payment = {
+        TransactionType: 'Payment',
+        Account: holder.classicAddress,
+        Destination: recipient.classicAddress,
+        Amount: {
+          mpt_issuance_id: mptIssuanceId,
+          value: '1000',
+        },
+        SendMax: {
+          mpt_issuance_id: mptIssuanceId,
+          value: '500',
+        },
+        Flags: PaymentFlags.tfPartialPayment,
+      }
+
+      const payResponse = await testTransaction(
+        testContext.client,
+        payTx,
+        holder,
+      )
+
+      const txHash = payResponse.result.tx_json.hash
+      const txResponse = await testContext.client.request({
+        command: 'tx',
+        transaction: txHash,
+      })
+
+      const meta = txResponse.result.meta as PaymentMetadata
+
+      assert.exists(
+        meta.delivered_amount,
+        'delivered_amount should exist for partial payment',
+      )
+      assert.isObject(
+        meta.delivered_amount,
+        'delivered_amount should be an MPT object',
+      )
+
+      const deliveredAmount = meta.delivered_amount as {
+        mpt_issuance_id: string
+        value: string
+      }
+
+      assert.equal(
+        deliveredAmount.mpt_issuance_id,
+        mptIssuanceId,
+        'delivered_amount mpt_issuance_id should match',
+      )
+      // The delivered amount should be <= SendMax (500),
+      // and less than the requested Amount (1000)
+      assert.equal(
+        deliveredAmount.value,
+        '500',
+        'delivered_amount should reflect actual delivered amount, not requested',
+      )
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/models/AMMClawback.test.ts
+++ b/packages/xrpl/test/models/AMMClawback.test.ts
@@ -129,16 +129,13 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Asset2: {
-        mpt_issuance_id:
-          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Amount: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
         value: '10',
       },
       Sequence: 1337,
@@ -152,12 +149,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Asset2: {
-        mpt_issuance_id:
-          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Sequence: 1337,
     }
@@ -170,12 +165,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Asset2: {
-        mpt_issuance_id:
-          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Amount: {
         mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
@@ -193,12 +186,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Asset2: {
-        mpt_issuance_id:
-          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Amount: {
         mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
@@ -216,12 +207,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Asset2: {
-        mpt_issuance_id:
-          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       },
       Amount: {
         mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),

--- a/packages/xrpl/test/models/AMMClawback.test.ts
+++ b/packages/xrpl/test/models/AMMClawback.test.ts
@@ -5,6 +5,8 @@ import {
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_1,
+  MPT_ISSUANCE_ID_2,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -129,13 +131,13 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
       },
       Asset2: {
-        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
       },
       Amount: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
         value: '10',
       },
       Sequence: 1337,
@@ -149,10 +151,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
       },
       Asset2: {
-        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
       },
       Sequence: 1337,
     }
@@ -165,10 +167,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
       },
       Asset2: {
-        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
       },
       Amount: {
         mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
@@ -186,10 +188,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
       },
       Asset2: {
-        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
       },
       Amount: {
         mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
@@ -207,10 +209,10 @@ describe('AMMClawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
       Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
       Asset: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
       },
       Asset2: {
-        mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
       },
       Amount: {
         mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),

--- a/packages/xrpl/test/models/AMMClawback.test.ts
+++ b/packages/xrpl/test/models/AMMClawback.test.ts
@@ -161,6 +161,53 @@ describe('AMMClawback', function () {
     assertValid(mptClawback)
   })
 
+  it(`throws w/ MPT Asset but IssuedCurrencyAmount Amount`, function () {
+    const mptClawback = {
+      TransactionType: 'AMMClawback',
+      Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+      Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
+      Asset: {
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
+      },
+      Asset2: {
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
+      },
+      Amount: {
+        currency: 'ETH',
+        issuer: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+        value: '100',
+      },
+      Sequence: 1337,
+    }
+    assertInvalid(
+      mptClawback,
+      'AMMClawback: Amount must be an MPTAmount when Asset is an MPTCurrency',
+    )
+  })
+
+  it(`throws w/ MPT Asset and Amount with mismatched mpt_issuance_id`, function () {
+    const mptClawback = {
+      TransactionType: 'AMMClawback',
+      Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+      Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
+      Asset: {
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
+      },
+      Asset2: {
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
+      },
+      Amount: {
+        mpt_issuance_id: MPT_ISSUANCE_ID_2,
+        value: '10',
+      },
+      Sequence: 1337,
+    }
+    assertInvalid(
+      mptClawback,
+      'AMMClawback: Amount.mpt_issuance_id must match Asset.mpt_issuance_id',
+    )
+  })
+
   it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
     const mptClawback = {
       TransactionType: 'AMMClawback',

--- a/packages/xrpl/test/models/AMMClawback.test.ts
+++ b/packages/xrpl/test/models/AMMClawback.test.ts
@@ -2,7 +2,11 @@ import {
   AMMClawbackFlags,
   validateAMMClawback,
 } from '../../src/models/transactions/AMMClawback'
-import { assertTxIsValid, assertTxValidationError } from '../testUtils'
+import {
+  assertTxIsValid,
+  assertTxValidationError,
+  MPTID_LENGTH,
+} from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateAMMClawback)
 const assertInvalid = (tx: any, message: string): void =>
@@ -116,5 +120,116 @@ describe('AMMClawback', function () {
     ammClawback.Amount.issuer = 'rnYgaEtpqpNRt3wxE39demVpDAA817rQEY'
     const errorMessage = 'AMMClawback: Amount.issuer must match Amount.issuer'
     assertInvalid(ammClawback, errorMessage)
+  })
+
+  // MPT-related tests
+  it(`verifies valid AMMClawback with MPT`, function () {
+    const mptClawback = {
+      TransactionType: 'AMMClawback',
+      Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+      Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
+      Asset: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Asset2: {
+        mpt_issuance_id:
+          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Amount: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        value: '10',
+      },
+      Sequence: 1337,
+    }
+    assertValid(mptClawback)
+  })
+
+  it(`verifies valid AMMClawback with MPT without Amount`, function () {
+    const mptClawback = {
+      TransactionType: 'AMMClawback',
+      Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+      Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
+      Asset: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Asset2: {
+        mpt_issuance_id:
+          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Sequence: 1337,
+    }
+    assertValid(mptClawback)
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
+    const mptClawback = {
+      TransactionType: 'AMMClawback',
+      Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+      Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
+      Asset: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Asset2: {
+        mpt_issuance_id:
+          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Amount: {
+        mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
+        value: '10',
+      },
+      Sequence: 1337,
+    }
+    const errorMessage = 'AMMClawback: invalid field Amount'
+    assertInvalid(mptClawback, errorMessage)
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id too short`, function () {
+    const mptClawback = {
+      TransactionType: 'AMMClawback',
+      Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+      Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
+      Asset: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Asset2: {
+        mpt_issuance_id:
+          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Amount: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
+        value: '10',
+      },
+      Sequence: 1337,
+    }
+    const errorMessage = 'AMMClawback: invalid field Amount'
+    assertInvalid(mptClawback, errorMessage)
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id too long`, function () {
+    const mptClawback = {
+      TransactionType: 'AMMClawback',
+      Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
+      Holder: 'rPyfep3gcLzkosKC9XiE77Y8DZWG6iWDT9',
+      Asset: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Asset2: {
+        mpt_issuance_id:
+          '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      },
+      Amount: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),
+        value: '10',
+      },
+      Sequence: 1337,
+    }
+    const errorMessage = 'AMMClawback: invalid field Amount'
+    assertInvalid(mptClawback, errorMessage)
   })
 })

--- a/packages/xrpl/test/models/AMMClawback.test.ts
+++ b/packages/xrpl/test/models/AMMClawback.test.ts
@@ -270,14 +270,4 @@ describe('AMMClawback', function () {
     const errorMessage = 'AMMClawback: invalid field Amount'
     assertInvalid(mptClawback, errorMessage)
   })
-
-  it(`throws w/ MPT Asset mpt_issuance_id contains non-hex characters`, function () {
-    ammClawback.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
-    assertInvalid(ammClawback, 'AMMClawback: invalid field Asset')
-  })
-
-  it(`throws w/ MPT Asset mpt_issuance_id wrong length`, function () {
-    ammClawback.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
-    assertInvalid(ammClawback, 'AMMClawback: invalid field Asset')
-  })
 })

--- a/packages/xrpl/test/models/AMMClawback.test.ts
+++ b/packages/xrpl/test/models/AMMClawback.test.ts
@@ -270,4 +270,14 @@ describe('AMMClawback', function () {
     const errorMessage = 'AMMClawback: invalid field Amount'
     assertInvalid(mptClawback, errorMessage)
   })
+
+  it(`throws w/ MPT Asset mpt_issuance_id contains non-hex characters`, function () {
+    ammClawback.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
+    assertInvalid(ammClawback, 'AMMClawback: invalid field Asset')
+  })
+
+  it(`throws w/ MPT Asset mpt_issuance_id wrong length`, function () {
+    ammClawback.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
+    assertInvalid(ammClawback, 'AMMClawback: invalid field Asset')
+  })
 })

--- a/packages/xrpl/test/models/AMMCreate.test.ts
+++ b/packages/xrpl/test/models/AMMCreate.test.ts
@@ -1,5 +1,9 @@
 import { validateAMMCreate } from '../../src/models/transactions/AMMCreate'
-import { assertTxIsValid, assertTxValidationError } from '../testUtils'
+import {
+  assertTxIsValid,
+  assertTxValidationError,
+  MPTID_LENGTH,
+} from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateAMMCreate)
 const assertInvalid = (tx: any, message: string): void =>
@@ -77,6 +81,63 @@ describe('AMMCreate', function () {
   it(`throws when TradingFee is a negative number`, function () {
     ammCreate.TradingFee = -1
     const errorMessage = 'AMMCreate: TradingFee must be between 0 and 1000'
+    assertInvalid(ammCreate, errorMessage)
+  })
+
+  // MPT-related tests
+  it(`verifies valid AMMCreate with two MPT assets`, function () {
+    ammCreate.Amount = {
+      mpt_issuance_id:
+        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      value: '250',
+    }
+    ammCreate.Amount2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      value: '250',
+    }
+    assertValid(ammCreate)
+  })
+
+  it(`throws w/ Amount mpt_issuance_id contains non-hex characters`, function () {
+    ammCreate.Amount = {
+      mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
+      value: '250',
+    }
+    ammCreate.Amount2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      value: '250',
+    }
+    const errorMessage = 'AMMCreate: Amount must be an Amount'
+    assertInvalid(ammCreate, errorMessage)
+  })
+
+  it(`throws w/ Amount mpt_issuance_id too short`, function () {
+    ammCreate.Amount = {
+      mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
+      value: '250',
+    }
+    ammCreate.Amount2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      value: '250',
+    }
+    const errorMessage = 'AMMCreate: Amount must be an Amount'
+    assertInvalid(ammCreate, errorMessage)
+  })
+
+  it(`throws w/ Amount mpt_issuance_id too long`, function () {
+    ammCreate.Amount = {
+      mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),
+      value: '250',
+    }
+    ammCreate.Amount2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      value: '250',
+    }
+    const errorMessage = 'AMMCreate: Amount must be an Amount'
     assertInvalid(ammCreate, errorMessage)
   })
 })

--- a/packages/xrpl/test/models/AMMCreate.test.ts
+++ b/packages/xrpl/test/models/AMMCreate.test.ts
@@ -87,13 +87,11 @@ describe('AMMCreate', function () {
   // MPT-related tests
   it(`verifies valid AMMCreate with two MPT assets`, function () {
     ammCreate.Amount = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       value: '250',
     }
     assertValid(ammCreate)
@@ -105,8 +103,7 @@ describe('AMMCreate', function () {
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       value: '250',
     }
     const errorMessage = 'AMMCreate: Amount must be an Amount'
@@ -119,8 +116,7 @@ describe('AMMCreate', function () {
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       value: '250',
     }
     const errorMessage = 'AMMCreate: Amount must be an Amount'
@@ -133,8 +129,7 @@ describe('AMMCreate', function () {
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
       value: '250',
     }
     const errorMessage = 'AMMCreate: Amount must be an Amount'

--- a/packages/xrpl/test/models/AMMCreate.test.ts
+++ b/packages/xrpl/test/models/AMMCreate.test.ts
@@ -2,6 +2,8 @@ import { validateAMMCreate } from '../../src/models/transactions/AMMCreate'
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_1,
+  MPT_ISSUANCE_ID_2,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -87,11 +89,11 @@ describe('AMMCreate', function () {
   // MPT-related tests
   it(`verifies valid AMMCreate with two MPT assets`, function () {
     ammCreate.Amount = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
       value: '250',
     }
     assertValid(ammCreate)
@@ -103,7 +105,7 @@ describe('AMMCreate', function () {
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
       value: '250',
     }
     const errorMessage = 'AMMCreate: Amount must be an Amount'
@@ -116,7 +118,7 @@ describe('AMMCreate', function () {
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
       value: '250',
     }
     const errorMessage = 'AMMCreate: Amount must be an Amount'
@@ -129,7 +131,7 @@ describe('AMMCreate', function () {
       value: '250',
     }
     ammCreate.Amount2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
       value: '250',
     }
     const errorMessage = 'AMMCreate: Amount must be an Amount'

--- a/packages/xrpl/test/models/AMMDeposit.test.ts
+++ b/packages/xrpl/test/models/AMMDeposit.test.ts
@@ -2,7 +2,11 @@
 
 import { AMMDepositFlags } from '../../src'
 import { validateAMMDeposit } from '../../src/models/transactions/AMMDeposit'
-import { assertTxIsValid, assertTxValidationError } from '../testUtils'
+import {
+  assertTxIsValid,
+  assertTxValidationError,
+  MPTID_LENGTH,
+} from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateAMMDeposit)
 const assertInvalid = (tx: any, message: string): void =>
@@ -143,6 +147,79 @@ describe('AMMDeposit', function () {
     deposit.Amount = '1000'
     deposit.EPrice = 1234
     const errorMessage = 'AMMDeposit: EPrice must be an Amount'
+    assertInvalid(deposit, errorMessage)
+  })
+
+  // MPT-related tests
+  it(`verifies valid AMMDeposit with single MPT asset`, function () {
+    deposit.Asset = {
+      mpt_issuance_id:
+        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Asset2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Amount = {
+      mpt_issuance_id:
+        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      value: '100',
+    }
+    deposit.Flags |= AMMDepositFlags.tfSingleAsset
+    assertValid(deposit)
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
+    deposit.Asset = {
+      mpt_issuance_id:
+        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Asset2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Amount = {
+      mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
+      value: '100',
+    }
+    deposit.Flags |= AMMDepositFlags.tfSingleAsset
+    const errorMessage = 'AMMDeposit: Amount must be an Amount'
+    assertInvalid(deposit, errorMessage)
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id too short`, function () {
+    deposit.Asset = {
+      mpt_issuance_id:
+        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Asset2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Amount = {
+      mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
+      value: '100',
+    }
+    deposit.Flags |= AMMDepositFlags.tfSingleAsset
+    const errorMessage = 'AMMDeposit: Amount must be an Amount'
+    assertInvalid(deposit, errorMessage)
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id too long`, function () {
+    deposit.Asset = {
+      mpt_issuance_id:
+        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Asset2 = {
+      mpt_issuance_id:
+        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+    }
+    deposit.Amount = {
+      mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),
+      value: '100',
+    }
+    deposit.Flags |= AMMDepositFlags.tfSingleAsset
+    const errorMessage = 'AMMDeposit: Amount must be an Amount'
     assertInvalid(deposit, errorMessage)
   })
 })

--- a/packages/xrpl/test/models/AMMDeposit.test.ts
+++ b/packages/xrpl/test/models/AMMDeposit.test.ts
@@ -153,16 +153,13 @@ describe('AMMDeposit', function () {
   // MPT-related tests
   it(`verifies valid AMMDeposit with single MPT asset`, function () {
     deposit.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Amount = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       value: '100',
     }
     deposit.Flags |= AMMDepositFlags.tfSingleAsset
@@ -171,12 +168,10 @@ describe('AMMDeposit', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
     deposit.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Amount = {
       mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
@@ -189,12 +184,10 @@ describe('AMMDeposit', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too short`, function () {
     deposit.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
@@ -207,12 +200,10 @@ describe('AMMDeposit', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too long`, function () {
     deposit.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     deposit.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),

--- a/packages/xrpl/test/models/AMMDeposit.test.ts
+++ b/packages/xrpl/test/models/AMMDeposit.test.ts
@@ -5,6 +5,8 @@ import { validateAMMDeposit } from '../../src/models/transactions/AMMDeposit'
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_1,
+  MPT_ISSUANCE_ID_2,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -153,13 +155,13 @@ describe('AMMDeposit', function () {
   // MPT-related tests
   it(`verifies valid AMMDeposit with single MPT asset`, function () {
     deposit.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     deposit.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     deposit.Amount = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
       value: '100',
     }
     deposit.Flags |= AMMDepositFlags.tfSingleAsset
@@ -168,10 +170,10 @@ describe('AMMDeposit', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
     deposit.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     deposit.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     deposit.Amount = {
       mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
@@ -184,10 +186,10 @@ describe('AMMDeposit', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too short`, function () {
     deposit.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     deposit.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     deposit.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
@@ -200,10 +202,10 @@ describe('AMMDeposit', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too long`, function () {
     deposit.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     deposit.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     deposit.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),

--- a/packages/xrpl/test/models/AMMDeposit.test.ts
+++ b/packages/xrpl/test/models/AMMDeposit.test.ts
@@ -215,16 +215,4 @@ describe('AMMDeposit', function () {
     const errorMessage = 'AMMDeposit: Amount must be an Amount'
     assertInvalid(deposit, errorMessage)
   })
-
-  it(`throws w/ MPT Asset mpt_issuance_id contains non-hex characters`, function () {
-    deposit.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
-    deposit.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
-    assertInvalid(deposit, 'AMMDeposit: Asset must be a Currency')
-  })
-
-  it(`throws w/ MPT Asset mpt_issuance_id wrong length`, function () {
-    deposit.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
-    deposit.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
-    assertInvalid(deposit, 'AMMDeposit: Asset must be a Currency')
-  })
 })

--- a/packages/xrpl/test/models/AMMDeposit.test.ts
+++ b/packages/xrpl/test/models/AMMDeposit.test.ts
@@ -215,4 +215,16 @@ describe('AMMDeposit', function () {
     const errorMessage = 'AMMDeposit: Amount must be an Amount'
     assertInvalid(deposit, errorMessage)
   })
+
+  it(`throws w/ MPT Asset mpt_issuance_id contains non-hex characters`, function () {
+    deposit.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
+    deposit.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
+    assertInvalid(deposit, 'AMMDeposit: Asset must be a Currency')
+  })
+
+  it(`throws w/ MPT Asset mpt_issuance_id wrong length`, function () {
+    deposit.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
+    deposit.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
+    assertInvalid(deposit, 'AMMDeposit: Asset must be a Currency')
+  })
 })

--- a/packages/xrpl/test/models/AMMWithdraw.test.ts
+++ b/packages/xrpl/test/models/AMMWithdraw.test.ts
@@ -159,16 +159,13 @@ describe('AMMWithdraw', function () {
   // MPT-related tests
   it(`verifies valid AMMWithdraw with single MPT asset`, function () {
     withdraw.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Amount = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
       value: '50',
     }
     withdraw.Flags |= AMMWithdrawFlags.tfSingleAsset
@@ -177,12 +174,10 @@ describe('AMMWithdraw', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
     withdraw.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Amount = {
       mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
@@ -195,12 +190,10 @@ describe('AMMWithdraw', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too short`, function () {
     withdraw.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
@@ -213,12 +206,10 @@ describe('AMMWithdraw', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too long`, function () {
     withdraw.Asset = {
-      mpt_issuance_id:
-        '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Asset2 = {
-      mpt_issuance_id:
-        '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
     }
     withdraw.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),

--- a/packages/xrpl/test/models/AMMWithdraw.test.ts
+++ b/packages/xrpl/test/models/AMMWithdraw.test.ts
@@ -5,6 +5,8 @@ import { validateAMMWithdraw } from '../../src/models/transactions/AMMWithdraw'
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_1,
+  MPT_ISSUANCE_ID_2,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -159,13 +161,13 @@ describe('AMMWithdraw', function () {
   // MPT-related tests
   it(`verifies valid AMMWithdraw with single MPT asset`, function () {
     withdraw.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     withdraw.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     withdraw.Amount = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
       value: '50',
     }
     withdraw.Flags |= AMMWithdrawFlags.tfSingleAsset
@@ -174,10 +176,10 @@ describe('AMMWithdraw', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
     withdraw.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     withdraw.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     withdraw.Amount = {
       mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
@@ -190,10 +192,10 @@ describe('AMMWithdraw', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too short`, function () {
     withdraw.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     withdraw.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     withdraw.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
@@ -206,10 +208,10 @@ describe('AMMWithdraw', function () {
 
   it(`throws w/ MPT Amount mpt_issuance_id too long`, function () {
     withdraw.Asset = {
-      mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     withdraw.Asset2 = {
-      mpt_issuance_id: '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506',
+      mpt_issuance_id: MPT_ISSUANCE_ID_2,
     }
     withdraw.Amount = {
       mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),

--- a/packages/xrpl/test/models/AMMWithdraw.test.ts
+++ b/packages/xrpl/test/models/AMMWithdraw.test.ts
@@ -221,16 +221,4 @@ describe('AMMWithdraw', function () {
     const errorMessage = 'AMMWithdraw: Amount must be an Amount'
     assertInvalid(withdraw, errorMessage)
   })
-
-  it(`throws w/ MPT Asset mpt_issuance_id contains non-hex characters`, function () {
-    withdraw.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
-    withdraw.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
-    assertInvalid(withdraw, 'AMMWithdraw: Asset must be a Currency')
-  })
-
-  it(`throws w/ MPT Asset mpt_issuance_id wrong length`, function () {
-    withdraw.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
-    withdraw.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
-    assertInvalid(withdraw, 'AMMWithdraw: Asset must be a Currency')
-  })
 })

--- a/packages/xrpl/test/models/AMMWithdraw.test.ts
+++ b/packages/xrpl/test/models/AMMWithdraw.test.ts
@@ -221,4 +221,16 @@ describe('AMMWithdraw', function () {
     const errorMessage = 'AMMWithdraw: Amount must be an Amount'
     assertInvalid(withdraw, errorMessage)
   })
+
+  it(`throws w/ MPT Asset mpt_issuance_id contains non-hex characters`, function () {
+    withdraw.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
+    withdraw.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
+    assertInvalid(withdraw, 'AMMWithdraw: Asset must be a Currency')
+  })
+
+  it(`throws w/ MPT Asset mpt_issuance_id wrong length`, function () {
+    withdraw.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
+    withdraw.Asset2 = { mpt_issuance_id: MPT_ISSUANCE_ID_2 }
+    assertInvalid(withdraw, 'AMMWithdraw: Asset must be a Currency')
+  })
 })

--- a/packages/xrpl/test/models/checkCash.test.ts
+++ b/packages/xrpl/test/models/checkCash.test.ts
@@ -1,5 +1,9 @@
 import { validateCheckCash } from '../../src/models/transactions/checkCash'
-import { assertTxIsValid, assertTxValidationError } from '../testUtils'
+import {
+  assertTxIsValid,
+  assertTxValidationError,
+  MPTID_LENGTH,
+} from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateCheckCash)
 const assertInvalid = (tx: any, message: string): void =>
@@ -73,5 +77,71 @@ describe('CheckCash', function () {
     } as any
 
     assertInvalid(invalidDeliverMin, 'CheckCash: invalid DeliverMin')
+  })
+
+  // MPT-related tests
+  it(`verifies valid CheckCash with MPT Amount`, function () {
+    const validCheckCash = {
+      Account: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      TransactionType: 'CheckCash',
+      Amount: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        value: '50',
+      },
+      CheckID:
+        '838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334',
+      Fee: '12',
+    } as any
+
+    assertValid(validCheckCash)
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id contains non-hex characters`, function () {
+    const invalidCheckCash = {
+      Account: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      TransactionType: 'CheckCash',
+      Amount: {
+        mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
+        value: '50',
+      },
+      CheckID:
+        '838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334',
+      Fee: '12',
+    } as any
+
+    assertInvalid(invalidCheckCash, 'CheckCash: invalid Amount')
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id too short`, function () {
+    const invalidCheckCash = {
+      Account: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      TransactionType: 'CheckCash',
+      Amount: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
+        value: '50',
+      },
+      CheckID:
+        '838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334',
+      Fee: '12',
+    } as any
+
+    assertInvalid(invalidCheckCash, 'CheckCash: invalid Amount')
+  })
+
+  it(`throws w/ MPT Amount mpt_issuance_id too long`, function () {
+    const invalidCheckCash = {
+      Account: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      TransactionType: 'CheckCash',
+      Amount: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),
+        value: '50',
+      },
+      CheckID:
+        '838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334',
+      Fee: '12',
+    } as any
+
+    assertInvalid(invalidCheckCash, 'CheckCash: invalid Amount')
   })
 })

--- a/packages/xrpl/test/models/checkCash.test.ts
+++ b/packages/xrpl/test/models/checkCash.test.ts
@@ -2,6 +2,7 @@ import { validateCheckCash } from '../../src/models/transactions/checkCash'
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_1,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -85,7 +86,7 @@ describe('CheckCash', function () {
       Account: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
       TransactionType: 'CheckCash',
       Amount: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
         value: '50',
       },
       CheckID:

--- a/packages/xrpl/test/models/checkCash.test.ts
+++ b/packages/xrpl/test/models/checkCash.test.ts
@@ -85,8 +85,7 @@ describe('CheckCash', function () {
       Account: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
       TransactionType: 'CheckCash',
       Amount: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
         value: '50',
       },
       CheckID:

--- a/packages/xrpl/test/models/checkCreate.test.ts
+++ b/packages/xrpl/test/models/checkCreate.test.ts
@@ -1,5 +1,9 @@
 import { validateCheckCreate } from '../../src/models/transactions/checkCreate'
-import { assertTxIsValid, assertTxValidationError } from '../testUtils'
+import {
+  assertTxIsValid,
+  assertTxValidationError,
+  MPTID_LENGTH,
+} from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateCheckCreate)
 const assertInvalid = (tx: any, message: string): void =>
@@ -107,5 +111,87 @@ describe('CheckCreate', function () {
     } as any
 
     assertInvalid(invalidInvoiceID, 'CheckCreate: invalid InvoiceID')
+  })
+
+  // MPT-related tests
+  it(`verifies valid CheckCreate with MPT SendMax`, function () {
+    const validCheck = {
+      TransactionType: 'CheckCreate',
+      Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
+      Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      SendMax: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        value: '50',
+      },
+      Fee: '12',
+    } as any
+
+    assertValid(validCheck)
+  })
+
+  it(`verifies valid CheckCreate with MPT SendMax and optional fields`, function () {
+    const validCheck = {
+      TransactionType: 'CheckCreate',
+      Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
+      Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      SendMax: {
+        mpt_issuance_id:
+          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        value: '50',
+      },
+      DestinationTag: 1,
+      Expiration: 970113521,
+      InvoiceID:
+        '6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B',
+      Fee: '12',
+    } as any
+
+    assertValid(validCheck)
+  })
+
+  it(`throws w/ MPT SendMax mpt_issuance_id contains non-hex characters`, function () {
+    const invalidCheck = {
+      TransactionType: 'CheckCreate',
+      Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
+      Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      SendMax: {
+        mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
+        value: '50',
+      },
+      Fee: '12',
+    } as any
+
+    assertInvalid(invalidCheck, 'CheckCreate: invalid SendMax')
+  })
+
+  it(`throws w/ MPT SendMax mpt_issuance_id too short`, function () {
+    const invalidCheck = {
+      TransactionType: 'CheckCreate',
+      Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
+      Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      SendMax: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
+        value: '50',
+      },
+      Fee: '12',
+    } as any
+
+    assertInvalid(invalidCheck, 'CheckCreate: invalid SendMax')
+  })
+
+  it(`throws w/ MPT SendMax mpt_issuance_id too long`, function () {
+    const invalidCheck = {
+      TransactionType: 'CheckCreate',
+      Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
+      Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
+      SendMax: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),
+        value: '50',
+      },
+      Fee: '12',
+    } as any
+
+    assertInvalid(invalidCheck, 'CheckCreate: invalid SendMax')
   })
 })

--- a/packages/xrpl/test/models/checkCreate.test.ts
+++ b/packages/xrpl/test/models/checkCreate.test.ts
@@ -120,8 +120,7 @@ describe('CheckCreate', function () {
       Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
       Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
       SendMax: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
         value: '50',
       },
       Fee: '12',
@@ -136,8 +135,7 @@ describe('CheckCreate', function () {
       Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
       Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
       SendMax: {
-        mpt_issuance_id:
-          '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
         value: '50',
       },
       DestinationTag: 1,

--- a/packages/xrpl/test/models/checkCreate.test.ts
+++ b/packages/xrpl/test/models/checkCreate.test.ts
@@ -2,6 +2,7 @@ import { validateCheckCreate } from '../../src/models/transactions/checkCreate'
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_1,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -120,7 +121,7 @@ describe('CheckCreate', function () {
       Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
       Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
       SendMax: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
         value: '50',
       },
       Fee: '12',
@@ -135,7 +136,7 @@ describe('CheckCreate', function () {
       Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
       Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',
       SendMax: {
-        mpt_issuance_id: '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
         value: '50',
       },
       DestinationTag: 1,

--- a/packages/xrpl/test/models/common.test.ts
+++ b/packages/xrpl/test/models/common.test.ts
@@ -1,0 +1,20 @@
+import { isCurrency } from '../../src/models/transactions/common'
+import { MPTID_LENGTH } from '../testUtils'
+
+describe('isCurrency', function () {
+  it('rejects malformed MPT mpt_issuance_id (non-hex or wrong length)', function () {
+    // wrong length
+    expect(isCurrency({ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) })).toBe(
+      false,
+    )
+    expect(isCurrency({ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1) })).toBe(
+      false,
+    )
+    // correct length but contains non-hex characters
+    expect(isCurrency({ mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) })).toBe(
+      false,
+    )
+    // canonical hex form passes
+    expect(isCurrency({ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH) })).toBe(true)
+  })
+})

--- a/packages/xrpl/test/models/offerCreate.test.ts
+++ b/packages/xrpl/test/models/offerCreate.test.ts
@@ -300,8 +300,7 @@ describe('OfferCreate', function () {
         value: '43.11584856965009',
       },
       TakerPays: {
-        mpt_issuance_id:
-          '000004C463C52827307480341125DA0577DEFC38405BABCD',
+        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405BABCD',
         value: '30',
       },
       TransactionType: 'OfferCreate',
@@ -314,8 +313,7 @@ describe('OfferCreate', function () {
     const offerTx = {
       Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
       TakerGets: {
-        mpt_issuance_id:
-          '000004C463C52827307480341125DA0577DEFC38405B0E3E',
+        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405B0E3E',
         value: '100',
       },
       TakerPays: '12928290425',
@@ -329,13 +327,11 @@ describe('OfferCreate', function () {
     const offerTx = {
       Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
       TakerGets: {
-        mpt_issuance_id:
-          '000004C463C52827307480341125DA0577DEFC38405B0E3E',
+        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405B0E3E',
         value: '100',
       },
       TakerPays: {
-        mpt_issuance_id:
-          '000004C463C52827307480341125DA0577DEFC38405BABCD',
+        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405BABCD',
         value: '30',
       },
       TransactionType: 'OfferCreate',

--- a/packages/xrpl/test/models/offerCreate.test.ts
+++ b/packages/xrpl/test/models/offerCreate.test.ts
@@ -5,6 +5,8 @@ import {
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_3,
+  MPT_ISSUANCE_ID_4,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -300,7 +302,7 @@ describe('OfferCreate', function () {
         value: '43.11584856965009',
       },
       TakerPays: {
-        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405BABCD',
+        mpt_issuance_id: MPT_ISSUANCE_ID_4,
         value: '30',
       },
       TransactionType: 'OfferCreate',
@@ -313,7 +315,7 @@ describe('OfferCreate', function () {
     const offerTx = {
       Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
       TakerGets: {
-        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405B0E3E',
+        mpt_issuance_id: MPT_ISSUANCE_ID_3,
         value: '100',
       },
       TakerPays: '12928290425',
@@ -327,11 +329,11 @@ describe('OfferCreate', function () {
     const offerTx = {
       Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
       TakerGets: {
-        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405B0E3E',
+        mpt_issuance_id: MPT_ISSUANCE_ID_3,
         value: '100',
       },
       TakerPays: {
-        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405BABCD',
+        mpt_issuance_id: MPT_ISSUANCE_ID_4,
         value: '30',
       },
       TransactionType: 'OfferCreate',

--- a/packages/xrpl/test/models/offerCreate.test.ts
+++ b/packages/xrpl/test/models/offerCreate.test.ts
@@ -2,7 +2,11 @@ import {
   OfferCreateFlags,
   validateOfferCreate,
 } from '../../src/models/transactions/offerCreate'
-import { assertTxIsValid, assertTxValidationError } from '../testUtils'
+import {
+  assertTxIsValid,
+  assertTxValidationError,
+  MPTID_LENGTH,
+} from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateOfferCreate)
 const assertInvalid = (tx: any, message: string): void =>
@@ -281,6 +285,102 @@ describe('OfferCreate', function () {
       TransactionType: 'OfferCreate',
       TxnSignature:
         '3045022100D874CDDD6BB24ED66E83B1D3574D3ECAC753A78F26DB7EBA89EAB8E7D72B95F802207C8CCD6CEA64E4AE2014E59EE9654E02CA8F03FE7FCE0539E958EAE182234D91',
+    } as any
+
+    assertInvalid(offerTx, 'OfferCreate: invalid TakerGets')
+  })
+
+  // MPT-related tests
+  it(`verifies valid OfferCreate with MPT TakerPays`, function () {
+    const offerTx = {
+      Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+      TakerGets: {
+        currency: 'DSH',
+        issuer: 'rcXY84C4g14iFp6taFXjjQGVeHqSCh9RX',
+        value: '43.11584856965009',
+      },
+      TakerPays: {
+        mpt_issuance_id:
+          '000004C463C52827307480341125DA0577DEFC38405BABCD',
+        value: '30',
+      },
+      TransactionType: 'OfferCreate',
+    } as any
+
+    assertValid(offerTx)
+  })
+
+  it(`verifies valid OfferCreate with MPT TakerGets`, function () {
+    const offerTx = {
+      Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+      TakerGets: {
+        mpt_issuance_id:
+          '000004C463C52827307480341125DA0577DEFC38405B0E3E',
+        value: '100',
+      },
+      TakerPays: '12928290425',
+      TransactionType: 'OfferCreate',
+    } as any
+
+    assertValid(offerTx)
+  })
+
+  it(`verifies valid OfferCreate with MPT on both sides`, function () {
+    const offerTx = {
+      Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+      TakerGets: {
+        mpt_issuance_id:
+          '000004C463C52827307480341125DA0577DEFC38405B0E3E',
+        value: '100',
+      },
+      TakerPays: {
+        mpt_issuance_id:
+          '000004C463C52827307480341125DA0577DEFC38405BABCD',
+        value: '30',
+      },
+      TransactionType: 'OfferCreate',
+    } as any
+
+    assertValid(offerTx)
+  })
+
+  it(`throws w/ MPT TakerGets mpt_issuance_id contains non-hex characters`, function () {
+    const offerTx = {
+      Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+      TakerGets: {
+        mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH),
+        value: '100',
+      },
+      TakerPays: '12928290425',
+      TransactionType: 'OfferCreate',
+    } as any
+
+    assertInvalid(offerTx, 'OfferCreate: invalid TakerGets')
+  })
+
+  it(`throws w/ MPT TakerGets mpt_issuance_id too short`, function () {
+    const offerTx = {
+      Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+      TakerGets: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1),
+        value: '100',
+      },
+      TakerPays: '12928290425',
+      TransactionType: 'OfferCreate',
+    } as any
+
+    assertInvalid(offerTx, 'OfferCreate: invalid TakerGets')
+  })
+
+  it(`throws w/ MPT TakerGets mpt_issuance_id too long`, function () {
+    const offerTx = {
+      Account: 'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+      TakerGets: {
+        mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1),
+        value: '100',
+      },
+      TakerPays: '12928290425',
+      TransactionType: 'OfferCreate',
     } as any
 
     assertInvalid(offerTx, 'OfferCreate: invalid TakerGets')

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -5,6 +5,7 @@ import { validatePayment } from '../../src/models/transactions/payment'
 import {
   assertTxIsValid,
   assertTxValidationError,
+  MPT_ISSUANCE_ID_3,
   MPTID_LENGTH,
 } from '../testUtils'
 
@@ -201,7 +202,7 @@ describe('Payment', function () {
       TransactionType: 'Payment',
       Account: 'rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo',
       Amount: {
-        mpt_issuance_id: '000004C463C52827307480341125DA0577DEFC38405B0E3E',
+        mpt_issuance_id: MPT_ISSUANCE_ID_3,
         value: '10',
       },
       Destination: 'rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy',

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -290,4 +290,28 @@ describe('Payment', function () {
     payment.Paths = [[{ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1) }]]
     assertInvalid(payment, 'PaymentTransaction: invalid Paths')
   })
+
+  it(`throws when PathStep has both account and mpt_issuance_id`, function () {
+    payment.Paths = [
+      [
+        {
+          account: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
+          mpt_issuance_id: 'A'.repeat(MPTID_LENGTH),
+        },
+      ],
+    ]
+    assertInvalid(payment, 'PaymentTransaction: invalid Paths')
+  })
+
+  it(`throws when PathStep has both currency and mpt_issuance_id`, function () {
+    payment.Paths = [
+      [
+        {
+          currency: 'USD',
+          mpt_issuance_id: 'A'.repeat(MPTID_LENGTH),
+        },
+      ],
+    ]
+    assertInvalid(payment, 'PaymentTransaction: invalid Paths')
+  })
 })

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -263,9 +263,7 @@ describe('Payment', function () {
   })
 
   it(`verifies valid Payment with MPT PathStep`, function () {
-    payment.Paths = [
-      [{ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH) }],
-    ]
+    payment.Paths = [[{ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH) }]]
     assertValid(payment)
   })
 
@@ -278,23 +276,17 @@ describe('Payment', function () {
   })
 
   it(`throws when Paths has MPT PathStep with non-hex mpt_issuance_id`, function () {
-    payment.Paths = [
-      [{ mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }],
-    ]
+    payment.Paths = [[{ mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }]]
     assertInvalid(payment, 'PaymentTransaction: invalid Paths')
   })
 
   it(`throws when Paths has MPT PathStep with too-short mpt_issuance_id`, function () {
-    payment.Paths = [
-      [{ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }],
-    ]
+    payment.Paths = [[{ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }]]
     assertInvalid(payment, 'PaymentTransaction: invalid Paths')
   })
 
   it(`throws when Paths has MPT PathStep with too-long mpt_issuance_id`, function () {
-    payment.Paths = [
-      [{ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1) }],
-    ]
+    payment.Paths = [[{ mpt_issuance_id: 'A'.repeat(MPTID_LENGTH + 1) }]]
     assertInvalid(payment, 'PaymentTransaction: invalid Paths')
   })
 })

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -314,4 +314,16 @@ describe('Payment', function () {
     ]
     assertInvalid(payment, 'PaymentTransaction: invalid Paths')
   })
+
+  it(`throws when PathStep has both issuer and mpt_issuance_id`, function () {
+    payment.Paths = [
+      [
+        {
+          issuer: 'r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ',
+          mpt_issuance_id: 'A'.repeat(MPTID_LENGTH),
+        },
+      ],
+    ]
+    assertInvalid(payment, 'PaymentTransaction: invalid Paths')
+  })
 })

--- a/packages/xrpl/test/models/vaultCreate.test.ts
+++ b/packages/xrpl/test/models/vaultCreate.test.ts
@@ -8,7 +8,12 @@ import {
 } from '../../src/models/transactions'
 import { validateVaultCreate } from '../../src/models/transactions/vaultCreate'
 import { MPT_META_WARNING_HEADER } from '../../src/models/utils/mptokenMetadata'
-import { assertTxIsValid, assertTxValidationError } from '../testUtils'
+import {
+  assertTxIsValid,
+  assertTxValidationError,
+  MPT_ISSUANCE_ID_1,
+  MPTID_LENGTH,
+} from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateVaultCreate)
 const assertInvalid = (tx: any, message: string): void =>
@@ -37,8 +42,7 @@ describe('VaultCreate', function () {
 
   it('verifies MPT/IOU Currency as Asset', function () {
     tx.Asset = {
-      mpt_issuance_id:
-        '983F536DBB46D5BBF43A0B5890576874EE1CF48CE31CA508A529EC17CD1A90EF',
+      mpt_issuance_id: MPT_ISSUANCE_ID_1,
     }
     assertValid(tx)
 
@@ -47,6 +51,16 @@ describe('VaultCreate', function () {
       issuer: 'rfmDuhDyLGgx94qiwf3YF8BUV5j6KSvE8',
     }
     assertValid(tx)
+  })
+
+  it('throws w/ MPT Asset mpt_issuance_id contains non-hex characters', function () {
+    tx.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
+    assertInvalid(tx, 'VaultCreate: invalid field Asset')
+  })
+
+  it('throws w/ MPT Asset mpt_issuance_id wrong length', function () {
+    tx.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
+    assertInvalid(tx, 'VaultCreate: invalid field Asset')
   })
 
   it('throws w/ missing Asset', function () {
@@ -120,8 +134,7 @@ describe('VaultCreate', function () {
 
     it('throws w/ Scale provided for MPT asset', function () {
       tx.Asset = {
-        mpt_issuance_id:
-          '983F536DBB46D5BBF43A0B5890576874EE1CF48CE31CA508A529EC17CD1A90EF',
+        mpt_issuance_id: MPT_ISSUANCE_ID_1,
       }
       tx.Scale = 5
       assertInvalid(

--- a/packages/xrpl/test/models/vaultCreate.test.ts
+++ b/packages/xrpl/test/models/vaultCreate.test.ts
@@ -12,7 +12,6 @@ import {
   assertTxIsValid,
   assertTxValidationError,
   MPT_ISSUANCE_ID_1,
-  MPTID_LENGTH,
 } from '../testUtils'
 
 const assertValid = (tx: any): void => assertTxIsValid(tx, validateVaultCreate)
@@ -51,16 +50,6 @@ describe('VaultCreate', function () {
       issuer: 'rfmDuhDyLGgx94qiwf3YF8BUV5j6KSvE8',
     }
     assertValid(tx)
-  })
-
-  it('throws w/ MPT Asset mpt_issuance_id contains non-hex characters', function () {
-    tx.Asset = { mpt_issuance_id: 'Z'.repeat(MPTID_LENGTH) }
-    assertInvalid(tx, 'VaultCreate: invalid field Asset')
-  })
-
-  it('throws w/ MPT Asset mpt_issuance_id wrong length', function () {
-    tx.Asset = { mpt_issuance_id: 'A'.repeat(MPTID_LENGTH - 1) }
-    assertInvalid(tx, 'VaultCreate: invalid field Asset')
   })
 
   it('throws w/ missing Asset', function () {

--- a/packages/xrpl/test/testUtils.ts
+++ b/packages/xrpl/test/testUtils.ts
@@ -15,6 +15,11 @@ import {
 import addresses from './fixtures/addresses.json'
 
 /**
+ * The expected hex character length of an MPT Issuance ID (Hash192 = 24 bytes = 48 hex chars).
+ */
+export const MPTID_LENGTH = 48
+
+/**
  * Setup to run tests on both classic addresses and X-addresses.
  */
 export const addressTests = [

--- a/packages/xrpl/test/testUtils.ts
+++ b/packages/xrpl/test/testUtils.ts
@@ -19,6 +19,16 @@ import addresses from './fixtures/addresses.json'
  */
 export const MPTID_LENGTH = 48
 
+// Sample MPTID values used in unit tests
+export const MPT_ISSUANCE_ID_1 =
+  '00000001A407AF5856CECE4281FED12B7B179B49A4AEF506'
+export const MPT_ISSUANCE_ID_2 =
+  '00000002A407AF5856CECE4281FED12B7B179B49A4AEF506'
+export const MPT_ISSUANCE_ID_3 =
+  '000004C463C52827307480341125DA0577DEFC38405B0E3E'
+export const MPT_ISSUANCE_ID_4 =
+  '000004C463C52827307480341125DA0577DEFC38405BABCD'
+
 /**
  * Setup to run tests on both classic addresses and X-addresses.
  */


### PR DESCRIPTION
## High Level Overview of Change

This PR implements the following XLS specification requirements for the xrpl-py client library: https://github.com/XRPLF/XRPL-Standards/discussions/231

The reference cpp implementation for rippled can be found here: https://github.com/XRPLF/rippled/pull/5285

This PR includes updates to the transaction and request models to accommodate MPTAmount, integration and unit tests for all the affected transaction-types and RPCs.

The PR also updates the binary-codec of the `PathSet` rippled type. The amendment allows for `mpt_issuance_id` inputs in the Path specification.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->



<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Appropriate unit and integration tests have been added.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
