### PR TITLE
breaking change: Update default choice of signing algorithm

### DIFF
--- a/packages/ripple-keypairs/HISTORY.md
+++ b/packages/ripple-keypairs/HISTORY.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### BREAKING CHANGES
+- Update the default signing algorithm in `ripple-keypairs` package's `generateSeed` function to `ed25519`. This brings compatibility with the `Wallet`-related methods in the `xrpl` package. Users can retrieve the cryptographic material used in the prior versions of the package by explicitly specifying `ecdsa-secp256k1` in the `ripple-keypairs` package's `generateSeed` function parameter.
+
+### Added
+- Export the Algorithm type in the public interface. This helps other packages consume the supported cryptographic signing algorithms (ex: secret-numbers)
+
 ## 2.0.0 (2024-02-01)
 
 ### BREAKING CHANGES

--- a/packages/ripple-keypairs/README.md
+++ b/packages/ripple-keypairs/README.md
@@ -11,7 +11,7 @@ eddsa deterministic signatures.
 ```
 generateSeed({entropy?: Array<integer>, algorithm?: string}) -> string
 ```
-Generate a seed that can be used to generate keypairs. Entropy can be provided as an array of bytes expressed as integers in the range 0-255. If provided, it must be 16 bytes long (additional bytes are ignored). If not provided, entropy will be automatically generated. The "algorithm" defaults to "ecdsa-secp256k1", but can also be set to "ed25519". The result is a seed encoded in base58, starting with "s".
+Generate a seed that can be used to generate keypairs. Entropy can be provided as an array of bytes expressed as integers in the range 0-255. If provided, it must be 16 bytes long (additional bytes are ignored). If not provided, entropy will be automatically generated. The "algorithm" defaults to "ed25519", but can also be set to "ecdsa-secp256k1". The result is a seed encoded in base58, starting with "s".
 
 ```
 deriveKeypair(seed: string) -> {privateKey: string, publicKey: string}

--- a/packages/ripple-keypairs/src/index.ts
+++ b/packages/ripple-keypairs/src/index.ts
@@ -31,6 +31,11 @@ function generateSeed(
     algorithm?: Algorithm
   } = {},
 ): string {
+  const VALID_ALGORITHMS: Algorithm[] = ['ecdsa-secp256k1', 'ed25519']
+  assert.ok(
+    !options.algorithm || VALID_ALGORITHMS.includes(options.algorithm),
+    `Unsupported algorithm: ${options.algorithm}. Use one of: ${VALID_ALGORITHMS.join(', ')}`,
+  )
   assert.ok(
     !options.entropy || options.entropy.length >= 16,
     'entropy too short',
@@ -38,7 +43,7 @@ function generateSeed(
   const entropy = options.entropy
     ? options.entropy.slice(0, 16)
     : randomBytes(16)
-  const type = options.algorithm === 'ed25519' ? 'ed25519' : 'secp256k1'
+  const type = options.algorithm === 'ecdsa-secp256k1' ? 'secp256k1' : 'ed25519'
   return encodeSeed(entropy, type)
 }
 
@@ -109,4 +114,5 @@ export {
   deriveAddress,
   deriveNodeAddress,
   decodeSeed,
+  type Algorithm,
 }

--- a/packages/ripple-keypairs/test/api.test.ts
+++ b/packages/ripple-keypairs/test/api.test.ts
@@ -15,15 +15,15 @@ const entropy = new Uint8Array([
 ])
 
 describe('api', () => {
-  it('generateSeed - secp256k1', () => {
-    expect(generateSeed({ entropy })).toEqual(fixtures.secp256k1.seed)
+  it('generateSeed - ed25519', () => {
+    expect(generateSeed({ entropy })).toEqual(fixtures.ed25519.seed)
   })
 
-  it('generateSeed - secp256k1, random', () => {
+  it('generateSeed - ed25519, random', () => {
     const seed = generateSeed()
     expect(seed.startsWith('s')).toBeTruthy()
     const { type, bytes } = decodeSeed(seed)
-    expect(type).toEqual('secp256k1')
+    expect(type).toEqual('ed25519')
     expect(bytes.length).toEqual(16)
   })
 
@@ -35,6 +35,28 @@ describe('api', () => {
 
   it('generateSeed - ed25519, random', () => {
     const seed = generateSeed({ algorithm: 'ed25519' })
+    expect(seed.startsWith('sEd')).toBeTruthy()
+    const { type, bytes } = decodeSeed(seed)
+    expect(type).toEqual('ed25519')
+    expect(bytes.length).toEqual(16)
+  })
+
+  it('generateSeed - secp256k1, deterministic', () => {
+    expect(generateSeed({ entropy, algorithm: 'ecdsa-secp256k1' })).toEqual(
+      fixtures.secp256k1.seed,
+    )
+  })
+
+  it('generateSeed - secp256k1, random', () => {
+    const seed = generateSeed({ algorithm: 'ecdsa-secp256k1' })
+    expect(seed.startsWith('s')).toBeTruthy()
+    const { type, bytes } = decodeSeed(seed)
+    expect(type).toEqual('secp256k1')
+    expect(bytes.length).toEqual(16)
+  })
+
+  it('generateSeed, default algorithm used is ed25519', () => {
+    const seed = generateSeed()
     expect(seed.startsWith('sEd')).toBeTruthy()
     const { type, bytes } = decodeSeed(seed)
     expect(type).toEqual('ed25519')

--- a/packages/secret-numbers/HISTORY.md
+++ b/packages/secret-numbers/HISTORY.md
@@ -4,6 +4,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 
+### BREAKING CHANGES:
+* `ED25519` is the default signing-algorithm for the default construction of Accounts. Users can explicitly specify `ecdsa-secp256k1` to retrieve the cryptographic material created using older versions of this package.
+
 ## 2.0.0 (2025-07-29)
 
 ### BREAKING CHANGES:

--- a/packages/secret-numbers/src/schema/Account.ts
+++ b/packages/secret-numbers/src/schema/Account.ts
@@ -1,4 +1,7 @@
 import { deriveAddress, deriveKeypair, generateSeed } from 'ripple-keypairs'
+// Use an import alias to avoid name-conflict with the Algorithm type
+// defined in extensions/node_modules/typescript/lib/lib.dom.d.ts
+import type { Algorithm as SignAlgorithm } from 'ripple-keypairs'
 
 import {
   entropyToSecret,
@@ -33,7 +36,14 @@ export class Account {
     },
   }
 
-  constructor(secretNumbers?: string[] | string | Uint8Array) {
+  private readonly _algorithm: SignAlgorithm
+
+  constructor(
+    secretNumbers?: string[] | string | Uint8Array,
+    algorithm: SignAlgorithm = 'ed25519',
+  ) {
+    this._algorithm = algorithm
+
     if (typeof secretNumbers === 'string') {
       this._secret = parseSecretString(secretNumbers)
     } else if (Array.isArray(secretNumbers)) {
@@ -75,7 +85,10 @@ export class Account {
   private derive(): void {
     try {
       const entropy = secretToEntropy(this._secret)
-      this._account.familySeed = generateSeed({ entropy })
+      this._account.familySeed = generateSeed({
+        entropy,
+        algorithm: this._algorithm,
+      })
       this._account.keypair = deriveKeypair(this._account.familySeed)
       this._account.address = deriveAddress(this._account.keypair.publicKey)
     } catch (error) {

--- a/packages/secret-numbers/test/api.test.ts
+++ b/packages/secret-numbers/test/api.test.ts
@@ -22,10 +22,10 @@ describe('API: XRPL Secret Numbers', () => {
     const account = new Account(entropy)
 
     it('familySeed as expected', () => {
-      expect(account.getFamilySeed()).toEqual('sp5DmDCut79BpgumfHhvRzdxXYQyU')
+      expect(account.getFamilySeed()).toEqual('sEdSKUm3MuTvN745ezpSM94Xw45BsbA')
     })
     it('address as expected', () => {
-      expect(account.getAddress()).toEqual('rMCcybKHfwCSkDHd3M36PAeUniEoygwjR3')
+      expect(account.getAddress()).toEqual('rMjDw1h3vQZUfYkQJV7PXeToajAA4JtkFJ')
     })
     it('Account object to string as expected', () => {
       const accountAsStr =
@@ -47,6 +47,63 @@ describe('API: XRPL Secret Numbers', () => {
     ]
 
     const account = new Account(secret)
+
+    it('familySeed as expected', () => {
+      expect(account.getFamilySeed()).toEqual('sEdSmrWh6iszywyGQCgguErD9DiuBY8')
+    })
+    it('publicKey as expected', () => {
+      const pubkey =
+        'EDBB1A131EA944C5D07D1DE39CAD2E128329CD1321F2F5759D2BB3EB94D5B8AB2F'
+      expect(account.getKeypair().publicKey).toEqual(pubkey)
+    })
+    it('privateKey as expected', () => {
+      const privkey =
+        'EDB55E7518A732963CD444E6D1E682DCD6AD60DD53AA5743854D4C4AB52E2D6800'
+      expect(account.getKeypair().privateKey).toEqual(privkey)
+    })
+    it('address as expected', () => {
+      expect(account.getAddress()).toEqual('rJmyR83BfJdRpJabbkBH2ES8mkR168bNVJ')
+    })
+    it('Account object to string as expected', () => {
+      const accountAsStr =
+        '084677 005323 580272 282388 626800 105300 560913 071783'
+      expect(`${account.toString()}`).toEqual(accountAsStr)
+    })
+  })
+
+  describe('Validate the default signing algorithm', () => {
+    const secret = [
+      '084677',
+      '005323',
+      '580272',
+      '282388',
+      '626800',
+      '105300',
+      '560913',
+      '071783',
+    ]
+
+    const account1 = new Account(secret)
+    const account2 = new Account(secret, 'ed25519')
+
+    it('default signing algorithm is ed25519 in the Account class', () => {
+      expect(account1).toEqual(account2)
+    })
+  })
+
+  describe('Account based on existing secret, explicitly specify secp256k1 algorithm', () => {
+    const secret = [
+      '084677',
+      '005323',
+      '580272',
+      '282388',
+      '626800',
+      '105300',
+      '560913',
+      '071783',
+    ]
+
+    const account = new Account(secret, 'ecdsa-secp256k1')
 
     it('familySeed as expected', () => {
       expect(account.getFamilySeed()).toEqual('sswpWwri7Y11dNCSmXdphgcoPZk3y')

--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -4,6 +4,9 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ## Unreleased
 
+### BREAKING CHANGES:
+* `ED25519` is the default signing-algorithm used in the `Wallet.fromMnemonic` method. Users can explicitly specify `ecdsa-secp256k1` to retrieve the cryptographic material created using older versions of this package.
+
 ### Added
 * Add new fields to `ServerDefinitionsResponse`: `ACCOUNT_SET_FLAGS`, `LEDGER_ENTRY_FLAGS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, and `TRANSACTION_FORMATS`, reflecting new sections returned by `server_definitions` in rippled.
 

--- a/packages/xrpl/src/Wallet/index.ts
+++ b/packages/xrpl/src/Wallet/index.ts
@@ -212,8 +212,7 @@ export class Wallet {
    * @param opts.mnemonicEncoding - If set to 'rfc1751', this interprets the mnemonic as a rippled RFC1751 mnemonic like
    *                          `wallet_propose` generates in rippled. Otherwise the function defaults to bip39 decoding.
    * @param opts.algorithm - Only used if opts.mnemonicEncoding is 'rfc1751'. Allows the mnemonic to generate its
-   *                         secp256k1 seed, or its ed25519 seed. By default, it will generate the secp256k1 seed
-   *                         to match the rippled `wallet_propose` default algorithm.
+   *                         secp256k1 seed, or its ed25519 seed. By default, it will generate the ed25519 seed.
    * @returns A Wallet derived from a mnemonic.
    * @throws ValidationError if unable to derive private key from mnemonic input.
    */
@@ -229,7 +228,7 @@ export class Wallet {
     if (opts.mnemonicEncoding === 'rfc1751') {
       return Wallet.fromRFC1751Mnemonic(mnemonic, {
         masterAddress: opts.masterAddress,
-        algorithm: opts.algorithm,
+        algorithm: opts.algorithm ?? DEFAULT_ALGORITHM,
       })
     }
     // Otherwise decode using bip39's mnemonic standard
@@ -269,11 +268,10 @@ export class Wallet {
   ): Wallet {
     const seed = rfc1751MnemonicToKey(mnemonic)
     let encodeAlgorithm: 'ed25519' | 'secp256k1'
-    if (opts.algorithm === ECDSA.ed25519) {
-      encodeAlgorithm = 'ed25519'
-    } else {
-      // Defaults to secp256k1 since that's the default for `wallet_propose`
+    if (opts.algorithm === ECDSA.secp256k1) {
       encodeAlgorithm = 'secp256k1'
+    } else {
+      encodeAlgorithm = 'ed25519'
     }
     const encodedSeed = encodeSeed(seed, encodeAlgorithm)
     return Wallet.fromSeed(encodedSeed, {

--- a/packages/xrpl/test/wallet/index.test.ts
+++ b/packages/xrpl/test/wallet/index.test.ts
@@ -310,6 +310,26 @@ describe('Wallet', function () {
       assert.equal(wallet.privateKey, regularKeyPair.privateKey)
       assert.equal(wallet.classicAddress, masterAddress)
     })
+
+    it('derive a wallet using the default signing algorithm (ed25519) with RFC1751 mnemonic', function () {
+      const masterAddress = 'rUAi7pipxGpYfPNg3LtPcf2ApiS8aw9A93'
+      const regularKeyPair = {
+        mnemonic: 'I IRE BOND BOW TRIO LAID SEAT GOAL HEN IBIS IBIS DARE',
+        publicKey:
+          'EDAAC3F98BB94F451804EF5993C847DAAA4E6154F455635659D88AA5C80F156303',
+        privateKey:
+          'ED93D09224D09221B8845E7A9772E0D6259CD01029C557CD95978CC674E0192B25',
+      }
+
+      const wallet = Wallet.fromMnemonic(regularKeyPair.mnemonic, {
+        masterAddress,
+        mnemonicEncoding: 'rfc1751',
+      })
+
+      assert.equal(wallet.publicKey, regularKeyPair.publicKey)
+      assert.equal(wallet.privateKey, regularKeyPair.privateKey)
+      assert.equal(wallet.classicAddress, masterAddress)
+    })
   })
 
   describe('fromSecretNumbers', function () {


### PR DESCRIPTION


## High Level Overview of Change

If no signing algorithm is specified, use ed25519. At the moment, the code uses secp256k1. This causes incoherence between the fromSeed and generateSeed functions because they use different defaults.

Note: This change causes breakage in downstream classes like Account


This PR is a replacement for https://github.com/XRPLF/xrpl.js/pull/2658. The original PR is > 2 years old. Github policies made it hard for me to sign+rebase all the ~210 older commits. So, I created a new PR.

This PR is identical to the existing-approved PR becase `git diff defaultSigningAlg..defaultSigningAlg-squashed-signed` produces an empty diff.


<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->



<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [x] Yes
- [ ] No, this change does not impact library users

## Test Plan
Appropriate tests have been added
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
