### PR TITLE
Rename ticket properties in ledgerEntry model

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -16,6 +16,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Disallow the input of Authorization Credentials over insecure WebSocket connections (`ws[+unix]?://`) to prevent MITM eavesdropping of sensitive data.
 * Fix incorrect `MPTAmount` field type to `string` instead of `MPTAmount`.
 * Fix `Client.getServerInfo()` swallowing errors from the underlying `server_info` request, which left `client.networkID` undefined and caused `autofill()` to silently omit the `NetworkID` field — producing signed transactions valid on the wrong network (cross-network replay risk). The method now throws on request failure or when the response is missing `network_id`. ([#3321](https://github.com/XRPLF/xrpl.js/issues/3321))
+* [Breaking change] Fix `LedgerEntryRequest` ticket field names: renamed `owner` to `account` and `ticket_sequence` to `ticket_seq` to match the official XRPL `ledger_entry` API specification. If you use the object form of the `ticket` field in `ledger_entry` requests, update your code to use the new field names.
 
 ## 4.6.0 (2026-02-12)
 

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -183,7 +183,7 @@ export interface LedgerEntryRequest extends BaseRequest, LookupByLedgerRequest {
 
   /**
    * The Ticket object to retrieve. If a string, must be the object ID of the
-   * Ticket, as hexadecimal. If an object, the `owner` and `ticket_sequence`
+   * Ticket, as hexadecimal. If an object, the `account` and `ticket_seq`
    * sub-fields are required to uniquely specify the Ticket entry.
    */
   ticket?:

--- a/packages/xrpl/src/models/methods/ledgerEntry.ts
+++ b/packages/xrpl/src/models/methods/ledgerEntry.ts
@@ -189,9 +189,9 @@ export interface LedgerEntryRequest extends BaseRequest, LookupByLedgerRequest {
   ticket?:
     | {
         /** The owner of the Ticket object. */
-        owner: string
+        account: string
         /** The Ticket Sequence number of the Ticket entry to retrieve. */
-        ticket_sequence: number
+        ticket_seq: number
       }
     | string
 

--- a/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
+++ b/packages/xrpl/test/integration/requests/ledgerEntry.test.ts
@@ -1,13 +1,18 @@
 import { assert } from 'chai'
 
-import type { LedgerEntryRequest } from '../../../src'
+import {
+  LedgerEntryRequest,
+  LedgerEntryResponse,
+  TicketCreate,
+} from '../../../src'
+import type Ticket from '../../../src/models/ledger/Ticket'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
   teardownClient,
   type XrplIntegrationTestContext,
 } from '../setup'
-import { generateFundedWallet } from '../utils'
+import { generateFundedWallet, testTransaction } from '../utils'
 
 // how long before each test case times out
 const TIMEOUT = 20000
@@ -106,6 +111,48 @@ describe('ledger_entry', function () {
       // @ts-expect-error - node is not present in the response
       assert.isUndefined(ledgerEntryResponse.result.node)
       assert.isDefined(ledgerEntryResponse.result.node_binary)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'fetches a Ticket object',
+    async () => {
+      const accountInfoResponse = await testContext.client.request({
+        command: 'account_info',
+        account: testContext.wallet.classicAddress,
+      })
+      const accSeq = accountInfoResponse.result.account_data.Sequence
+      const ticketSeq = accSeq + 1
+
+      const ticketCreate: TicketCreate = {
+        TransactionType: 'TicketCreate',
+        Account: testContext.wallet.classicAddress,
+        TicketCount: 1,
+        Sequence: accSeq,
+      }
+      await testTransaction(testContext.client, ticketCreate, testContext.wallet)
+
+      const ledgerEntryRequest: LedgerEntryRequest = {
+        command: 'ledger_entry',
+        ticket: {
+          account: testContext.wallet.classicAddress,
+          ticket_seq: ticketSeq,
+        },
+      }
+      const ledgerEntryResponse: LedgerEntryResponse<Ticket> =
+        await testContext.client.request(ledgerEntryRequest)
+
+      assert.equal(ledgerEntryResponse.type, 'response')
+      assert.equal(ledgerEntryResponse.result.node?.LedgerEntryType, 'Ticket')
+      assert.equal(
+        ledgerEntryResponse.result.node?.Account,
+        testContext.wallet.classicAddress,
+      )
+      assert.equal(
+        ledgerEntryResponse.result.node?.TicketSequence,
+        ticketSeq,
+      )
     },
     TIMEOUT,
   )


### PR DESCRIPTION
fix bug for ticket objects request

## High Level Overview of Change

This PR fixes the `ledger_entry` request model for `ticket` objects in `xrpl.js`.

Changes made:
- renamed `ticket.owner` to `ticket.account`
- renamed `ticket.ticket_sequence` to `ticket.ticket_seq`

This aligns the request payload with the XRPL `ledger_entry` API specification for Ticket objects, where the object form of `ticket` requires `account` and `ticket_seq`. 
https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry#get-ticket-entry

### Context of Change

The current model uses incorrect field names for ticket lookup requests:
- `owner`
- `ticket_sequence`

According to the official XRPL documentation, the correct fields are:
- `account`
- `ticket_seq` 

Because of this mismatch, requests built using the current typed object shape do not match the API contract and fail when trying to retrieve Ticket ledger objects through `ledger_entry`. The documented Ticket request example also uses `account` and `ticket_seq`. 

This change updates the TypeScript model so the library matches the official API and users can construct valid Ticket object requests.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan

Verified the change by reviewing the XRPL `ledger_entry` Ticket request specification and matching the request model to the documented parameter names:
- `ticket.account`
- `ticket.ticket_seq` 

To reproduce:
1. Build a `ledger_entry` request for a Ticket using object form.
2. Use:
   ```json
   {
     "command": "ledger_entry",
     "ticket": {
       "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
       "ticket_seq": 389
     },
     "ledger_index": "validated"
   }