### PR TITLE
fix: add new fields to `server_definitions`

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 
+### Added
+* Add new fields to `ServerDefinitionsResponse`: `ACCOUNT_SET_FLAGS`, `LEDGER_ENTRY_FLAGS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, and `TRANSACTION_FORMATS`, reflecting new sections returned by `server_definitions` in rippled.
+
 ## 4.6.0 (2026-02-12)
 
 ### Added

--- a/packages/xrpl/src/models/methods/serverDefinitions.ts
+++ b/packages/xrpl/src/models/methods/serverDefinitions.ts
@@ -52,7 +52,10 @@ export interface ServerDefinitionsResponse extends BaseResponse {
         /** Maps ledger entry type names to their flags and flag values. */
         LEDGER_ENTRY_FLAGS: Record<string, Record<string, number>>
 
-        /** Describes the fields and their optionality for each ledger entry type, including common fields shared across all ledger entries. */
+        /**
+         * Describes the fields and their optionality for each ledger entry type,
+         * including common fields shared across all ledger entries.
+         */
         LEDGER_ENTRY_FORMATS: Record<
           string,
           Array<{ name: string; optionality: number }>
@@ -61,7 +64,10 @@ export interface ServerDefinitionsResponse extends BaseResponse {
         /** Maps transaction type names to their supported flags and flag values. */
         TRANSACTION_FLAGS: Record<string, Record<string, number>>
 
-        /** Describes the fields and their optionality for each transaction type, including common fields shared across all transactions. */
+        /**
+         * Describes the fields and their optionality for each transaction type,
+         * including common fields shared across all transactions.
+         */
         TRANSACTION_FORMATS: Record<
           string,
           Array<{ name: string; optionality: number }>

--- a/packages/xrpl/test/integration/requests/serverDefinitions.test.ts
+++ b/packages/xrpl/test/integration/requests/serverDefinitions.test.ts
@@ -11,6 +11,72 @@ import {
 // how long before each test case times out
 const TIMEOUT = 20000
 
+function assertStringNumberMap(map: Record<string, number>): void {
+  assert.typeOf(map, 'object')
+  Object.entries(map).forEach(([key, value]) => {
+    assert.typeOf(key, 'string')
+    assert.typeOf(value, 'number')
+  })
+}
+
+function assertFields(
+  fields: Array<
+    [
+      string,
+      {
+        nth: number
+        isVLEncoded: boolean
+        isSerialized: boolean
+        isSigningField: boolean
+        type: string
+      },
+    ]
+  >,
+): void {
+  assert.typeOf(fields, 'array')
+  for (const field of fields) {
+    assert.typeOf(field[0], 'string')
+    assert.hasAllKeys(field[1], [
+      'nth',
+      'isVLEncoded',
+      'isSerialized',
+      'isSigningField',
+      'type',
+    ])
+    assert.typeOf(field[1].nth, 'number')
+    assert.typeOf(field[1].isVLEncoded, 'boolean')
+    assert.typeOf(field[1].isSerialized, 'boolean')
+    assert.typeOf(field[1].isSigningField, 'boolean')
+    assert.typeOf(field[1].type, 'string')
+  }
+}
+
+function assertFlagsMap(map: Record<string, Record<string, number>>): void {
+  assert.typeOf(map, 'object')
+  Object.entries(map).forEach(([name, flags]) => {
+    assert.typeOf(name, 'string')
+    assert.typeOf(flags, 'object')
+    Object.entries(flags).forEach(([flagName, flagValue]) => {
+      assert.typeOf(flagName, 'string')
+      assert.typeOf(flagValue, 'number')
+    })
+  })
+}
+
+function assertFormatsMap(
+  map: Record<string, Array<{ name: string; optionality: number }>>,
+): void {
+  assert.typeOf(map, 'object')
+  Object.entries(map).forEach(([name, fields]) => {
+    assert.typeOf(name, 'string')
+    assert.isArray(fields)
+    for (const field of fields) {
+      assert.typeOf(field.name, 'string')
+      assert.typeOf(field.optionality, 'number')
+    }
+  })
+}
+
 describe('server_definitions', function () {
   let testContext: XrplIntegrationTestContext
 
@@ -45,93 +111,17 @@ describe('server_definitions', function () {
       ])
 
       assert.typeOf(result.hash, 'string')
+      assertFields(result.FIELDS!)
+      assertStringNumberMap(result.LEDGER_ENTRY_TYPES!)
+      assertStringNumberMap(result.TRANSACTION_RESULTS!)
+      assertStringNumberMap(result.TRANSACTION_TYPES!)
+      assertStringNumberMap(result.TYPES!)
+      assertStringNumberMap(result.ACCOUNT_SET_FLAGS!)
 
-      assert.typeOf(result.FIELDS, 'array')
-      for (const field of result.FIELDS!) {
-        assert.typeOf(field[0], 'string')
-        assert.hasAllKeys(field[1], [
-          'nth',
-          'isVLEncoded',
-          'isSerialized',
-          'isSigningField',
-          'type',
-        ])
-        assert.typeOf(field[1].nth, 'number')
-        assert.typeOf(field[1].isVLEncoded, 'boolean')
-        assert.typeOf(field[1].isSerialized, 'boolean')
-        assert.typeOf(field[1].isSigningField, 'boolean')
-        assert.typeOf(field[1].type, 'string')
-      }
-
-      assert.typeOf(result.LEDGER_ENTRY_TYPES, 'object')
-      Object.entries(result.LEDGER_ENTRY_TYPES!).forEach(([key, value]) => {
-        assert.typeOf(key, 'string')
-        assert.typeOf(value, 'number')
-      })
-
-      assert.typeOf(result.TRANSACTION_RESULTS, 'object')
-      Object.entries(result.TRANSACTION_RESULTS!).forEach(([key, value]) => {
-        assert.typeOf(key, 'string')
-        assert.typeOf(value, 'number')
-      })
-
-      assert.typeOf(result.TRANSACTION_TYPES, 'object')
-      Object.entries(result.TRANSACTION_TYPES!).forEach(([key, value]) => {
-        assert.typeOf(key, 'string')
-        assert.typeOf(value, 'number')
-      })
-
-      assert.typeOf(result.TYPES, 'object')
-      Object.entries(result.TYPES!).forEach(([key, value]) => {
-        assert.typeOf(key, 'string')
-        assert.typeOf(value, 'number')
-      })
-
-      assert.typeOf(result.ACCOUNT_SET_FLAGS, 'object')
-      Object.entries(result.ACCOUNT_SET_FLAGS!).forEach(([name, value]) => {
-        assert.typeOf(name, 'string')
-        assert.typeOf(value, 'number')
-      })
-
-      assert.typeOf(result.LEDGER_ENTRY_FLAGS, 'object')
-      Object.entries(result.LEDGER_ENTRY_FLAGS!).forEach(([name, flags]) => {
-        assert.typeOf(name, 'string')
-        assert.typeOf(flags, 'object')
-        Object.entries(flags).forEach(([flagName, flagValue]) => {
-          assert.typeOf(flagName, 'string')
-          assert.typeOf(flagValue, 'number')
-        })
-      })
-
-      assert.typeOf(result.LEDGER_ENTRY_FORMATS, 'object')
-      Object.entries(result.LEDGER_ENTRY_FORMATS!).forEach(([name, fields]) => {
-        assert.typeOf(name, 'string')
-        assert.isArray(fields)
-        for (const field of fields) {
-          assert.typeOf(field.name, 'string')
-          assert.typeOf(field.optionality, 'number')
-        }
-      })
-
-      assert.typeOf(result.TRANSACTION_FLAGS, 'object')
-      Object.entries(result.TRANSACTION_FLAGS!).forEach(([name, flags]) => {
-        assert.typeOf(name, 'string')
-        assert.typeOf(flags, 'object')
-        Object.entries(flags).forEach(([flagName, flagValue]) => {
-          assert.typeOf(flagName, 'string')
-          assert.typeOf(flagValue, 'number')
-        })
-      })
-
-      assert.typeOf(result.TRANSACTION_FORMATS, 'object')
-      Object.entries(result.TRANSACTION_FORMATS!).forEach(([name, fields]) => {
-        assert.typeOf(name, 'string')
-        assert.isArray(fields)
-        for (const field of fields) {
-          assert.typeOf(field.name, 'string')
-          assert.typeOf(field.optionality, 'number')
-        }
-      })
+      assertFlagsMap(result.LEDGER_ENTRY_FLAGS!)
+      assertFormatsMap(result.LEDGER_ENTRY_FORMATS!)
+      assertFlagsMap(result.TRANSACTION_FLAGS!)
+      assertFormatsMap(result.TRANSACTION_FORMATS!)
     },
     TIMEOUT,
   )


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
Next rippled release will introduce new fields to `server_definitions` (already merged to `develop`):
- `TRANSACTION_FORMATS`: Describes the fields and their optionality for each transaction type, including common fields shared across all transactions.
- `LEDGER_ENTRY_FORMATS`: Describes the fields and their optionality for each ledger entry type, including common fields shared across all ledger entries.
- `TRANSACTION_FLAGS`: Maps transaction type names to their supported flags and flag values.
- `LEDGER_ENTRY_FLAGS`: Maps ledger entry type names to their flags and flag values.
- `ACCOUNT_SET_FLAGS`: Maps AccountSet flag names (asf flags) to their numeric values.
  
  See [feat: Add Formats and Flags to server_definitions](https://github.com/XRPLF/rippled/pull/6321)
  
  This will allow our CI tests to pass.
### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [ ] No, this change does not impact library users

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->
All CI tests pass.

## Future Tasks
<!--
For future tasks related to PR.
-->
Update our scripts to fetch this data from rippled codebase into `definitions.json`
