### PR TITLE
feat: Enhance parseTransactionFlags with string overload and includeAll option (#1903)

### DIFF
--- a/packages/xrpl/src/models/utils/flags.ts
+++ b/packages/xrpl/src/models/utils/flags.ts
@@ -143,6 +143,14 @@ export function convertTxFlagsToNumber(tx: Transaction): number {
 }
 
 /**
+ * Options for {@link parseTransactionFlags}.
+ */
+export interface ParseTransactionFlagsOptions {
+  /** Set to `true` to include disabled flags (as `false`) in the result. */
+  includeAll?: boolean
+}
+
+/**
  * Convert a Transaction flags property into a map for easy interpretation.
  *
  * Can be called with a Transaction object or with a transaction type string
@@ -174,19 +182,31 @@ export function convertTxFlagsToNumber(tx: Transaction): number {
  * @returns A map of flag names to booleans.
  */
 export function parseTransactionFlags(
+  tx: Transaction,
+  options?: ParseTransactionFlagsOptions,
+): Record<string, boolean>
+export function parseTransactionFlags(
+  txType: string,
+  flagsNum: number,
+  options?: ParseTransactionFlagsOptions,
+): Record<string, boolean>
+export function parseTransactionFlags(
   txOrType: Transaction | string,
-  flagsNum?: number,
-  options?: { includeAll?: boolean },
+  flagsNumOrOptions?: number | ParseTransactionFlagsOptions,
+  maybeOptions?: ParseTransactionFlagsOptions,
 ): Record<string, boolean> {
   let flags: number
   let transactionType: string
+  let options: ParseTransactionFlagsOptions | undefined
 
   if (typeof txOrType === 'string') {
     transactionType = txOrType
-    flags = flagsNum ?? 0
+    flags = (flagsNumOrOptions as number) ?? 0
+    options = maybeOptions
   } else {
     transactionType = txOrType.TransactionType
     flags = convertTxFlagsToNumber(txOrType)
+    options = flagsNumOrOptions as ParseTransactionFlagsOptions | undefined
   }
 
   const includeAll = options?.includeAll ?? false

--- a/packages/xrpl/test/models/utils.test.ts
+++ b/packages/xrpl/test/models/utils.test.ts
@@ -441,7 +441,7 @@ describe('Models Utils', function () {
         Flags: PaymentChannelClaimFlags.tfRenew,
       }
 
-      const flagsMap = parseTransactionFlags(tx, undefined, {
+      const flagsMap = parseTransactionFlags(tx, {
         includeAll: true,
       })
       assert.deepEqual(flagsMap, {


### PR DESCRIPTION
## Summary

Enhances the existing `parseTransactionFlags` utility to address the usability gaps described in #1903.

### Changes

1. **String overload**: Accept `(txType: string, flags: number)` directly, so users working with raw API responses can parse flags without constructing a full `Transaction` object:

```typescript
import { parseTransactionFlags } from 'xrpl'

// Parse flags from a raw API response
parseTransactionFlags('OfferCreate', 2148007936)
// => { tfSell: true, tfFullyCanonicalSig: true }
```

2. **`includeAll` option**: Optionally include *all* possible flags for a transaction type (with `false` for disabled ones):

```typescript
parseTransactionFlags('Payment', 0x00020000, { includeAll: true })
// => { tfNoRippleDirect: false, tfPartialPayment: true, tfLimitQuality: false, tfInnerBatchTxn: false }
```

3. **Improved typing**: Return type changed from `object` to `Record<string, boolean>`.

4. **Missing flag mappings**: Added `EnableAmendment` and `LoanSet` to the `txToFlag` map.

### Backward Compatibility

Fully backward compatible — the existing `parseTransactionFlags(tx: Transaction)` signature continues to work identically.

### Tests

Added 7 new test cases covering:
- String overload with single and combined flags
- Zero flags edge case
- `includeAll` option with both string and Transaction overloads
- Unknown transaction types (global flags only)
- String overload with global flags

All existing tests continue to pass.

Closes #1903