### PR TITLE
fix: change MPTAmount field type from MPTAmount to string

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -7,6 +7,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 ### Added
 * Add new fields to `ServerDefinitionsResponse`: `ACCOUNT_SET_FLAGS`, `LEDGER_ENTRY_FLAGS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, and `TRANSACTION_FORMATS`, reflecting new sections returned by `server_definitions` in rippled.
 
+### Fixed
+* Fix incorrect `MPTAmount` field type to `string` instead of `MPTAmount`.
+
 ## 4.6.0 (2026-02-12)
 
 ### Added

--- a/packages/xrpl/src/models/ledger/MPToken.ts
+++ b/packages/xrpl/src/models/ledger/MPToken.ts
@@ -1,11 +1,9 @@
-import { MPTAmount } from '../common'
-
 import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 
 export interface MPToken extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'MPToken'
   MPTokenIssuanceID: string
-  MPTAmount?: MPTAmount
+  MPTAmount?: string
   Flags: number
   OwnerNode?: string
   LockedAmount?: string

--- a/packages/xrpl/src/models/ledger/MPToken.ts
+++ b/packages/xrpl/src/models/ledger/MPToken.ts
@@ -3,7 +3,7 @@ import { BaseLedgerEntry, HasPreviousTxnID } from './BaseLedgerEntry'
 export interface MPToken extends BaseLedgerEntry, HasPreviousTxnID {
   LedgerEntryType: 'MPToken'
   MPTokenIssuanceID: string
-  MPTAmount?: string
+  MPTAmount: string
   Flags: number
   OwnerNode?: string
   LockedAmount?: string


### PR DESCRIPTION
## High Level Overview of Change

as title says

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users
