### PR TITLE
type: TxResponse narrowing

### DIFF
--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -354,7 +354,9 @@ class Client extends EventEmitter<EventTypes> {
    */
   public async request<
     R extends Request,
-    V extends APIVersion = typeof DEFAULT_API_VERSION,
+    V extends APIVersion = R['api_version'] extends APIVersion
+      ? R['api_version']
+      : typeof DEFAULT_API_VERSION,
     T = RequestResponseMap<R, V>,
   >(req: R): Promise<T> {
     const request = {

--- a/packages/xrpl/src/models/methods/baseMethod.ts
+++ b/packages/xrpl/src/models/methods/baseMethod.ts
@@ -1,4 +1,4 @@
-import { LedgerIndex } from '../common'
+import { APIVersion, LedgerIndex } from '../common'
 
 import type { Request } from '.'
 
@@ -13,7 +13,7 @@ export interface BaseRequest {
   /** The name of the API method. */
   command: string
   /** The API version to use. If omitted, use version 1. */
-  api_version?: number
+  api_version?: APIVersion
 }
 
 export interface LookupByLedgerRequest {

--- a/packages/xrpl/src/models/methods/index.ts
+++ b/packages/xrpl/src/models/methods/index.ts
@@ -191,7 +191,7 @@ import {
   TransactionEntryRequest,
   TransactionEntryResponse,
 } from './transactionEntry'
-import { TxRequest, TxResponse, TxV1Response, TxVersionResponseMap } from './tx'
+import { TxBinaryRequest, TxJsonRequest, TxRequest, TxResponse, TxV1Response, TxVersionResponseMap } from './tx'
 import {
   UnsubscribeBook,
   UnsubscribeRequest,
@@ -437,7 +437,9 @@ export type RequestResponseMap<
   ? SubmitMultisignedVersionResponseMap<Version>
   : T extends TransactionEntryRequest
   ? TransactionEntryResponse
-  : T extends TxRequest
+  : T extends TxBinaryRequest
+  ? TxVersionResponseMap<Version, true>
+  : T extends TxJsonRequest
   ? TxVersionResponseMap<Version>
   : T extends BookOffersRequest
   ? BookOffersResponse

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -111,7 +111,7 @@ interface TxBinaryResult extends BaseTxResult {
 }
 
 interface TxBinaryResultV1 extends BaseTxResult {
-  tx_blob: string
+  tx: string
   /** Unique hashed string Transaction metadata blob, which describes the results of the transaction.
    *  Can be undefined if a transaction has not been validated yet. */
   meta?: string

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -15,7 +15,7 @@ import { BaseRequest, BaseResponse } from './baseMethod'
  *
  * @category Requests
  */
-export interface TxRequest extends BaseRequest {
+interface TxRequestBase extends BaseRequest {
   command: 'tx'
   /**
    * The transaction hash to look up. Exactly one of `transaction` or `ctid` must be specified for a TxRequest.
@@ -25,12 +25,6 @@ export interface TxRequest extends BaseRequest {
    * The Concise Transaction ID to look up. Exactly one of `transaction` or `ctid` must be specified for a TxRequest.
    */
   ctid?: string
-  /**
-   * If true, return transaction data and metadata as binary serialized to
-   * hexadecimal strings. If false, return transaction data and metadata as.
-   * JSON. The default is false.
-   */
-  binary?: boolean
   /**
    * Use this with max_ledger to specify a range of up to 1000 ledger indexes,
    * starting with this ledger (inclusive). If the server cannot find the
@@ -47,15 +41,39 @@ export interface TxRequest extends BaseRequest {
   max_ledger?: number
 }
 
+export interface TxRequest extends TxRequestBase {
+  /**
+   * If true, return transaction data and metadata as binary serialized to
+   * hexadecimal strings. If false, return transaction data and metadata as.
+   * JSON. The default is false.
+   */
+  binary?: boolean
+}
+
+export interface TxBinaryRequest extends TxRequestBase {
+  /**
+   * If true, return transaction data and metadata as binary serialized to
+   * hexadecimal strings. If false, return transaction data and metadata as.
+   * JSON. The default is false.
+   */
+  binary: true
+}
+
+export interface TxJsonRequest extends TxRequestBase {
+  /**
+   * If true, return transaction data and metadata as binary serialized to
+   * hexadecimal strings. If false, return transaction data and metadata as.
+   * JSON. The default is false.
+   */
+  binary?: false
+}
+
 /**
  * Common properties of transaction responses.
  *
  * @category Responses
  */
-interface BaseTxResult<
-  Version extends APIVersion = typeof DEFAULT_API_VERSION,
-  T extends BaseTransaction = Transaction,
-> {
+interface BaseTxResult {
   /** The SHA-512 hash of the transaction. */
   hash: string
   /**
@@ -64,15 +82,6 @@ interface BaseTxResult<
   ctid?: string
   /** The ledger index of the ledger that includes this transaction. */
   ledger_index?: number
-  /** Unique hashed string Transaction metadata blob, which describes the results of the transaction.
-   *  Can be undefined if a transaction has not been validated yet. This field is omitted if binary
-   *  binary format is not requested. */
-  meta_blob?: Version extends typeof RIPPLED_API_V2
-    ? TransactionMetadata<T> | string
-    : never
-  /** Transaction metadata, which describes the results of the transaction.
-   *  Can be undefined if a transaction has not been validated yet. */
-  meta?: TransactionMetadata<T> | string
   /**
    * If true, this data comes from a validated ledger version; if omitted or.
    * Set to false, this data is not final.
@@ -88,6 +97,42 @@ interface BaseTxResult<
   date?: number
 }
 
+interface TxJsonResult<
+  T extends BaseTransaction = Transaction,
+> extends BaseTxResult {
+  /** Transaction metadata, which describes the results of the transaction.
+   *  Can be undefined if a transaction has not been validated yet. */
+  meta?: TransactionMetadata<T>
+}
+
+type RemoveIndexSignature<T> = T extends unknown
+  ? {
+      // Drop BaseTransaction's Record<string, unknown> index signature so
+      // unknown transaction fields are not treated as valid response fields.
+      [K in keyof T as string extends K
+        ? never
+        : number extends K
+          ? never
+          : symbol extends K
+            ? never
+            : K]: T[K]
+    }
+  : never
+
+interface TxBinaryResult extends BaseTxResult {
+  tx_blob: string
+  /** Unique hashed string Transaction metadata blob, which describes the results of the transaction.
+   *  Can be undefined if a transaction has not been validated yet. */
+  meta_blob: string
+}
+
+interface TxBinaryResultV1 extends BaseTxResult {
+  tx_blob: string
+  /** Unique hashed string Transaction metadata blob, which describes the results of the transaction.
+   *  Can be undefined if a transaction has not been validated yet. */
+  meta: string
+}
+
 /**
  * Response expected from a {@link TxRequest}.
  *
@@ -95,8 +140,9 @@ interface BaseTxResult<
  */
 export interface TxResponse<
   T extends BaseTransaction = Transaction,
+  B extends boolean = false,
 > extends BaseResponse {
-  result: BaseTxResult<typeof RIPPLED_API_V2, T> & { tx_json: T }
+  result: B extends true ? TxBinaryResult : TxJsonResult<T> & { tx_json: T }
   /**
    * If true, the server was able to search all of the specified ledger
    * versions, and the transaction was in none of them. If false, the server did
@@ -113,8 +159,11 @@ export interface TxResponse<
  */
 export interface TxV1Response<
   T extends BaseTransaction = Transaction,
+  B extends boolean = false,
 > extends BaseResponse {
-  result: BaseTxResult<typeof RIPPLED_API_V1, T> & T
+  result: B extends true
+    ? TxBinaryResultV1
+    : TxJsonResult<T> & RemoveIndexSignature<T>
   /**
    * If true, the server was able to search all of the specified ledger
    * versions, and the transaction was in none of them. If false, the server did
@@ -131,4 +180,7 @@ export interface TxV1Response<
  */
 export type TxVersionResponseMap<
   Version extends APIVersion = typeof DEFAULT_API_VERSION,
-> = Version extends typeof RIPPLED_API_V1 ? TxV1Response : TxResponse
+  B extends boolean = false,
+> = Version extends typeof RIPPLED_API_V1
+  ? TxV1Response<Transaction, B>
+  : TxResponse<Transaction, B>

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -34,25 +34,21 @@ interface TxRequestBase extends BaseRequest {
    * the requested range.
    */
   max_ledger?: number
+  /**
+   * If true, return transaction data and metadata as binary serialized to
+   * hexadecimal strings. If false, return transaction data and metadata as
+   * JSON. The default is false.
+   */
+  binary?: boolean
 }
 
 export type TxRequest = TxJsonRequest | TxBinaryRequest
 
 export interface TxBinaryRequest extends TxRequestBase {
-  /**
-   * If true, return transaction data and metadata as binary serialized to
-   * hexadecimal strings. If false, return transaction data and metadata as.
-   * JSON. The default is false.
-   */
   binary: true
 }
 
 export interface TxJsonRequest extends TxRequestBase {
-  /**
-   * If true, return transaction data and metadata as binary serialized to
-   * hexadecimal strings. If false, return transaction data and metadata as.
-   * JSON. The default is false.
-   */
   binary?: false
 }
 

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -1,9 +1,4 @@
-import {
-  APIVersion,
-  DEFAULT_API_VERSION,
-  RIPPLED_API_V1,
-  RIPPLED_API_V2,
-} from '../common'
+import { APIVersion, DEFAULT_API_VERSION, RIPPLED_API_V1 } from '../common'
 import { Transaction, TransactionMetadata } from '../transactions'
 import { BaseTransaction } from '../transactions/common'
 
@@ -41,14 +36,7 @@ interface TxRequestBase extends BaseRequest {
   max_ledger?: number
 }
 
-export interface TxRequest extends TxRequestBase {
-  /**
-   * If true, return transaction data and metadata as binary serialized to
-   * hexadecimal strings. If false, return transaction data and metadata as.
-   * JSON. The default is false.
-   */
-  binary?: boolean
-}
+export type TxRequest = TxJsonRequest | TxBinaryRequest
 
 export interface TxBinaryRequest extends TxRequestBase {
   /**

--- a/packages/xrpl/src/models/methods/tx.ts
+++ b/packages/xrpl/src/models/methods/tx.ts
@@ -123,14 +123,14 @@ interface TxBinaryResult extends BaseTxResult {
   tx_blob: string
   /** Unique hashed string Transaction metadata blob, which describes the results of the transaction.
    *  Can be undefined if a transaction has not been validated yet. */
-  meta_blob: string
+  meta_blob?: string
 }
 
 interface TxBinaryResultV1 extends BaseTxResult {
   tx_blob: string
   /** Unique hashed string Transaction metadata blob, which describes the results of the transaction.
    *  Can be undefined if a transaction has not been validated yet. */
-  meta: string
+  meta?: string
 }
 
 /**

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -156,7 +156,8 @@ describe('tx', function () {
         binary: true,
       })
       assert.isDefined(txBinaryResponse.result.tx)
-      assert.isDefined(txBinaryResponse.result.meta)
+      // meta is undefined since not validated tx
+      assert.isUndefined(txBinaryResponse.result.meta)
       // @ts-expect-error: tx_json is not defined for binary responses
       assert.isUndefined(txBinaryResponse.result.tx_json)
       // @ts-expect-error: tx_blob is not defined for binary responses V1

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -4,7 +4,6 @@ import {
   AccountSet,
   hashes,
   SubmitResponse,
-  TxRequest,
   TxResponse,
   TxV1Response,
 } from '../../../src'
@@ -29,7 +28,7 @@ describe('tx', function () {
   afterEach(async () => teardownClient(testContext))
 
   it(
-    'base',
+    'uses api_version 2 (default)',
     async () => {
       const account = testContext.wallet.classicAddress
       const accountSet: AccountSet = {
@@ -51,6 +50,11 @@ describe('tx', function () {
         transaction: hash,
       })
 
+      assert.isDefined(txResponse.result.tx_json)
+      assert.isDefined(txResponse.result.meta)
+      // @ts-expect-error: meta_blob is only defined for binary responses
+      assert.isUndefined(txResponse.result.meta_blob)
+
       const expectedResponse: TxResponse = {
         api_version: 2,
         id: txResponse.id,
@@ -71,6 +75,19 @@ describe('tx', function () {
       }
 
       assert.deepEqual(txResponse, expectedResponse)
+
+      // test with binary response
+      const txBinaryResponse = await testContext.client.request({
+        command: 'tx',
+        transaction: hash,
+        binary: true,
+      })
+      assert.isDefined(txBinaryResponse.result.tx_blob)
+      assert.isDefined(txBinaryResponse.result.meta_blob)
+      // @ts-expect-error: tx_json is not defined for binary responses
+      assert.isUndefined(txBinaryResponse.result.tx_json)
+      // @ts-expect-error: meta is not defined for binary responses
+      assert.isUndefined(txBinaryResponse.result.meta)
     },
     TIMEOUT,
   )
@@ -93,11 +110,17 @@ describe('tx', function () {
       )
 
       const hash = hashSignedTx(response.result.tx_blob)
-      const txV1Response = await testContext.client.request<TxRequest, 1>({
+      const txV1Response = await testContext.client.request({
         command: 'tx',
         transaction: hash,
         api_version: 1,
       })
+
+      assert.isDefined(txV1Response.result.meta)
+      // @ts-expect-error: tx_json is not defined for api_version 1 responses
+      assert.isUndefined(txV1Response.result.tx_json)
+      // @ts-expect-error: meta_blob is only defined for binary responses
+      assert.isUndefined(txV1Response.result.meta_blob)
 
       const expectedResponse: TxV1Response = {
         api_version: 1,
@@ -117,6 +140,20 @@ describe('tx', function () {
       }
 
       assert.deepEqual(txV1Response, expectedResponse)
+
+      // test with binary response
+      const txBinaryResponse = await testContext.client.request({
+        command: 'tx',
+        transaction: hash,
+        api_version: 1,
+        binary: true,
+      })
+      assert.isDefined(txBinaryResponse.result.tx_blob)
+      assert.isDefined(txBinaryResponse.result.meta)
+      // @ts-expect-error: tx_json is not defined for binary responses
+      assert.isUndefined(txBinaryResponse.result.tx_json)
+      // @ts-expect-error: meta_blob is not defined for binary responses V1
+      assert.isDefined(txBinaryResponse.result.meta_blob)
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -51,7 +51,10 @@ describe('tx', function () {
       })
 
       assert.isDefined(txResponse.result.tx_json)
-      assert.isDefined(txResponse.result.meta)
+      // meta is undefined since not validated tx
+      assert.isUndefined(txResponse.result.meta)
+      // @ts-expect-error: meta_blob is only defined for binary responses
+      assert.isUndefined(txResponse.result.tx_blob)
       // @ts-expect-error: meta_blob is only defined for binary responses
       assert.isUndefined(txResponse.result.meta_blob)
 
@@ -116,7 +119,8 @@ describe('tx', function () {
         api_version: 1,
       })
 
-      assert.isDefined(txV1Response.result.meta)
+      // meta is undefined since not validated tx
+      assert.isUndefined(txV1Response.result.meta)
       // @ts-expect-error: tx_json is not defined for api_version 1 responses
       assert.isUndefined(txV1Response.result.tx_json)
       // @ts-expect-error: meta_blob is only defined for binary responses

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -88,6 +88,8 @@ describe('tx', function () {
       assert.isDefined(txBinaryResponse.result.tx_blob)
       // meta_blob is undefined since not validated tx
       assert.isUndefined(txBinaryResponse.result.meta_blob)
+      // @ts-expect-error: tx is not defined for binary responses V2
+      assert.isUndefined(txBinaryResponse.result.tx)
       // @ts-expect-error: tx_json is not defined for binary responses
       assert.isUndefined(txBinaryResponse.result.tx_json)
       // @ts-expect-error: meta is not defined for binary responses
@@ -153,10 +155,12 @@ describe('tx', function () {
         api_version: 1,
         binary: true,
       })
-      assert.isDefined(txBinaryResponse.result.tx_blob)
+      assert.isDefined(txBinaryResponse.result.tx)
       assert.isDefined(txBinaryResponse.result.meta)
       // @ts-expect-error: tx_json is not defined for binary responses
       assert.isUndefined(txBinaryResponse.result.tx_json)
+      // @ts-expect-error: tx_blob is not defined for binary responses V1
+      assert.isUndefined(txBinaryResponse.result.tx_blob)
       // @ts-expect-error: meta_blob is not defined for binary responses V1
       assert.isUndefined(txBinaryResponse.result.meta_blob)
     },

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -53,7 +53,7 @@ describe('tx', function () {
       assert.isDefined(txResponse.result.tx_json)
       // meta is undefined since not validated tx
       assert.isUndefined(txResponse.result.meta)
-      // @ts-expect-error: meta_blob is only defined for binary responses
+      // @ts-expect-error: tx_blob is only defined for binary responses
       assert.isUndefined(txResponse.result.tx_blob)
       // @ts-expect-error: meta_blob is only defined for binary responses
       assert.isUndefined(txResponse.result.meta_blob)
@@ -86,7 +86,8 @@ describe('tx', function () {
         binary: true,
       })
       assert.isDefined(txBinaryResponse.result.tx_blob)
-      assert.isDefined(txBinaryResponse.result.meta_blob)
+      // meta_blob is undefined since not validated tx
+      assert.isUndefined(txBinaryResponse.result.meta_blob)
       // @ts-expect-error: tx_json is not defined for binary responses
       assert.isUndefined(txBinaryResponse.result.tx_json)
       // @ts-expect-error: meta is not defined for binary responses

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -153,7 +153,7 @@ describe('tx', function () {
       // @ts-expect-error: tx_json is not defined for binary responses
       assert.isUndefined(txBinaryResponse.result.tx_json)
       // @ts-expect-error: meta_blob is not defined for binary responses V1
-      assert.isDefined(txBinaryResponse.result.meta_blob)
+      assert.isUndefined(txBinaryResponse.result.meta_blob)
     },
     TIMEOUT,
   )

--- a/packages/xrpl/test/integration/submitAndWait.test.ts
+++ b/packages/xrpl/test/integration/submitAndWait.test.ts
@@ -145,4 +145,21 @@ describe('client.submitAndWait', function () {
     },
     TIMEOUT,
   )
+
+  it('returns a TxResponse with the transaction data and metadata', async () => {
+    const accountSet: AccountSet = {
+      TransactionType: 'AccountSet',
+      Account: testContext.wallet.classicAddress,
+      Domain: convertStringToHex('example.com'),
+    }
+    const { tx_blob: signedAccountSet } = testContext.wallet.sign(
+      await testContext.client.autofill(accountSet),
+    )
+    const response = await testContext.client.submitAndWait(signedAccountSet)
+
+    assert.isDefined(response.result.tx_json)
+    assert.isDefined(response.result.meta)
+    // @ts-expect-error: meta_blob is only defined for binary responses
+    assert.isUndefined(response.result.meta_blob)
+  })
 })

--- a/packages/xrpl/test/integration/submitAndWait.test.ts
+++ b/packages/xrpl/test/integration/submitAndWait.test.ts
@@ -155,11 +155,17 @@ describe('client.submitAndWait', function () {
     const { tx_blob: signedAccountSet } = testContext.wallet.sign(
       await testContext.client.autofill(accountSet),
     )
-    const response = await testContext.client.submitAndWait(signedAccountSet)
-
-    assert.isDefined(response.result.tx_json)
-    assert.isDefined(response.result.meta)
-    // @ts-expect-error: meta_blob is only defined for binary responses
-    assert.isUndefined(response.result.meta_blob)
+    const responsePromise = testContext.client.submitAndWait(signedAccountSet)
+    const ledgerPromise = delayedLedgerAccept()
+    return Promise.all([responsePromise, ledgerPromise]).then(
+      ([response, _ledger]) => {
+        assert.isDefined(response.result.tx_json)
+        assert.isDefined(response.result.meta)
+        // @ts-expect-error: tx_blob is only defined for binary responses
+        assert.isUndefined(response.result.tx_blob)
+        // @ts-expect-error: meta_blob is only defined for binary responses
+        assert.isUndefined(response.result.meta_blob)
+      },
+    )
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Make `TxResponse` type-safe based on the `binary` field and `api_version` value in `TxRequest`. Previously, the response type did not precisely distinguish JSON and binary transaction responses, or API v1 and API v2 response shapes. Now TypeScript narrows the response type so `tx_json`, `tx_blob`, `meta`, and `meta_blob` are only available on the response variants where they are actually returned.

## Context of Change

When using `client.request()` with a `TxRequest`, developers could not rely on the request fields to get an accurate response type. For example, `binary: true` still allowed JSON-only fields in the response type, and `api_version: 1` required explicitly passing a generic type parameter to get the API v1 response shape.

This change adds `TxBinaryRequest` and `TxJsonRequest`, maps them to the correct `TxVersionResponseMap`, and updates `Client.request()` so the `api_version` literal from the request is used for response inference. This follows the existing type-narrowing pattern used by similar request/response pairs.

### APIVersion=2 and binary=false
- before
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
})

txResponse.result.tx_json =>  Transaction
txResponse.result.tx_blob => Not Defined
txResponse.result.meta => TransactionMeta | string | undefined
txResponse.result.meta_blob => TransactionMetadata
```

- after
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
})

txResponse.result.tx_json =>  Transaction
txResponse.result.tx_blob => Not Defined
txResponse.result.meta => TransactionMeta | undefined
txResponse.result.meta_blob => Not Defined
```

### APIVersion=2 and binary=true
- before
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
  binary: true,
})

txResponse.result.tx_json =>  Transaction
txResponse.result.tx_blob => Not Defined
txResponse.result.meta => TransactionMeta | string | undefined
txResponse.result.meta_blob => TransactionMetadata | string | undefined
```

- after
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
  binary: true,
})

txResponse.result.tx_json =>  Not Defined
txResponse.result.tx_blob => string
txResponse.result.meta => string | undefined
txResponse.result.meta_blob => string | undefined
```

### APIVersion=1 and binary=false
- before
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
  api_version: 1,
})


txResponse.result.Fee=> Defined (Transaction Field)
txResponse.result.tx_json => Not Defined
txResponse.result.tx_blob => Not Defined
txResponse.result.meta => TransactionMeta | string | undefined
txResponse.result.meta_blob => undefined
```

- after
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
})

txResponse.result.Fee=> Defined (Transaction Field)
txResponse.result.tx_json =>  Not Defined
txResponse.result.tx_blob => Not Defined
txResponse.result.meta => TransactionMeta | undefined
txResponse.result.meta_blob => Not Defined
```

### APIVersion=1 and binary=true
- before
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
  api_version: 1,
  binary: true,
})

txResponse.result.Fee=> Defined (Transaction Field)
txResponse.result.tx_json => Not Defined
txResponse.result.tx_blob => Not Defined
txResponse.result.tx => Not Defined
txResponse.result.meta => TransactionMeta | string | undefined
txResponse.result.meta_blob => undefined
```

- after
```ts
const txResponse = await testContext.client.request({
  command: 'tx',
  transaction: hash,
  binary: true,
})

txResponse.result.Fee=> Not Defined (Transaction Field)
txResponse.result.tx_json =>  Not Defined
txResponse.result.tx_blob => Not Defined
txResponse.result.tx => string
txResponse.result.meta => string | undefined
txResponse.result.meta_blob => undefined
```

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Did you update HISTORY.md?

- [x] No (this is a types-only change)