### PR TITLE
fix(ripple-binary-codec): prevent Amount.toJSON() from mutating internal buffer (#3319)

### DIFF
--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -6,6 +6,7 @@
 * Fix: Include the last byte in the comparison operator of `Hash[128|256]` types.
 * Fix: Validate the input of non-numeric values for `Amount` field.
 * Fix: Add validation checks for negative inputs to `read`, `peek` and `skip` methods in the binary-codec.
+* Fix: `Amount.toJSON()` no longer mutates the internal buffer for native XRP amounts; subsequent calls and re-serializations now return consistent values (#3319).
 
 ## 2.7.0 (2026-02-12)
 

--- a/packages/ripple-binary-codec/src/types/amount.ts
+++ b/packages/ripple-binary-codec/src/types/amount.ts
@@ -194,7 +194,7 @@ class Amount extends SerializedType {
    */
   toJSON(): AmountObject | string {
     if (this.isNative()) {
-      const bytes = this.bytes
+      const bytes = this.bytes.slice()
       const isPositive = bytes[0] & 0x40
       const sign = isPositive ? '' : '-'
       bytes[0] &= 0x3f

--- a/packages/ripple-binary-codec/test/amount.test.ts
+++ b/packages/ripple-binary-codec/test/amount.test.ts
@@ -90,5 +90,14 @@ describe('Amount', function () {
     )
   })
 
+  it('toJSON() does not mutate internal buffer for native XRP amounts', function () {
+    const amt = Amount.from('1000000')
+    const hexBefore = amt.toHex()
+    const first = amt.toJSON()
+    const second = amt.toJSON()
+    expect(second).toEqual(first)
+    expect(amt.toHex()).toEqual(hexBefore)
+  })
+
   amountErrorTests()
 })

--- a/packages/ripple-binary-codec/test/amount.test.ts
+++ b/packages/ripple-binary-codec/test/amount.test.ts
@@ -99,5 +99,55 @@ describe('Amount', function () {
     expect(amt.toHex()).toEqual(hexBefore)
   })
 
+  it('toJSON() does not mutate internal buffer for IOU amounts', function () {
+    const amt = Amount.from({
+      value: '1',
+      issuer: '0000000000000000000000000000000000000000',
+      currency: 'USD',
+    })
+    const hexBefore = amt.toHex()
+    const first = amt.toJSON()
+    const second = amt.toJSON()
+    expect(second).toEqual(first)
+    expect(amt.toHex()).toEqual(hexBefore)
+  })
+
+  it('toJSON() does not mutate internal buffer for negative IOU amounts', function () {
+    const amt = Amount.from({
+      value: '-1',
+      issuer: '0000000000000000000000000000000000000000',
+      currency: 'USD',
+    })
+    const hexBefore = amt.toHex()
+    const first = amt.toJSON()
+    const second = amt.toJSON()
+    expect(second).toEqual(first)
+    expect(amt.toHex()).toEqual(hexBefore)
+  })
+
+  it('toJSON() does not mutate internal buffer for MPT amounts', function () {
+    const amt = Amount.from({
+      value: '100',
+      mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    })
+    const hexBefore = amt.toHex()
+    const first = amt.toJSON()
+    const second = amt.toJSON()
+    expect(second).toEqual(first)
+    expect(amt.toHex()).toEqual(hexBefore)
+  })
+
+  it('toJSON() does not mutate internal buffer for negative MPT amounts', function () {
+    const parser = makeParser(
+      '20000000000000006400002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    )
+    const amt = parser.readType(Amount)
+    const hexBefore = amt.toHex()
+    const first = amt.toJSON()
+    const second = amt.toJSON()
+    expect(second).toEqual(first)
+    expect(amt.toHex()).toEqual(hexBefore)
+  })
+
   amountErrorTests()
 })

--- a/packages/ripple-binary-codec/test/amount.test.ts
+++ b/packages/ripple-binary-codec/test/amount.test.ts
@@ -92,11 +92,11 @@ describe('Amount', function () {
 
   it('toJSON() does not mutate internal buffer for native XRP amounts', function () {
     const amt = Amount.from('1000000')
-    const hexBefore = amt.toHex()
-    const first = amt.toJSON()
-    const second = amt.toJSON()
-    expect(second).toEqual(first)
-    expect(amt.toHex()).toEqual(hexBefore)
+    const serializedHexBeforeJsonCalls = amt.toHex()
+    const firstJsonResult = amt.toJSON()
+    const secondJsonResult = amt.toJSON()
+    expect(secondJsonResult).toEqual(firstJsonResult)
+    expect(amt.toHex()).toEqual(serializedHexBeforeJsonCalls)
   })
 
   it('toJSON() does not mutate internal buffer for IOU amounts', function () {
@@ -105,11 +105,11 @@ describe('Amount', function () {
       issuer: '0000000000000000000000000000000000000000',
       currency: 'USD',
     })
-    const hexBefore = amt.toHex()
-    const first = amt.toJSON()
-    const second = amt.toJSON()
-    expect(second).toEqual(first)
-    expect(amt.toHex()).toEqual(hexBefore)
+    const serializedHexBeforeJsonCalls = amt.toHex()
+    const firstJsonResult = amt.toJSON()
+    const secondJsonResult = amt.toJSON()
+    expect(secondJsonResult).toEqual(firstJsonResult)
+    expect(amt.toHex()).toEqual(serializedHexBeforeJsonCalls)
   })
 
   it('toJSON() does not mutate internal buffer for negative IOU amounts', function () {
@@ -118,11 +118,11 @@ describe('Amount', function () {
       issuer: '0000000000000000000000000000000000000000',
       currency: 'USD',
     })
-    const hexBefore = amt.toHex()
-    const first = amt.toJSON()
-    const second = amt.toJSON()
-    expect(second).toEqual(first)
-    expect(amt.toHex()).toEqual(hexBefore)
+    const serializedHexBeforeJsonCalls = amt.toHex()
+    const firstJsonResult = amt.toJSON()
+    const secondJsonResult = amt.toJSON()
+    expect(secondJsonResult).toEqual(firstJsonResult)
+    expect(amt.toHex()).toEqual(serializedHexBeforeJsonCalls)
   })
 
   it('toJSON() does not mutate internal buffer for MPT amounts', function () {
@@ -130,11 +130,11 @@ describe('Amount', function () {
       value: '100',
       mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
     })
-    const hexBefore = amt.toHex()
-    const first = amt.toJSON()
-    const second = amt.toJSON()
-    expect(second).toEqual(first)
-    expect(amt.toHex()).toEqual(hexBefore)
+    const serializedHexBeforeJsonCalls = amt.toHex()
+    const firstJsonResult = amt.toJSON()
+    const secondJsonResult = amt.toJSON()
+    expect(secondJsonResult).toEqual(firstJsonResult)
+    expect(amt.toHex()).toEqual(serializedHexBeforeJsonCalls)
   })
 
   it('toJSON() does not mutate internal buffer for negative MPT amounts', function () {
@@ -142,11 +142,11 @@ describe('Amount', function () {
       '20000000000000006400002403C84A0A28E0190E208E982C352BBD5006600555CF',
     )
     const amt = parser.readType(Amount)
-    const hexBefore = amt.toHex()
-    const first = amt.toJSON()
-    const second = amt.toJSON()
-    expect(second).toEqual(first)
-    expect(amt.toHex()).toEqual(hexBefore)
+    const serializedHexBeforeJsonCalls = amt.toHex()
+    const firstJsonResult = amt.toJSON()
+    const secondJsonResult = amt.toJSON()
+    expect(secondJsonResult).toEqual(firstJsonResult)
+    expect(amt.toHex()).toEqual(serializedHexBeforeJsonCalls)
   })
 
   amountErrorTests()


### PR DESCRIPTION
## High Level Overview of Change

- Fixes [#3319](https://github.com/XRPLF/xrpl.js/issues/3319): `Amount.toJSON()` mutated the internal byte buffer for native XRP amounts, so consecutive calls produced different results (transaction-malleability vector).
- Adds idempotency regression tests for the native XRP, IOU (positive + negative), and MPT (positive + negative) branches of `Amount.toJSON()`.

### Context of Change

The native-XRP branch of `Amount.toJSON()` did `const bytes = this.bytes` and then `bytes[0] &= 0x3f` to clear the type/sign discrimination bits. Because `this.bytes` is a `Uint8Array`, the local `bytes` was a reference (not a copy), so the mask mutated the `SerializedType`'s internal buffer in place.

This is a transaction-malleability vector — `serialize → deserialize → toJSON() → re-serialize` produces different bytes. The IOU and MPT branches construct a fresh `BinaryParser(this.toString())`, so their internal masking does not alias `this.bytes` and is unaffected.


### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Did you update HISTORY.md?

- [x] Yes

## Test Plan

- 5 new idempotency tests covering native XRP, IOU (positive + negative), and MPT (positive + negative).
- Verified the new native-XRP idempotency test **fails** against the pre-fix code.
- IOU and MPT idempotency tests pass both before and after the fix (the bug was native-XRP-only); they are added as forward regressions in case those branches are ever rewritten to read from `this.bytes` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)