### PR TITLE
fix(connection): block reserved internal event types from server messages

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -16,6 +16,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 * Disallow the input of Authorization Credentials over insecure WebSocket connections (`ws[+unix]?://`) to prevent MITM eavesdropping of sensitive data.
 * Fix incorrect `MPTAmount` field type to `string` instead of `MPTAmount`.
 * Fix `Client.getServerInfo()` swallowing errors from the underlying `server_info` request, which left `client.networkID` undefined and caused `autofill()` to silently omit the `NetworkID` field — producing signed transactions valid on the wrong network (cross-network replay risk). The method now throws on request failure or when the response is missing `network_id`. ([#3321](https://github.com/XRPLF/xrpl.js/issues/3321))
+* Refuse to forward server-supplied `data.type` values that collide with `Connection`'s internal state events (`connected`, `disconnected`, `error`, `reconnect`). Previously a malicious or compromised server could inject `{"type":"connected"}` (and friends) over the wire and trigger spoofed local state transitions; the message is now dropped and surfaced as a `badMessage` error. ([#3318](https://github.com/XRPLF/xrpl.js/issues/3318))
 
 ## 4.6.0 (2026-02-12)
 

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -28,13 +28,14 @@ const CONNECTION_TIMEOUT = 5
  * of a server-supplied `data.type`, otherwise a malicious or compromised
  * rippled server could spoof connection state (e.g. claim the client is
  * `connected` when it is not, or inject a fake `error`/`disconnected`/
- * `reconnect` to drive the client into a bad state). See DGE-6740.
+ * `reconnect`/`reconnecting` to drive the client into a bad state).
  */
 const RESERVED_INTERNAL_EVENTS: ReadonlySet<string> = new Set([
   'connected',
   'disconnected',
   'error',
   'reconnect',
+  'reconnecting',
 ])
 
 /**
@@ -373,7 +374,7 @@ export class Connection extends EventEmitter {
       // Refuse to forward server-supplied event names that collide with
       // Connection's internal state events. Otherwise a rogue server could
       // spoof local connection state by sending e.g. `{"type":"connected"}`
-      // or `{"type":"error"}`. See DGE-6740.
+      // or `{"type":"error"}`.
       if (RESERVED_INTERNAL_EVENTS.has(type)) {
         this.emit(
           'error',

--- a/packages/xrpl/src/client/connection.ts
+++ b/packages/xrpl/src/client/connection.ts
@@ -23,6 +23,21 @@ const TIMEOUT = 20
 const CONNECTION_TIMEOUT = 5
 
 /**
+ * Event names that are emitted internally by Connection to signal local
+ * client/socket state transitions. These must never be emitted as a result
+ * of a server-supplied `data.type`, otherwise a malicious or compromised
+ * rippled server could spoof connection state (e.g. claim the client is
+ * `connected` when it is not, or inject a fake `error`/`disconnected`/
+ * `reconnect` to drive the client into a bad state). See DGE-6740.
+ */
+const RESERVED_INTERNAL_EVENTS: ReadonlySet<string> = new Set([
+  'connected',
+  'disconnected',
+  'error',
+  'reconnect',
+])
+
+/**
  * ConnectionOptions is the configuration for the Connection class.
  */
 interface ConnectionOptions {
@@ -354,7 +369,21 @@ export class Connection extends EventEmitter {
     }
     if (data.type) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Should be true
-      this.emit(data.type as string, data)
+      const type = data.type as string
+      // Refuse to forward server-supplied event names that collide with
+      // Connection's internal state events. Otherwise a rogue server could
+      // spoof local connection state by sending e.g. `{"type":"connected"}`
+      // or `{"type":"error"}`. See DGE-6740.
+      if (RESERVED_INTERNAL_EVENTS.has(type)) {
+        this.emit(
+          'error',
+          'badMessage',
+          `Server message used reserved internal event type "${type}"; dropping.`,
+          message,
+        )
+        return
+      }
+      this.emit(type, data)
     }
     if (data.type === 'response') {
       try {

--- a/packages/xrpl/test/connection.test.ts
+++ b/packages/xrpl/test/connection.test.ts
@@ -903,59 +903,31 @@ describe('Connection', function () {
     TIMEOUT,
   )
 
-  // DGE-6740: Server messages whose `type` collides with a reserved internal
-  // event name (`connected`, `disconnected`, `error`, `reconnect`) must not
-  // be forwarded as that internal event. Otherwise a rogue server could spoof
-  // connection state.
-  it.each(['connected', 'disconnected', 'reconnect'])(
+  // Server messages whose `type` collides with a reserved internal event
+  // name (`connected`, `disconnected`, `error`, `reconnect`, `reconnecting`)
+  // must not be forwarded as that internal event. Otherwise a rogue server
+  // could spoof connection state. For `error` specifically, we also verify
+  // the raw spoofed payload object never reaches 'error' listeners — only
+  // the synthesized `('error', 'badMessage', ...)` emission is allowed.
+  it.each(['connected', 'disconnected', 'reconnect', 'reconnecting', 'error'])(
     'drops server message with reserved internal event type "%s"',
     async (reservedType) => {
-      // If the fix regresses, the reserved listener will fire and we'll fail.
-      const spoofTrigger = new Promise<never>((_resolve, reject) => {
-        clientContext.client.connection.on(reservedType, () => {
-          reject(
-            new XrplError(
-              `Reserved internal event "${reservedType}" was emitted from a server message`,
-            ),
-          )
-        })
-      })
-
-      const errorReceived = new Promise<void>((resolve) => {
-        clientContext.client.connection.on(
-          'error',
-          (errorCode, errorMessage) => {
-            if (
-              errorCode === 'badMessage' &&
-              typeof errorMessage === 'string' &&
-              errorMessage.includes(reservedType)
-            ) {
-              resolve()
-            }
-          },
-        )
-      })
-
-      // @ts-expect-error -- Testing private member
-      clientContext.client.connection.onMessage(
-        JSON.stringify({ type: reservedType }),
-      )
-
-      await Promise.race([errorReceived, spoofTrigger])
-    },
-    TIMEOUT,
-  )
-
-  // DGE-6740: A spoofed `{"type":"error"}` payload must not be forwarded to
-  // 'error' listeners as the raw payload. Instead the fix emits an 'error'
-  // event whose first arg is the string code 'badMessage'. We verify the
-  // 'error' listener never receives the raw spoofed object.
-  it(
-    'drops server message with reserved internal event type "error"',
-    async () => {
-      const spoofedPayload = { type: 'error', error: 'spoof' }
+      const spoofedPayload = { type: reservedType, error: 'spoof' }
 
       const result = new Promise<void>((resolve, reject) => {
+        // For non-'error' reserved events, a direct listener on that event
+        // must never fire from a server message. (We can't attach this for
+        // 'error' because the fix itself emits 'error' to surface badMessage.)
+        if (reservedType !== 'error') {
+          clientContext.client.connection.on(reservedType, () => {
+            reject(
+              new XrplError(
+                `Reserved internal event "${reservedType}" was emitted from a server message`,
+              ),
+            )
+          })
+        }
+
         clientContext.client.connection.on(
           'error',
           (errorCodeOrPayload, errorMessage) => {
@@ -963,18 +935,17 @@ describe('Connection', function () {
             if (
               errorCodeOrPayload === 'badMessage' &&
               typeof errorMessage === 'string' &&
-              errorMessage.includes('error')
+              errorMessage.includes(reservedType)
             ) {
               resolve()
               return
             }
-            // Anything that looks like the spoofed payload object indicates
-            // the raw server message reached 'error' listeners, which is the
-            // exact bug being fixed.
+            // If the raw spoofed payload object reaches 'error' listeners,
+            // the type:"error" spoof bug has regressed.
             if (
               errorCodeOrPayload != null &&
               typeof errorCodeOrPayload === 'object' &&
-              (errorCodeOrPayload as { type?: unknown }).type === 'error'
+              (errorCodeOrPayload as { type?: unknown }).type === reservedType
             ) {
               reject(
                 new XrplError(

--- a/packages/xrpl/test/connection.test.ts
+++ b/packages/xrpl/test/connection.test.ts
@@ -903,6 +903,97 @@ describe('Connection', function () {
     TIMEOUT,
   )
 
+  // DGE-6740: Server messages whose `type` collides with a reserved internal
+  // event name (`connected`, `disconnected`, `error`, `reconnect`) must not
+  // be forwarded as that internal event. Otherwise a rogue server could spoof
+  // connection state.
+  it.each(['connected', 'disconnected', 'reconnect'])(
+    'drops server message with reserved internal event type "%s"',
+    async (reservedType) => {
+      // If the fix regresses, the reserved listener will fire and we'll fail.
+      const spoofTrigger = new Promise<never>((_resolve, reject) => {
+        clientContext.client.connection.on(reservedType, () => {
+          reject(
+            new XrplError(
+              `Reserved internal event "${reservedType}" was emitted from a server message`,
+            ),
+          )
+        })
+      })
+
+      const errorReceived = new Promise<void>((resolve) => {
+        clientContext.client.connection.on(
+          'error',
+          (errorCode, errorMessage) => {
+            if (
+              errorCode === 'badMessage' &&
+              typeof errorMessage === 'string' &&
+              errorMessage.includes(reservedType)
+            ) {
+              resolve()
+            }
+          },
+        )
+      })
+
+      // @ts-expect-error -- Testing private member
+      clientContext.client.connection.onMessage(
+        JSON.stringify({ type: reservedType }),
+      )
+
+      await Promise.race([errorReceived, spoofTrigger])
+    },
+    TIMEOUT,
+  )
+
+  // DGE-6740: A spoofed `{"type":"error"}` payload must not be forwarded to
+  // 'error' listeners as the raw payload. Instead the fix emits an 'error'
+  // event whose first arg is the string code 'badMessage'. We verify the
+  // 'error' listener never receives the raw spoofed object.
+  it(
+    'drops server message with reserved internal event type "error"',
+    async () => {
+      const spoofedPayload = { type: 'error', error: 'spoof' }
+
+      const result = new Promise<void>((resolve, reject) => {
+        clientContext.client.connection.on(
+          'error',
+          (errorCodeOrPayload, errorMessage) => {
+            // The fix's emission: emit('error', 'badMessage', '<msg>', rawJson).
+            if (
+              errorCodeOrPayload === 'badMessage' &&
+              typeof errorMessage === 'string' &&
+              errorMessage.includes('error')
+            ) {
+              resolve()
+              return
+            }
+            // Anything that looks like the spoofed payload object indicates
+            // the raw server message reached 'error' listeners, which is the
+            // exact bug being fixed.
+            if (
+              errorCodeOrPayload != null &&
+              typeof errorCodeOrPayload === 'object' &&
+              (errorCodeOrPayload as { type?: unknown }).type === 'error'
+            ) {
+              reject(
+                new XrplError(
+                  'Spoofed server payload was forwarded to error listeners',
+                ),
+              )
+            }
+          },
+        )
+      })
+
+      // @ts-expect-error -- Testing private member
+      clientContext.client.connection.onMessage(JSON.stringify(spoofedPayload))
+
+      await result
+    },
+    TIMEOUT,
+  )
+
   // it('should clean up websocket connection if error after websocket is opened', async function () {
   //   await clientContext.client.disconnect()
   //   // fail on connection


### PR DESCRIPTION
## Summary

Closes #3318

`Connection.onMessage` previously called `this.emit(data.type as string, data)` with zero validation of `data.type`. A malicious or compromised rippled server could therefore send `{"type":"connected"}`, `{"type":"disconnected"}`, `{"type":"error"}`, or `{"type":"reconnect"}` and trigger `Connection`'s internal state-event listeners (registered in `Client`), spoofing the local connection state, faking errors, or driving reconnect logic.

This PR introduces a denylist of reserved internal event names and refuses to forward server messages whose `type` collides with any of them. Such messages are dropped and surfaced via the existing `('error', 'badMessage', ...)` channel so they remain observable.

A denylist (rather than the whitelist suggested in the issue) was chosen deliberately to preserve the existing "unrecognized message type" forward-compatibility contract in `packages/xrpl/test/connection.test.ts`. Unknown future rippled stream types continue to be forwarded as before; only reserved local event names are blocked.

## Changes
- `packages/xrpl/src/client/connection.ts`: add `RESERVED_INTERNAL_EVENTS` set and guard the emit in `onMessage` against it.
- `packages/xrpl/test/connection.test.ts`: add unit tests covering all four reserved event names, including the subtle `type: "error"` case (verifies the raw payload object never reaches `error` listeners).
- `packages/xrpl/HISTORY.md`: changelog entry under Unreleased -> Fixed.

## Test plan
- [ ] `cd packages/xrpl && npm test -- connection.test.ts` - new "drops server message with reserved internal event type" cases pass.
- [ ] Existing "unrecognized message type" test still passes (forward-compat preserved).
- [ ] Existing "emit stream messages" and "propagates error message" tests still pass (legitimate stream/error paths unaffected).
- [ ] `npm run lint` in `packages/xrpl` clean.
