### PR TITLE
feat: add type narrowing for LedgerEntryRequest based on binary flag

### DIFF
--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -326,164 +326,164 @@ export type RequestResponseMap<
 > = T extends AccountChannelsRequest
   ? AccountChannelsResponse
   : T extends AccountCurrenciesRequest
-    ? AccountCurrenciesResponse
-    : T extends AccountInfoRequest
-      ? AccountInfoVersionResponseMap<Version>
-      : T extends AccountLinesRequest
-        ? AccountLinesResponse
-        : T extends AccountNFTsRequest
-          ? AccountNFTsResponse
-          : T extends AccountObjectsRequest
-            ? AccountObjectsResponse
-            : T extends AccountOffersRequest
-              ? AccountOffersResponse
-              : T extends AccountTxRequest
-                ? AccountTxVersionResponseMap<Version>
-                : T extends AMMInfoRequest
-                  ? AMMInfoResponse
-                  : T extends GatewayBalancesRequest
-                    ? GatewayBalancesResponse
-                    : T extends GetAggregatePriceRequest
-                      ? GetAggregatePriceResponse
-                      : T extends NoRippleCheckRequest
-                        ? NoRippleCheckResponse
-                        : // NOTE: The order of these LedgerRequest types is important
-                          // to get the proper type matching overrides based on parameters set
-                          // in the request. For example LedgerRequestExpandedTransactionsBinary
-                          // should match LedgerRequestExpandedTransactionsOnly, but not
-                          // LedgerRequestExpandedAccountsOnly. This is because the
-                          // LedgerRequestExpandedTransactionsBinary type is a superset of
-                          // LedgerRequestExpandedTransactionsOnly, but not of the other.
-                          // This is why LedgerRequestExpandedTransactionsBinary is listed
-                          // first in the type list.
-                          //
-                          // Here is an example using real data:
-                          // LedgerRequestExpandedTransactionsBinary = {
-                          //   command: 'ledger',
-                          //   ledger_index: 'validated',
-                          //   expand: true,
-                          //   transactions: true,
-                          //   binary: true,
-                          // }
-                          // LedgerRequestExpandedTransactionsOnly = {
-                          //   command: 'ledger',
-                          //   ledger_index: 'validated',
-                          //   expand: true,
-                          //   transactions: true,
-                          // }
-                          // LedgerRequestExpandedAccountsOnly = {
-                          //   command: 'ledger',
-                          //   ledger_index: 'validated',
-                          //   accounts: true,
-                          //   expand: true,
-                          // }
-                          // LedgerRequest = {
-                          //   command: 'ledger',
-                          //   ledger_index: 'validated',
-                          // }
-                          //
-                          // The type with the most parameters set should be listed first. In this
-                          // case LedgerRequestExpandedTransactionsBinary has the most parameters (`expand`, `transactions`, and `binary`)
-                          // set, so it is listed first. When TypeScript tries to match the type of
-                          // a request to a response, it will try to match the request type to the
-                          // response type in the order they are listed. So, if we have a request
-                          // with the following parameters:
-                          // {
-                          //   command: 'ledger',
-                          //   ledger_index: 'validated',
-                          //   expand: true,
-                          //   transactions: true,
-                          //   binary: true,
-                          // }
-                          // TypeScript will first try to match the request type to
-                          // LedgerRequestExpandedTransactionsBinary, which will succeed. It will
-                          // then try to match the response type to LedgerResponseExpanded, which
-                          // will also succeed. If we had listed LedgerRequestExpandedTransactionsOnly
-                          // first, TypeScript would have tried to match the request type to
-                          // LedgerRequestExpandedTransactionsOnly, which would have succeeded, but
-                          // then we'd get the wrong response type, LedgerResponse, instead of
-                          // LedgerResponseExpanded.
-                          T extends LedgerRequestExpandedTransactionsBinary
-                          ? LedgerVersionResponseMap<Version>
-                          : T extends LedgerRequestExpandedAccountsAndTransactions
-                            ? LedgerResponseExpanded<Version>
-                            : T extends LedgerRequestExpandedTransactionsOnly
-                              ? LedgerResponseExpanded<Version>
-                              : T extends LedgerRequestExpandedAccountsOnly
-                                ? LedgerResponseExpanded<Version>
-                                : T extends LedgerRequest
-                                  ? LedgerVersionResponseMap<Version>
-                                  : T extends LedgerClosedRequest
-                                    ? LedgerClosedResponse
-                                    : T extends LedgerCurrentRequest
-                                      ? LedgerCurrentResponse
-                                      : T extends LedgerDataRequest
-                                        ? LedgerDataResponse
-                                        : T extends LedgerEntryBinaryRequest
-                                          ? LedgerEntryBinaryResponse
-                                          : T extends LedgerEntryJsonRequest
-                                            ? LedgerEntryJsonResponse
-                                            : T extends LedgerEntryRequest
-                                              ? LedgerEntryJsonResponse
-                                              : T extends SimulateBinaryRequest
-                                                ? SimulateBinaryResponse
-                                                : T extends SimulateJsonRequest
-                                                  ? SimulateJsonResponse
-                                                  : T extends SimulateRequest
-                                                    ? SimulateJsonResponse
-                                                    : T extends SubmitRequest
-                                                      ? SubmitResponse
-                                                      : T extends SubmitMultisignedRequest
-                                                        ? SubmitMultisignedVersionResponseMap<Version>
-                                                        : T extends TransactionEntryRequest
-                                                          ? TransactionEntryResponse
-                                                          : T extends TxRequest
-                                                            ? TxVersionResponseMap<Version>
-                                                            : T extends BookOffersRequest
-                                                              ? BookOffersResponse
-                                                              : T extends DepositAuthorizedRequest
-                                                                ? DepositAuthorizedResponse
-                                                                : T extends PathFindRequest
-                                                                  ? PathFindResponse
-                                                                  : T extends RipplePathFindRequest
-                                                                    ? RipplePathFindResponse
-                                                                    : T extends ChannelVerifyRequest
-                                                                      ? ChannelVerifyResponse
-                                                                      : T extends SubscribeRequest
-                                                                        ? SubscribeResponse
-                                                                        : T extends UnsubscribeRequest
-                                                                          ? UnsubscribeResponse
-                                                                          : T extends FeeRequest
-                                                                            ? FeeResponse
-                                                                            : T extends ManifestRequest
-                                                                              ? ManifestResponse
-                                                                              : T extends ServerInfoRequest
-                                                                                ? ServerInfoResponse
-                                                                                : T extends ServerStateRequest
-                                                                                  ? ServerStateResponse
-                                                                                  : T extends ServerDefinitionsRequest
-                                                                                    ? ServerDefinitionsResponse
-                                                                                    : T extends FeatureAllRequest
-                                                                                      ? FeatureAllResponse
-                                                                                      : T extends FeatureOneRequest
-                                                                                        ? FeatureOneResponse
-                                                                                        : T extends PingRequest
-                                                                                          ? PingResponse
-                                                                                          : T extends RandomRequest
-                                                                                            ? RandomResponse
-                                                                                            : T extends NFTBuyOffersRequest
-                                                                                              ? NFTBuyOffersResponse
-                                                                                              : T extends NFTSellOffersRequest
-                                                                                                ? NFTSellOffersResponse
-                                                                                                : T extends NFTInfoRequest
-                                                                                                  ? NFTInfoResponse
-                                                                                                  : T extends NFTsByIssuerRequest
-                                                                                                    ? NFTsByIssuerResponse
-                                                                                                    : T extends NFTHistoryRequest
-                                                                                                      ? NFTHistoryResponse
-                                                                                                      : T extends VaultInfoRequest
-                                                                                                        ? VaultInfoResponse
-                                                                                                        : Response<Version>
+  ? AccountCurrenciesResponse
+  : T extends AccountInfoRequest
+  ? AccountInfoVersionResponseMap<Version>
+  : T extends AccountLinesRequest
+  ? AccountLinesResponse
+  : T extends AccountNFTsRequest
+  ? AccountNFTsResponse
+  : T extends AccountObjectsRequest
+  ? AccountObjectsResponse
+  : T extends AccountOffersRequest
+  ? AccountOffersResponse
+  : T extends AccountTxRequest
+  ? AccountTxVersionResponseMap<Version>
+  : T extends AMMInfoRequest
+  ? AMMInfoResponse
+  : T extends GatewayBalancesRequest
+  ? GatewayBalancesResponse
+  : T extends GetAggregatePriceRequest
+  ? GetAggregatePriceResponse
+  : T extends NoRippleCheckRequest
+  ? NoRippleCheckResponse
+  : // NOTE: The order of these LedgerRequest types is important
+  // to get the proper type matching overrides based on parameters set
+  // in the request. For example LedgerRequestExpandedTransactionsBinary
+  // should match LedgerRequestExpandedTransactionsOnly, but not
+  // LedgerRequestExpandedAccountsOnly. This is because the
+  // LedgerRequestExpandedTransactionsBinary type is a superset of
+  // LedgerRequestExpandedTransactionsOnly, but not of the other.
+  // This is why LedgerRequestExpandedTransactionsBinary is listed
+  // first in the type list.
+  //
+  // Here is an example using real data:
+  // LedgerRequestExpandedTransactionsBinary = {
+  //   command: 'ledger',
+  //   ledger_index: 'validated',
+  //   expand: true,
+  //   transactions: true,
+  //   binary: true,
+  // }
+  // LedgerRequestExpandedTransactionsOnly = {
+  //   command: 'ledger',
+  //   ledger_index: 'validated',
+  //   expand: true,
+  //   transactions: true,
+  // }
+  // LedgerRequestExpandedAccountsOnly = {
+  //   command: 'ledger',
+  //   ledger_index: 'validated',
+  //   accounts: true,
+  //   expand: true,
+  // }
+  // LedgerRequest = {
+  //   command: 'ledger',
+  //   ledger_index: 'validated',
+  // }
+  //
+  // The type with the most parameters set should be listed first. In this
+  // case LedgerRequestExpandedTransactionsBinary has the most parameters (`expand`, `transactions`, and `binary`)
+  // set, so it is listed first. When TypeScript tries to match the type of
+  // a request to a response, it will try to match the request type to the
+  // response type in the order they are listed. So, if we have a request
+  // with the following parameters:
+  // {
+  //   command: 'ledger',
+  //   ledger_index: 'validated',
+  //   expand: true,
+  //   transactions: true,
+  //   binary: true,
+  // }
+  // TypeScript will first try to match the request type to
+  // LedgerRequestExpandedTransactionsBinary, which will succeed. It will
+  // then try to match the response type to LedgerResponseExpanded, which
+  // will also succeed. If we had listed LedgerRequestExpandedTransactionsOnly
+  // first, TypeScript would have tried to match the request type to
+  // LedgerRequestExpandedTransactionsOnly, which would have succeeded, but
+  // then we'd get the wrong response type, LedgerResponse, instead of
+  // LedgerResponseExpanded.
+  T extends LedgerRequestExpandedTransactionsBinary
+  ? LedgerVersionResponseMap<Version>
+  : T extends LedgerRequestExpandedAccountsAndTransactions
+  ? LedgerResponseExpanded<Version>
+  : T extends LedgerRequestExpandedTransactionsOnly
+  ? LedgerResponseExpanded<Version>
+  : T extends LedgerRequestExpandedAccountsOnly
+  ? LedgerResponseExpanded<Version>
+  : T extends LedgerRequest
+  ? LedgerVersionResponseMap<Version>
+  : T extends LedgerClosedRequest
+  ? LedgerClosedResponse
+  : T extends LedgerCurrentRequest
+  ? LedgerCurrentResponse
+  : T extends LedgerDataRequest
+  ? LedgerDataResponse
+  : T extends LedgerEntryBinaryRequest
+  ? LedgerEntryBinaryResponse
+  : T extends LedgerEntryJsonRequest
+  ? LedgerEntryJsonResponse
+  : T extends LedgerEntryRequest
+  ? LedgerEntryJsonResponse
+  : T extends SimulateBinaryRequest
+  ? SimulateBinaryResponse
+  : T extends SimulateJsonRequest
+  ? SimulateJsonResponse
+  : T extends SimulateRequest
+  ? SimulateJsonResponse
+  : T extends SubmitRequest
+  ? SubmitResponse
+  : T extends SubmitMultisignedRequest
+  ? SubmitMultisignedVersionResponseMap<Version>
+  : T extends TransactionEntryRequest
+  ? TransactionEntryResponse
+  : T extends TxRequest
+  ? TxVersionResponseMap<Version>
+  : T extends BookOffersRequest
+  ? BookOffersResponse
+  : T extends DepositAuthorizedRequest
+  ? DepositAuthorizedResponse
+  : T extends PathFindRequest
+  ? PathFindResponse
+  : T extends RipplePathFindRequest
+  ? RipplePathFindResponse
+  : T extends ChannelVerifyRequest
+  ? ChannelVerifyResponse
+  : T extends SubscribeRequest
+  ? SubscribeResponse
+  : T extends UnsubscribeRequest
+  ? UnsubscribeResponse
+  : T extends FeeRequest
+  ? FeeResponse
+  : T extends ManifestRequest
+  ? ManifestResponse
+  : T extends ServerInfoRequest
+  ? ServerInfoResponse
+  : T extends ServerStateRequest
+  ? ServerStateResponse
+  : T extends ServerDefinitionsRequest
+  ? ServerDefinitionsResponse
+  : T extends FeatureAllRequest
+  ? FeatureAllResponse
+  : T extends FeatureOneRequest
+  ? FeatureOneResponse
+  : T extends PingRequest
+  ? PingResponse
+  : T extends RandomRequest
+  ? RandomResponse
+  : T extends NFTBuyOffersRequest
+  ? NFTBuyOffersResponse
+  : T extends NFTSellOffersRequest
+  ? NFTSellOffersResponse
+  : T extends NFTInfoRequest
+  ? NFTInfoResponse
+  : T extends NFTsByIssuerRequest
+  ? NFTsByIssuerResponse
+  : T extends NFTHistoryRequest
+  ? NFTHistoryResponse
+  : T extends VaultInfoRequest
+  ? VaultInfoResponse
+  : Response<Version>
 
 export type MarkerRequest = Request & {
   limit?: number
@@ -504,18 +504,18 @@ export type RequestAllResponseMap<
 > = T extends AccountChannelsRequest
   ? AccountChannelsResponse
   : T extends AccountLinesRequest
-    ? AccountLinesResponse
-    : T extends AccountObjectsRequest
-      ? AccountObjectsResponse
-      : T extends AccountOffersRequest
-        ? AccountOffersResponse
-        : T extends AccountTxRequest
-          ? AccountTxVersionResponseMap<Version>
-          : T extends LedgerDataRequest
-            ? LedgerDataResponse
-            : T extends BookOffersRequest
-              ? BookOffersResponse
-              : MarkerResponse<Version>
+  ? AccountLinesResponse
+  : T extends AccountObjectsRequest
+  ? AccountObjectsResponse
+  : T extends AccountOffersRequest
+  ? AccountOffersResponse
+  : T extends AccountTxRequest
+  ? AccountTxVersionResponseMap<Version>
+  : T extends LedgerDataRequest
+  ? LedgerDataResponse
+  : T extends BookOffersRequest
+  ? BookOffersResponse
+  : MarkerResponse<Version>
 
 export {
   // Allow users to define their own requests and responses.  This is useful for releasing experimental versions

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -108,7 +108,14 @@ import {
   LedgerDataRequest,
   LedgerDataResponse,
 } from './ledgerData'
-import { LedgerEntryBinaryRequest, LedgerEntryJsonRequest, LedgerEntryRequest, LedgerEntryBinaryResponse, LedgerEntryJsonResponse, LedgerEntryResponse } from './ledgerEntry'
+import {
+  LedgerEntryBinaryRequest,
+  LedgerEntryJsonRequest,
+  LedgerEntryRequest,
+  LedgerEntryBinaryResponse,
+  LedgerEntryJsonResponse,
+  LedgerEntryResponse,
+} from './ledgerEntry'
 import { ManifestRequest, ManifestResponse } from './manifest'
 import { NFTBuyOffersRequest, NFTBuyOffersResponse } from './nftBuyOffers'
 import {
@@ -319,164 +326,164 @@ export type RequestResponseMap<
 > = T extends AccountChannelsRequest
   ? AccountChannelsResponse
   : T extends AccountCurrenciesRequest
-  ? AccountCurrenciesResponse
-  : T extends AccountInfoRequest
-  ? AccountInfoVersionResponseMap<Version>
-  : T extends AccountLinesRequest
-  ? AccountLinesResponse
-  : T extends AccountNFTsRequest
-  ? AccountNFTsResponse
-  : T extends AccountObjectsRequest
-  ? AccountObjectsResponse
-  : T extends AccountOffersRequest
-  ? AccountOffersResponse
-  : T extends AccountTxRequest
-  ? AccountTxVersionResponseMap<Version>
-  : T extends AMMInfoRequest
-  ? AMMInfoResponse
-  : T extends GatewayBalancesRequest
-  ? GatewayBalancesResponse
-  : T extends GetAggregatePriceRequest
-  ? GetAggregatePriceResponse
-  : T extends NoRippleCheckRequest
-  ? NoRippleCheckResponse
-  : // NOTE: The order of these LedgerRequest types is important
-  // to get the proper type matching overrides based on parameters set
-  // in the request. For example LedgerRequestExpandedTransactionsBinary
-  // should match LedgerRequestExpandedTransactionsOnly, but not
-  // LedgerRequestExpandedAccountsOnly. This is because the
-  // LedgerRequestExpandedTransactionsBinary type is a superset of
-  // LedgerRequestExpandedTransactionsOnly, but not of the other.
-  // This is why LedgerRequestExpandedTransactionsBinary is listed
-  // first in the type list.
-  //
-  // Here is an example using real data:
-  // LedgerRequestExpandedTransactionsBinary = {
-  //   command: 'ledger',
-  //   ledger_index: 'validated',
-  //   expand: true,
-  //   transactions: true,
-  //   binary: true,
-  // }
-  // LedgerRequestExpandedTransactionsOnly = {
-  //   command: 'ledger',
-  //   ledger_index: 'validated',
-  //   expand: true,
-  //   transactions: true,
-  // }
-  // LedgerRequestExpandedAccountsOnly = {
-  //   command: 'ledger',
-  //   ledger_index: 'validated',
-  //   accounts: true,
-  //   expand: true,
-  // }
-  // LedgerRequest = {
-  //   command: 'ledger',
-  //   ledger_index: 'validated',
-  // }
-  //
-  // The type with the most parameters set should be listed first. In this
-  // case LedgerRequestExpandedTransactionsBinary has the most parameters (`expand`, `transactions`, and `binary`)
-  // set, so it is listed first. When TypeScript tries to match the type of
-  // a request to a response, it will try to match the request type to the
-  // response type in the order they are listed. So, if we have a request
-  // with the following parameters:
-  // {
-  //   command: 'ledger',
-  //   ledger_index: 'validated',
-  //   expand: true,
-  //   transactions: true,
-  //   binary: true,
-  // }
-  // TypeScript will first try to match the request type to
-  // LedgerRequestExpandedTransactionsBinary, which will succeed. It will
-  // then try to match the response type to LedgerResponseExpanded, which
-  // will also succeed. If we had listed LedgerRequestExpandedTransactionsOnly
-  // first, TypeScript would have tried to match the request type to
-  // LedgerRequestExpandedTransactionsOnly, which would have succeeded, but
-  // then we'd get the wrong response type, LedgerResponse, instead of
-  // LedgerResponseExpanded.
-  T extends LedgerRequestExpandedTransactionsBinary
-  ? LedgerVersionResponseMap<Version>
-  : T extends LedgerRequestExpandedAccountsAndTransactions
-  ? LedgerResponseExpanded<Version>
-  : T extends LedgerRequestExpandedTransactionsOnly
-  ? LedgerResponseExpanded<Version>
-  : T extends LedgerRequestExpandedAccountsOnly
-  ? LedgerResponseExpanded<Version>
-  : T extends LedgerRequest
-  ? LedgerVersionResponseMap<Version>
-  : T extends LedgerClosedRequest
-  ? LedgerClosedResponse
-  : T extends LedgerCurrentRequest
-  ? LedgerCurrentResponse
-  : T extends LedgerDataRequest
-  ? LedgerDataResponse
-  : T extends LedgerEntryBinaryRequest
-  ? LedgerEntryBinaryResponse
-  : T extends LedgerEntryJsonRequest
-  ? LedgerEntryJsonResponse
-  : T extends LedgerEntryRequest
-  ? LedgerEntryJsonResponse
-  : T extends SimulateBinaryRequest
-  ? SimulateBinaryResponse
-  : T extends SimulateJsonRequest
-  ? SimulateJsonResponse
-  : T extends SimulateRequest
-  ? SimulateJsonResponse
-  : T extends SubmitRequest
-  ? SubmitResponse
-  : T extends SubmitMultisignedRequest
-  ? SubmitMultisignedVersionResponseMap<Version>
-  : T extends TransactionEntryRequest
-  ? TransactionEntryResponse
-  : T extends TxRequest
-  ? TxVersionResponseMap<Version>
-  : T extends BookOffersRequest
-  ? BookOffersResponse
-  : T extends DepositAuthorizedRequest
-  ? DepositAuthorizedResponse
-  : T extends PathFindRequest
-  ? PathFindResponse
-  : T extends RipplePathFindRequest
-  ? RipplePathFindResponse
-  : T extends ChannelVerifyRequest
-  ? ChannelVerifyResponse
-  : T extends SubscribeRequest
-  ? SubscribeResponse
-  : T extends UnsubscribeRequest
-  ? UnsubscribeResponse
-  : T extends FeeRequest
-  ? FeeResponse
-  : T extends ManifestRequest
-  ? ManifestResponse
-  : T extends ServerInfoRequest
-  ? ServerInfoResponse
-  : T extends ServerStateRequest
-  ? ServerStateResponse
-  : T extends ServerDefinitionsRequest
-  ? ServerDefinitionsResponse
-  : T extends FeatureAllRequest
-  ? FeatureAllResponse
-  : T extends FeatureOneRequest
-  ? FeatureOneResponse
-  : T extends PingRequest
-  ? PingResponse
-  : T extends RandomRequest
-  ? RandomResponse
-  : T extends NFTBuyOffersRequest
-  ? NFTBuyOffersResponse
-  : T extends NFTSellOffersRequest
-  ? NFTSellOffersResponse
-  : T extends NFTInfoRequest
-  ? NFTInfoResponse
-  : T extends NFTsByIssuerRequest
-  ? NFTsByIssuerResponse
-  : T extends NFTHistoryRequest
-  ? NFTHistoryResponse
-  : T extends VaultInfoRequest
-  ? VaultInfoResponse
-  : Response<Version>
+    ? AccountCurrenciesResponse
+    : T extends AccountInfoRequest
+      ? AccountInfoVersionResponseMap<Version>
+      : T extends AccountLinesRequest
+        ? AccountLinesResponse
+        : T extends AccountNFTsRequest
+          ? AccountNFTsResponse
+          : T extends AccountObjectsRequest
+            ? AccountObjectsResponse
+            : T extends AccountOffersRequest
+              ? AccountOffersResponse
+              : T extends AccountTxRequest
+                ? AccountTxVersionResponseMap<Version>
+                : T extends AMMInfoRequest
+                  ? AMMInfoResponse
+                  : T extends GatewayBalancesRequest
+                    ? GatewayBalancesResponse
+                    : T extends GetAggregatePriceRequest
+                      ? GetAggregatePriceResponse
+                      : T extends NoRippleCheckRequest
+                        ? NoRippleCheckResponse
+                        : // NOTE: The order of these LedgerRequest types is important
+                          // to get the proper type matching overrides based on parameters set
+                          // in the request. For example LedgerRequestExpandedTransactionsBinary
+                          // should match LedgerRequestExpandedTransactionsOnly, but not
+                          // LedgerRequestExpandedAccountsOnly. This is because the
+                          // LedgerRequestExpandedTransactionsBinary type is a superset of
+                          // LedgerRequestExpandedTransactionsOnly, but not of the other.
+                          // This is why LedgerRequestExpandedTransactionsBinary is listed
+                          // first in the type list.
+                          //
+                          // Here is an example using real data:
+                          // LedgerRequestExpandedTransactionsBinary = {
+                          //   command: 'ledger',
+                          //   ledger_index: 'validated',
+                          //   expand: true,
+                          //   transactions: true,
+                          //   binary: true,
+                          // }
+                          // LedgerRequestExpandedTransactionsOnly = {
+                          //   command: 'ledger',
+                          //   ledger_index: 'validated',
+                          //   expand: true,
+                          //   transactions: true,
+                          // }
+                          // LedgerRequestExpandedAccountsOnly = {
+                          //   command: 'ledger',
+                          //   ledger_index: 'validated',
+                          //   accounts: true,
+                          //   expand: true,
+                          // }
+                          // LedgerRequest = {
+                          //   command: 'ledger',
+                          //   ledger_index: 'validated',
+                          // }
+                          //
+                          // The type with the most parameters set should be listed first. In this
+                          // case LedgerRequestExpandedTransactionsBinary has the most parameters (`expand`, `transactions`, and `binary`)
+                          // set, so it is listed first. When TypeScript tries to match the type of
+                          // a request to a response, it will try to match the request type to the
+                          // response type in the order they are listed. So, if we have a request
+                          // with the following parameters:
+                          // {
+                          //   command: 'ledger',
+                          //   ledger_index: 'validated',
+                          //   expand: true,
+                          //   transactions: true,
+                          //   binary: true,
+                          // }
+                          // TypeScript will first try to match the request type to
+                          // LedgerRequestExpandedTransactionsBinary, which will succeed. It will
+                          // then try to match the response type to LedgerResponseExpanded, which
+                          // will also succeed. If we had listed LedgerRequestExpandedTransactionsOnly
+                          // first, TypeScript would have tried to match the request type to
+                          // LedgerRequestExpandedTransactionsOnly, which would have succeeded, but
+                          // then we'd get the wrong response type, LedgerResponse, instead of
+                          // LedgerResponseExpanded.
+                          T extends LedgerRequestExpandedTransactionsBinary
+                          ? LedgerVersionResponseMap<Version>
+                          : T extends LedgerRequestExpandedAccountsAndTransactions
+                            ? LedgerResponseExpanded<Version>
+                            : T extends LedgerRequestExpandedTransactionsOnly
+                              ? LedgerResponseExpanded<Version>
+                              : T extends LedgerRequestExpandedAccountsOnly
+                                ? LedgerResponseExpanded<Version>
+                                : T extends LedgerRequest
+                                  ? LedgerVersionResponseMap<Version>
+                                  : T extends LedgerClosedRequest
+                                    ? LedgerClosedResponse
+                                    : T extends LedgerCurrentRequest
+                                      ? LedgerCurrentResponse
+                                      : T extends LedgerDataRequest
+                                        ? LedgerDataResponse
+                                        : T extends LedgerEntryBinaryRequest
+                                          ? LedgerEntryBinaryResponse
+                                          : T extends LedgerEntryJsonRequest
+                                            ? LedgerEntryJsonResponse
+                                            : T extends LedgerEntryRequest
+                                              ? LedgerEntryJsonResponse
+                                              : T extends SimulateBinaryRequest
+                                                ? SimulateBinaryResponse
+                                                : T extends SimulateJsonRequest
+                                                  ? SimulateJsonResponse
+                                                  : T extends SimulateRequest
+                                                    ? SimulateJsonResponse
+                                                    : T extends SubmitRequest
+                                                      ? SubmitResponse
+                                                      : T extends SubmitMultisignedRequest
+                                                        ? SubmitMultisignedVersionResponseMap<Version>
+                                                        : T extends TransactionEntryRequest
+                                                          ? TransactionEntryResponse
+                                                          : T extends TxRequest
+                                                            ? TxVersionResponseMap<Version>
+                                                            : T extends BookOffersRequest
+                                                              ? BookOffersResponse
+                                                              : T extends DepositAuthorizedRequest
+                                                                ? DepositAuthorizedResponse
+                                                                : T extends PathFindRequest
+                                                                  ? PathFindResponse
+                                                                  : T extends RipplePathFindRequest
+                                                                    ? RipplePathFindResponse
+                                                                    : T extends ChannelVerifyRequest
+                                                                      ? ChannelVerifyResponse
+                                                                      : T extends SubscribeRequest
+                                                                        ? SubscribeResponse
+                                                                        : T extends UnsubscribeRequest
+                                                                          ? UnsubscribeResponse
+                                                                          : T extends FeeRequest
+                                                                            ? FeeResponse
+                                                                            : T extends ManifestRequest
+                                                                              ? ManifestResponse
+                                                                              : T extends ServerInfoRequest
+                                                                                ? ServerInfoResponse
+                                                                                : T extends ServerStateRequest
+                                                                                  ? ServerStateResponse
+                                                                                  : T extends ServerDefinitionsRequest
+                                                                                    ? ServerDefinitionsResponse
+                                                                                    : T extends FeatureAllRequest
+                                                                                      ? FeatureAllResponse
+                                                                                      : T extends FeatureOneRequest
+                                                                                        ? FeatureOneResponse
+                                                                                        : T extends PingRequest
+                                                                                          ? PingResponse
+                                                                                          : T extends RandomRequest
+                                                                                            ? RandomResponse
+                                                                                            : T extends NFTBuyOffersRequest
+                                                                                              ? NFTBuyOffersResponse
+                                                                                              : T extends NFTSellOffersRequest
+                                                                                                ? NFTSellOffersResponse
+                                                                                                : T extends NFTInfoRequest
+                                                                                                  ? NFTInfoResponse
+                                                                                                  : T extends NFTsByIssuerRequest
+                                                                                                    ? NFTsByIssuerResponse
+                                                                                                    : T extends NFTHistoryRequest
+                                                                                                      ? NFTHistoryResponse
+                                                                                                      : T extends VaultInfoRequest
+                                                                                                        ? VaultInfoResponse
+                                                                                                        : Response<Version>
 
 export type MarkerRequest = Request & {
   limit?: number
@@ -497,18 +504,18 @@ export type RequestAllResponseMap<
 > = T extends AccountChannelsRequest
   ? AccountChannelsResponse
   : T extends AccountLinesRequest
-  ? AccountLinesResponse
-  : T extends AccountObjectsRequest
-  ? AccountObjectsResponse
-  : T extends AccountOffersRequest
-  ? AccountOffersResponse
-  : T extends AccountTxRequest
-  ? AccountTxVersionResponseMap<Version>
-  : T extends LedgerDataRequest
-  ? LedgerDataResponse
-  : T extends BookOffersRequest
-  ? BookOffersResponse
-  : MarkerResponse<Version>
+    ? AccountLinesResponse
+    : T extends AccountObjectsRequest
+      ? AccountObjectsResponse
+      : T extends AccountOffersRequest
+        ? AccountOffersResponse
+        : T extends AccountTxRequest
+          ? AccountTxVersionResponseMap<Version>
+          : T extends LedgerDataRequest
+            ? LedgerDataResponse
+            : T extends BookOffersRequest
+              ? BookOffersResponse
+              : MarkerResponse<Version>
 
 export {
   // Allow users to define their own requests and responses.  This is useful for releasing experimental versions

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -108,7 +108,7 @@ import {
   LedgerDataRequest,
   LedgerDataResponse,
 } from './ledgerData'
-import { LedgerEntryRequest, LedgerEntryResponse } from './ledgerEntry'
+import { LedgerEntryBinaryRequest, LedgerEntryJsonRequest, LedgerEntryRequest, LedgerEntryBinaryResponse, LedgerEntryJsonResponse, LedgerEntryResponse } from './ledgerEntry'
 import { ManifestRequest, ManifestResponse } from './manifest'
 import { NFTBuyOffersRequest, NFTBuyOffersResponse } from './nftBuyOffers'
 import {
@@ -412,8 +412,12 @@ export type RequestResponseMap<
   ? LedgerCurrentResponse
   : T extends LedgerDataRequest
   ? LedgerDataResponse
+  : T extends LedgerEntryBinaryRequest
+  ? LedgerEntryBinaryResponse
+  : T extends LedgerEntryJsonRequest
+  ? LedgerEntryJsonResponse
   : T extends LedgerEntryRequest
-  ? LedgerEntryResponse
+  ? LedgerEntryJsonResponse
   : T extends SimulateBinaryRequest
   ? SimulateBinaryResponse
   : T extends SimulateJsonRequest
@@ -565,7 +569,11 @@ export {
   LedgerDataBinaryLedgerEntry,
   LedgerDataResponse,
   LedgerDataLedgerState,
+  LedgerEntryBinaryRequest,
+  LedgerEntryJsonRequest,
   LedgerEntryRequest,
+  LedgerEntryBinaryResponse,
+  LedgerEntryJsonResponse,
   LedgerEntryResponse,
   // transaction methods with types
   SimulateRequest,

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -230,17 +230,60 @@ export interface LedgerEntryRequest extends BaseRequest, LookupByLedgerRequest {
   }
 }
 
+export type LedgerEntryBinaryRequest = LedgerEntryRequest & {
+  binary: true
+}
+
+export type LedgerEntryJsonRequest = LedgerEntryRequest & {
+  binary?: false
+}
+
+interface LedgerEntryResponseResultBase {
+  /** The unique ID of this ledger object. */
+  index: string
+  /** The ledger index of the ledger that was used when retrieving this data. */
+  ledger_current_index: number
+  validated?: boolean
+  /**
+   * (Optional) Indicates the ledger index at which the object was deleted.
+   */
+  deleted_ledger_index?: number
+}
+
+/**
+ * Response expected from a {@link LedgerEntryRequest} with binary: true.
+ *
+ * @category Responses
+ */
+export interface LedgerEntryBinaryResponse extends BaseResponse {
+  result: LedgerEntryResponseResultBase & {
+    /** The binary representation of the ledger object, as hexadecimal. */
+    node_binary: string
+  }
+}
+
+/**
+ * Response expected from a {@link LedgerEntryRequest} with binary: false or omitted.
+ *
+ * @category Responses
+ */
+export interface LedgerEntryJsonResponse<T = LedgerEntry> extends BaseResponse {
+  result: LedgerEntryResponseResultBase & {
+    /**
+     * Object containing the data of this ledger object, according to the
+     * ledger format.
+     */
+    node: T
+  }
+}
+
 /**
  * Response expected from a {@link LedgerEntryRequest}.
  *
  * @category Responses
  */
 export interface LedgerEntryResponse<T = LedgerEntry> extends BaseResponse {
-  result: {
-    /** The unique ID of this ledger object. */
-    index: string
-    /** The ledger index of the ledger that was used when retrieving this data. */
-    ledger_current_index: number
+  result: LedgerEntryResponseResultBase & {
     /**
      * Object containing the data of this ledger object, according to the
      * ledger format.
@@ -248,10 +291,5 @@ export interface LedgerEntryResponse<T = LedgerEntry> extends BaseResponse {
     node?: T
     /** The binary representation of the ledger object, as hexadecimal. */
     node_binary?: string
-    validated?: boolean
-    /**
-     * (Optional) Indicates the ledger index at which the object was deleted.
-     */
-    deleted_ledger_index?: number
   }
 }

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,10 +1,6 @@
 import { assert } from 'chai'
 
-import {
-  LedgerEntryJsonResponse,
-  LedgerEntryRequest,
-  LedgerEntryResponse,
-} from '../../../src'
+import { LedgerEntryJsonResponse, LedgerEntryRequest } from '../../../src'
 import serverUrl from '../serverUrl'
 import {
   setupClient,

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 
-import { LedgerEntryRequest } from '../../../src'
+import type { LedgerEntryRequest } from '../../../src'
 import serverUrl from '../serverUrl'
 import {
   setupClient,

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,10 +1,6 @@
 import { assert } from 'chai'
 
-import {
-  LedgerEntryBinaryRequest,
-  LedgerEntryJsonResponse,
-  LedgerEntryRequest,
-} from '../../../src'
+import { LedgerEntryRequest } from '../../../src'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -89,9 +85,9 @@ describe('ledger_entry', function () {
         binary: false,
       })
 
-      assert.isUndefined(ledgerEntryResponse.result.node)
+      assert.isDefined(ledgerEntryResponse.result.node)
       // @ts-expect-error - node_binary is not present in the response
-      assert.isDefined(ledgerEntryResponse.result.node_binary)
+      assert.isUndefined(ledgerEntryResponse.result.node_binary)
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,12 +1,17 @@
 import { assert } from 'chai'
 
-import { LedgerEntryJsonResponse, LedgerEntryRequest } from '../../../src'
+import {
+  LedgerEntryBinaryRequest,
+  LedgerEntryJsonResponse,
+  LedgerEntryRequest,
+} from '../../../src'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
   teardownClient,
   type XrplIntegrationTestContext,
 } from '../setup'
+import { generateFundedWallet } from '../utils'
 
 // how long before each test case times out
 const TIMEOUT = 20000
@@ -38,7 +43,7 @@ describe('ledger_entry', function () {
       const ledgerEntryResponse =
         await testContext.client.request(ledgerEntryRequest)
 
-      const expectedResponse: LedgerEntryJsonResponse = {
+      const expectedResponse = {
         api_version: 2,
         id: ledgerEntryResponse.id,
         type: 'response',
@@ -52,6 +57,59 @@ describe('ledger_entry', function () {
 
       assert.equal(ledgerEntryResponse.type, 'response')
       assert.deepEqual(ledgerEntryResponse, expectedResponse)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'binary = (default)',
+    async () => {
+      const wallet = await generateFundedWallet(testContext.client)
+
+      const ledgerEntryResponse = await testContext.client.request({
+        command: 'ledger_entry',
+        account_root: wallet.address,
+      })
+
+      assert.isDefined(ledgerEntryResponse.result.node)
+      // @ts-expect-error - node_binary is not present in the response
+      assert.isUndefined(ledgerEntryResponse.result.node_binary)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'binary = false',
+    async () => {
+      const wallet = await generateFundedWallet(testContext.client)
+
+      const ledgerEntryResponse = await testContext.client.request({
+        command: 'ledger_entry',
+        account_root: wallet.address,
+        binary: false,
+      })
+
+      assert.isUndefined(ledgerEntryResponse.result.node)
+      // @ts-expect-error - node_binary is not present in the response
+      assert.isDefined(ledgerEntryResponse.result.node_binary)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'binary = true',
+    async () => {
+      const wallet = await generateFundedWallet(testContext.client)
+
+      const ledgerEntryResponse = await testContext.client.request({
+        command: 'ledger_entry',
+        account_root: wallet.address,
+        binary: true,
+      })
+
+      // @ts-expect-error - node is not present in the response
+      assert.isUndefined(ledgerEntryResponse.result.node)
+      assert.isDefined(ledgerEntryResponse.result.node_binary)
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,6 +1,10 @@
 import { assert } from 'chai'
 
-import { LedgerEntryRequest, LedgerEntryResponse } from '../../../src'
+import {
+  LedgerEntryJsonResponse,
+  LedgerEntryRequest,
+  LedgerEntryResponse,
+} from '../../../src'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -38,7 +42,7 @@ describe('ledger_entry', function () {
       const ledgerEntryResponse =
         await testContext.client.request(ledgerEntryRequest)
 
-      const expectedResponse: LedgerEntryResponse = {
+      const expectedResponse: LedgerEntryJsonResponse = {
         api_version: 2,
         id: ledgerEntryResponse.id,
         type: 'response',


### PR DESCRIPTION
## High Level Overview of Change                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                   
Make LedgerEntryResponse type-safe based on the binary field value in LedgerEntryRequest. Previously, the response type always included both node? and node_binary? regardless of whether binary: true or binary: false was specified in the request. Now,
TypeScript correctly narrows the response type based on the binary field.                                                                                                                                                                                          
                                                                                                                                                                                                                                                                   
## Context of Change

When using client.request() with a LedgerEntryRequest, the response type did not differentiate between binary and JSON responses. This meant developers had to manually check for node or node_binary existence even when the request explicitly specified binary:
true or binary: false. This follows the existing pattern established by SimulateBinaryRequest / SimulateJsonRequest.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)

## Did you update HISTORY.md?

- [ ] Yes
- [x] No (this is a types-only change)

## Test Plan

- npx tsc --noEmit passes with no errors
- Existing LedgerEntryResponse union type maintains backward compatibility
- LedgerEntryBinaryRequest (binary: true) maps to LedgerEntryBinaryResponse with node_binary: string (no node)
- LedgerEntryJsonRequest (binary?: false) maps to LedgerEntryJsonResponse<T> with node: T (no node_binary)
- Generic LedgerEntryRequest still maps to the union LedgerEntryResponse