### PR TITLE
fix(xrpl): use deep amount comparison in handleDeliverMax (#3313)

### DIFF
--- a/packages/xrpl/src/client/partialPayment.ts
+++ b/packages/xrpl/src/client/partialPayment.ts
@@ -28,7 +28,16 @@ const WARN_PARTIAL_PAYMENT_CODE = 2001
 
 /* eslint-disable complexity -- check different token types */
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- known currency type */
-function amountsEqual(
+/**
+ * Returns true when two transaction amounts represent the same on-ledger value.
+ *
+ * Handles all three amount shapes (XRP string, IOU object, MPT object) and uses
+ * `BigNumber` for the numeric `value` field so `"1.0"` and `"1"` compare equal.
+ * Exported so callers outside this module (notably `handleDeliverMax` in
+ * `sugar/autofill.ts`) can avoid reference-equality bugs on IOU/MPT objects —
+ * see issue #3313.
+ */
+export function amountsEqual(
   amt1: Amount | MPTAmount,
   amt2: Amount | MPTAmount,
 ): boolean {

--- a/packages/xrpl/src/sugar/autofill.ts
+++ b/packages/xrpl/src/sugar/autofill.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import { xAddressToClassicAddress, isValidXAddress } from 'ripple-address-codec'
 
 import { type Client } from '..'
+import { amountsEqual } from '../client/partialPayment'
 import { ValidationError, XrplError } from '../errors'
 import { LoanBroker } from '../models/ledger'
 import {
@@ -478,8 +479,12 @@ export function handleDeliverMax(tx: Payment): void {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-param-reassign -- needed here
     tx.Amount ??= tx.DeliverMax
 
+    // Use `amountsEqual` rather than `!==` so two distinct objects with identical
+    // currency/issuer/value fields don't trigger a spurious validation error. The previous
+    // reference-equality check rejected every IOU payment whose caller built `Amount` and
+    // `DeliverMax` as separate object literals (issue #3313).
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- needed here
-    if (tx.Amount != null && tx.Amount !== tx.DeliverMax) {
+    if (tx.Amount != null && !amountsEqual(tx.Amount, tx.DeliverMax)) {
       throw new ValidationError(
         'PaymentTransaction: Amount and DeliverMax fields must be identical when both are provided',
       )

--- a/packages/xrpl/test/client/autofill.test.ts
+++ b/packages/xrpl/test/client/autofill.test.ts
@@ -105,6 +105,31 @@ describe('client.autofill', function () {
     await assertRejects(testContext.client.autofill(paymentTx), ValidationError)
   })
 
+  it('Validate Payment transaction API v2: Payment Transaction: identical IOU DeliverMax and Amount as separate objects (#3313)', async function () {
+    // Regression test: the previous `tx.Amount !== tx.DeliverMax` used reference equality,
+    // which always returned false for two distinct IssuedCurrencyAmount object literals
+    // even when their fields were identical — every IOU payment that set both fields was
+    // rejected.
+    const issuer = 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X'
+    paymentTx.Amount = { currency: 'USD', issuer, value: '100' }
+    paymentTx.DeliverMax = { currency: 'USD', issuer, value: '100' }
+
+    const txResult = await testContext.client.autofill(paymentTx)
+
+    assert.deepEqual(txResult.Amount, { currency: 'USD', issuer, value: '100' })
+    assert.strictEqual('DeliverMax' in txResult, false)
+  })
+
+  it('Validate Payment transaction API v2: Payment Transaction: differing IOU DeliverMax and Amount values still rejected', async function () {
+    // Companion to the case above: ensure the fix didn't loosen validation. Identical
+    // currency/issuer but different `value` must still throw.
+    const issuer = 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X'
+    paymentTx.Amount = { currency: 'USD', issuer, value: '100' }
+    paymentTx.DeliverMax = { currency: 'USD', issuer, value: '200' }
+
+    await assertRejects(testContext.client.autofill(paymentTx), ValidationError)
+  })
+
   it('should not autofill if fields are present', async function () {
     const tx: Transaction = {
       TransactionType: 'DepositPreauth',

--- a/packages/xrpl/test/client/autofill.test.ts
+++ b/packages/xrpl/test/client/autofill.test.ts
@@ -107,9 +107,9 @@ describe('client.autofill', function () {
 
   it('Validate Payment transaction API v2: Payment Transaction: identical IOU DeliverMax and Amount as separate objects (#3313)', async function () {
     // Regression test: the previous `tx.Amount !== tx.DeliverMax` used reference equality,
-    // which always returned false for two distinct IssuedCurrencyAmount object literals
-    // even when their fields were identical — every IOU payment that set both fields was
-    // rejected.
+    // which always returned true for two distinct IssuedCurrencyAmount object literals
+    // (different references, even with identical fields) — every IOU payment that set both
+    // fields as separate objects therefore tripped the validation throw.
     const issuer = 'r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X'
     paymentTx.Amount = { currency: 'USD', issuer, value: '100' }
     paymentTx.DeliverMax = { currency: 'USD', issuer, value: '100' }


### PR DESCRIPTION
Closes #3313.

## Summary

`handleDeliverMax` in `src/sugar/autofill.ts` compared the two fields with `!==` (reference equality). For IOU and MPT amounts — objects like `{currency, issuer, value}` — two distinct object literals with identical fields always compare not-equal, so every IOU payment that set both \`Amount\` and \`DeliverMax\` as separate object literals threw a spurious validation error:

```
PaymentTransaction: Amount and DeliverMax fields must be identical when both are provided
```

This silently broke any IOU payment flow that built the two fields independently (e.g. one constructed by the caller, the other autofilled from a higher-level helper).

## Fix

Reuse the existing `amountsEqual` helper from `src/client/partialPayment.ts`. It already handles all three amount shapes correctly:

- **XRP** (string drops): `===`
- **IOU**: `currency` + `issuer` + `BigNumber(value)` (so `"1.0"` and `"1"` compare equal)
- **MPT**: `mpt_issuance_id` + `BigNumber(value)`

Only change to `partialPayment.ts` is making `amountsEqual` exported (was previously file-local). Same implementation, just visible to other modules.

## Tests

Two new tests in `packages/xrpl/test/client/autofill.test.ts`:

1. **Regression** — identical IOU `Amount` and `DeliverMax` as **separate object literals** → must autofill cleanly. Fails on `main` (throws the spurious `ValidationError`), passes after.
2. **Companion** — different `value` with same `currency` / `issuer` → must still throw. Pins that the fix didn't loosen validation.

The pre-existing tests for the `=== string` path and the same-reference IOU case (`paymentTx.DeliverMax = paymentTx.Amount`) still pass.

## Smoke gate

- `npm run build` from repo root — all 6 workspaces build clean.
- `npx jest --config=jest.config.unit.js --testPathPatterns autofill` — 23 passed, 0 failed.