### PR TITLE
fix(xrpl): throw on server_info failure or missing network_id (#3321)

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -6,6 +6,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ### BREAKING CHANGES:
 * `ED25519` is the default signing-algorithm used in the `Wallet.fromMnemonic` method. Users can explicitly specify `ecdsa-secp256k1` to retrieve the cryptographic material created using older versions of this package.
+* `Client.getServerInfo()` and `Client.connect()` now throw if the `server_info` request fails, or if the response succeeds but does not include a `network_id`. Previously, these failures were swallowed and only logged via `console.error`, leaving `client.networkID` undefined and causing `autofill()` to omit the `NetworkID` field — producing transactions valid on the wrong network. Servers running rippled <1.11 (which do not return `network_id`) will now fail to connect; upgrade to rippled 1.11+ or set `client.networkID` manually after construction.
 
 ### Added
 * Add new fields to `ServerDefinitionsResponse`: `ACCOUNT_SET_FLAGS`, `LEDGER_ENTRY_FLAGS`, `LEDGER_ENTRY_FORMATS`, `TRANSACTION_FLAGS`, and `TRANSACTION_FORMATS`, reflecting new sections returned by `server_definitions` in rippled.
@@ -14,6 +15,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Fix event listener accumulation bug where `'connected'` event handlers would fire multiple times after each reconnection. The fix cleans up stale listeners from previous reconnect attempts to prevent duplicate event emissions on flaky connections with multiple sequential reconnect attempts.
 * Disallow the input of Authorization Credentials over insecure WebSocket connections (`ws[+unix]?://`) to prevent MITM eavesdropping of sensitive data.
 * Fix incorrect `MPTAmount` field type to `string` instead of `MPTAmount`.
+* Fix `Client.getServerInfo()` swallowing errors from the underlying `server_info` request, which left `client.networkID` undefined and caused `autofill()` to silently omit the `NetworkID` field — producing signed transactions valid on the wrong network (cross-network replay risk). The method now throws on request failure or when the response is missing `network_id`. ([#3321](https://github.com/XRPLF/xrpl.js/issues/3321))
 
 ## 4.6.0 (2026-02-12)
 

--- a/packages/xrpl/src/client/index.ts
+++ b/packages/xrpl/src/client/index.ts
@@ -523,9 +523,19 @@ class Client extends EventEmitter<EventTypes> {
   }
 
   /**
-   * Get networkID and buildVersion from server_info
+   * Get networkID and buildVersion from server_info.
+   *
+   * Throws if the underlying `server_info` request fails (e.g. `RippledError`
+   * for `noNetwork` / `notSynced`, `DisconnectedError`, `TimeoutError`), or if
+   * the response succeeds but does not include `network_id`. Callers must
+   * handle these — letting them propagate is intentional, since signing a
+   * transaction without a known network ID can produce a signature that is
+   * valid on the wrong network (cross-network replay).
    *
    * @returns void
+   * @throws {XrplError} If the `server_info` response does not include a `network_id`.
+   * @throws {RippledError} If rippled returns an error (e.g. server not synced to network).
+   * @throws {DisconnectedError | TimeoutError | NotConnectedError} If the request cannot reach the server.
    * @example
    * ```ts
    * const { Client } = require('xrpl')
@@ -536,15 +546,15 @@ class Client extends EventEmitter<EventTypes> {
    * ```
    */
   public async getServerInfo(): Promise<void> {
-    try {
-      const response = await this.request({
-        command: 'server_info',
-      })
-      this.networkID = response.result.info.network_id ?? undefined
-      this.buildVersion = response.result.info.build_version
-    } catch (error) {
-      // eslint-disable-next-line no-console -- Print the error to console but allows client to be connected.
-      console.error(error)
+    const response = await this.request({
+      command: 'server_info',
+    })
+    this.networkID = response.result.info.network_id ?? undefined
+    this.buildVersion = response.result.info.build_version
+    if (this.networkID === undefined) {
+      throw new XrplError(
+        'server_info response is missing network_id; cannot safely sign transactions without a known network ID',
+      )
     }
   }
 

--- a/packages/xrpl/test/client/getServerInfo.test.ts
+++ b/packages/xrpl/test/client/getServerInfo.test.ts
@@ -1,0 +1,167 @@
+import { assert } from 'chai'
+
+import { Client } from '../../src'
+import createMockRippled, {
+  type MockedWebSocketServer,
+} from '../createMockRippled'
+import rippled from '../fixtures/rippled'
+import { destroyServer, getFreePort } from '../testUtils'
+
+const TIMEOUT = 20000
+
+describe('client.getServerInfo', function () {
+  let mockRippled: MockedWebSocketServer
+  let client: Client
+  let port: number
+
+  beforeEach(async () => {
+    port = await getFreePort()
+    mockRippled = createMockRippled(port)
+    client = new Client(`ws://localhost:${port}`)
+    client.on('error', () => {
+      // Required to avoid unhandled error events from reconnect attempts
+    })
+  })
+
+  afterEach(async () => {
+    if (client.isConnected()) {
+      await client.disconnect()
+    }
+    await new Promise<void>((resolve) => {
+      mockRippled.close(() => resolve())
+    })
+    await destroyServer(port)
+  })
+
+  it(
+    'connect() rejects when server_info request fails',
+    async () => {
+      mockRippled.addResponse('server_info', {
+        id: 0,
+        status: 'error',
+        type: 'response',
+        error: 'noNetwork',
+        error_code: 17,
+        error_message: 'Not synced to the network.',
+        request: { command: 'server_info', id: 0 },
+      })
+
+      let connectError: Error | undefined
+      try {
+        await client.connect()
+      } catch (err) {
+        connectError = err as Error
+      }
+
+      assert.isDefined(
+        connectError,
+        'connect() should reject when server_info fails so that signed transactions cannot accidentally omit NetworkID',
+      )
+      assert.strictEqual(client.networkID, undefined)
+      assert.strictEqual(client.buildVersion, undefined)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'getServerInfo() throws when server_info request fails',
+    async () => {
+      mockRippled.addResponse('server_info', rippled.server_info.withNetworkId)
+      await client.connect()
+
+      mockRippled.addResponse('server_info', {
+        id: 0,
+        status: 'error',
+        type: 'response',
+        error: 'noNetwork',
+        error_code: 17,
+        error_message: 'Not synced to the network.',
+        request: { command: 'server_info', id: 0 },
+      })
+
+      let getServerInfoError: Error | undefined
+      try {
+        await client.getServerInfo()
+      } catch (err) {
+        getServerInfoError = err as Error
+      }
+
+      assert.isDefined(
+        getServerInfoError,
+        'getServerInfo() should propagate the underlying request error rather than swallow it',
+      )
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'connect() populates networkID and buildVersion on success',
+    async () => {
+      mockRippled.addResponse('server_info', rippled.server_info.withNetworkId)
+
+      await client.connect()
+
+      assert.strictEqual(
+        client.networkID,
+        rippled.server_info.withNetworkId.result.info.network_id,
+      )
+      assert.strictEqual(
+        client.buildVersion,
+        rippled.server_info.withNetworkId.result.info.build_version,
+      )
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'connect() rejects when server_info succeeds without network_id',
+    async () => {
+      const responseWithoutNetworkId = JSON.parse(
+        JSON.stringify(rippled.server_info.withNetworkId),
+      )
+      delete responseWithoutNetworkId.result.info.network_id
+      mockRippled.addResponse('server_info', responseWithoutNetworkId)
+
+      let connectError: Error | undefined
+      try {
+        await client.connect()
+      } catch (err) {
+        connectError = err as Error
+      }
+
+      assert.isDefined(
+        connectError,
+        'connect() should reject when server_info returns no network_id, since signing without a known network ID can produce cross-network-replayable transactions',
+      )
+      assert.strictEqual(client.networkID, undefined)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'getServerInfo() throws when server_info succeeds without network_id',
+    async () => {
+      mockRippled.addResponse('server_info', rippled.server_info.withNetworkId)
+      await client.connect()
+
+      const responseWithoutNetworkId = JSON.parse(
+        JSON.stringify(rippled.server_info.withNetworkId),
+      )
+      delete responseWithoutNetworkId.result.info.network_id
+      mockRippled.addResponse('server_info', responseWithoutNetworkId)
+
+      let getServerInfoError: Error | undefined
+      try {
+        await client.getServerInfo()
+      } catch (err) {
+        getServerInfoError = err as Error
+      }
+
+      assert.isDefined(
+        getServerInfoError,
+        'getServerInfo() should throw when server_info returns no network_id, since signing without a known network ID can produce cross-network-replayable transactions',
+      )
+    },
+    TIMEOUT,
+  )
+})


### PR DESCRIPTION
Fixes #3321.

## High Level Overview of Change

`Client.getServerInfo()` previously caught errors from the `server_info` request and only logged them via `console.error`, leaving `client.networkID` undefined. Downstream, `txNeedsNetworkID()` returned false, so `autofill()` silently omitted the `NetworkID` field from signed transactions — making them valid on the wrong network (cross-network replay risk).

The method now propagates request errors and throws if the response is missing `network_id`.

### Context of Change

Breaking change for clients connecting to rippled <1.11 (which does not return `network_id`); upgrade rippled or set `client.networkID` manually after construction.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Did you update HISTORY.md?

- [x] Yes

## Test Plan

New unit tests in `packages/xrpl/test/client/getServerInfo.test.ts`:

- `connect()` rejects when `server_info` returns an error
- `getServerInfo()` throws when `server_info` returns an error
- `connect()` rejects when `server_info` succeeds without `network_id`
- `getServerInfo()` throws when `server_info` succeeds without `network_id`

All four were confirmed to fail against pre-fix code.