### PR TITLE
Update definitions.json

### DIFF
--- a/.claude/skills/batch-deps-upgrade/SKILL.md
+++ b/.claude/skills/batch-deps-upgrade/SKILL.md
@@ -37,7 +37,7 @@ Run the full test suite in order:
 2. npm test
 3. Start xrpld Docker container (based on CONTRIBUTING.md):
    - Pre-run cleanup (in case a previous run left a container behind): `docker rm -f xrpld-service 2>/dev/null || true`
-   - Start the container: `docker run --detach --rm --publish 6006:6006 --volume "$PWD/.ci-config:/etc/opt/xrpld/" --name xrpld-service rippleci/xrpld:develop --standalone`
+   - Start the container: `docker run --detach --rm --publish 6006:6006 --volume "$PWD/.ci-config:/etc/xrpld/" --name xrpld-service rippleci/xrpld:develop --standalone`
    - Wait for port 6006 with a bounded timeout and halt on failure:
      ```bash
      SECONDS=0

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -144,7 +144,7 @@ jobs:
           docker run \
             --detach \
             --publish 6006:6006 \
-            --volume "${{ github.workspace }}/.ci-config/":"/etc/opt/xrpld/" \
+            --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" \
             --name xrpld-service \
             ${{ env.XRPLD_DOCKER_IMAGE }} --standalone
 
@@ -209,7 +209,7 @@ jobs:
           docker run \
             --detach \
             --publish 6006:6006 \
-            --volume "${{ github.workspace }}/.ci-config/":"/etc/opt/xrpld/" \
+            --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" \
             --name xrpld-service \
             ${{ env.XRPLD_DOCKER_IMAGE }} --standalone
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ npm install
 docker run \
   --detach \
   --publish 6006:6006 \
-  --volume "$PWD/.ci-config:/etc/opt/xrpld/" \
+  --volume "$PWD/.ci-config:/etc/xrpld/" \
   --name xrpld-service \
   rippleci/xrpld:develop --standalone
 npm run build
@@ -77,7 +77,7 @@ npm run test:integration
 Breaking down the command:
 * `--detach` runs the container in the background so the terminal stays free.
 * `--publish 6006:6006` exposes the admin WebSocket port on the host.
-* `--volume "$PWD/.ci-config:/etc/opt/xrpld/"` mounts the host directory containing `xrpld.cfg` and `validators.txt` into the container. The host path may be relative, but the container path must be absolute; `$PWD` is used so the command works regardless of where it's run from.
+* `--volume "$PWD/.ci-config:/etc/xrpld/"` mounts the host directory containing `xrpld.cfg` and `validators.txt` into the container. The host path may be relative, but the container path must be absolute; `$PWD` is used so the command works regardless of where it's run from.
 * `--name xrpld-service` names the container — this is the label shown by `docker ps` / `docker stats`.
 * `rippleci/xrpld:develop` is the image, regularly rebuilt from the `develop` branch of `rippled`. Omitting the tag resolves to `:latest`.
 * `--standalone` is passed to the image's entrypoint (`xrpld`) to start the node in standalone mode.
@@ -177,11 +177,10 @@ This updates `docs/` at the top level, where GitHub Pages looks for the docs.
 
 ## Updating `definitions.json`
 
-This should almost always be done using [this script](./packages/ripple-binary-codec/tools/generateDefinitions.js) - if the output needs manual intervention afterwards, consider updating the script instead.
+> **Note:** The previous workflow that generated definitions from rippled source files is deprecated. The generation script is being updated to use the `server_definitions` WebSocket command against a running rippled node instead. Until that work is complete, update definitions.json manually:
 
-1. Clone / pull the latest changes from [rippled](https://github.com/XRPLF/rippled) - Specifically the `develop` branch is usually the right one.
-2. Run `node packages/ripple-binary-codec/tools/generateDefinitions.js path/to/rippled` (assuming you're calling this file from the root directory of xrpl.js).
-3. Verify that the changes make sense by inspection before submitting, as there may be updates required for the tool depending on the latest amendments we're updating to match.
+1. Start a rippled node from the develop branch.
+2. Send the `server_definitions` command via WebSocket and copy the response `result` into `packages/ripple-binary-codec/src/enums/definitions.json`.
 
 ## Adding and removing packages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ npm run build
 docker run \
   --detach \
   --publish 6006:6006 \
-  --volume "$PWD/.ci-config:/etc/opt/xrpld/" \
+  --volume "$PWD/.ci-config:/etc/xrpld/" \
   --name xrpld-service \
   rippleci/xrpld:develop --standalone
 npm run test:browser

--- a/packages/ripple-binary-codec/src/enums/definitions.json
+++ b/packages/ripple-binary-codec/src/enums/definitions.json
@@ -1,15 +1,23 @@
 {
+  "ACCOUNT_SET_FLAGS": {
+    "asfAccountTxnID": 5,
+    "asfAllowTrustLineClawback": 16,
+    "asfAllowTrustLineLocking": 17,
+    "asfAuthorizedNFTokenMinter": 10,
+    "asfDefaultRipple": 8,
+    "asfDepositAuth": 9,
+    "asfDisableMaster": 4,
+    "asfDisallowIncomingCheck": 13,
+    "asfDisallowIncomingNFTokenOffer": 12,
+    "asfDisallowIncomingPayChan": 14,
+    "asfDisallowIncomingTrustline": 15,
+    "asfDisallowXRP": 3,
+    "asfGlobalFreeze": 7,
+    "asfNoFreeze": 6,
+    "asfRequireAuth": 2,
+    "asfRequireDest": 1
+  },
   "FIELDS": [
-    [
-      "Generic",
-      {
-        "isSerialized": false,
-        "isSigningField": false,
-        "isVLEncoded": false,
-        "nth": 0,
-        "type": "Unknown"
-      }
-    ],
     [
       "Invalid",
       {
@@ -58,6 +66,16 @@
         "isVLEncoded": false,
         "nth": 259,
         "type": "Amount"
+      }
+    ],
+    [
+      "Generic",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 0,
+        "type": "Unknown"
       }
     ],
     [
@@ -1507,6 +1525,16 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 38,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "ReferenceHolding",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 39,
         "type": "Hash256"
       }
     ],
@@ -3321,6 +3349,26 @@
       }
     ],
     [
+      "TakerPaysMPT",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
+        "type": "Hash192"
+      }
+    ],
+    [
+      "TakerGetsMPT",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
+        "type": "Hash192"
+      }
+    ],
+    [
       "LockingChainIssue",
       {
         "isSerialized": true,
@@ -3431,6 +3479,1412 @@
       }
     ]
   ],
+  "LEDGER_ENTRY_FLAGS": {
+    "AccountRoot": {
+      "lsfAllowTrustLineClawback": 2147483648,
+      "lsfAllowTrustLineLocking": 1073741824,
+      "lsfDefaultRipple": 8388608,
+      "lsfDepositAuth": 16777216,
+      "lsfDisableMaster": 1048576,
+      "lsfDisallowIncomingCheck": 134217728,
+      "lsfDisallowIncomingNFTokenOffer": 67108864,
+      "lsfDisallowIncomingPayChan": 268435456,
+      "lsfDisallowIncomingTrustline": 536870912,
+      "lsfDisallowXRP": 524288,
+      "lsfGlobalFreeze": 4194304,
+      "lsfNoFreeze": 2097152,
+      "lsfPasswordSpent": 65536,
+      "lsfRequireAuth": 262144,
+      "lsfRequireDestTag": 131072
+    },
+    "Credential": {
+      "lsfAccepted": 65536
+    },
+    "DirNode": {
+      "lsfNFTokenBuyOffers": 1,
+      "lsfNFTokenSellOffers": 2
+    },
+    "Loan": {
+      "lsfLoanDefault": 65536,
+      "lsfLoanImpaired": 131072,
+      "lsfLoanOverpayment": 262144
+    },
+    "MPToken": {
+      "lsfMPTAMM": 4,
+      "lsfMPTAuthorized": 2,
+      "lsfMPTLocked": 1
+    },
+    "MPTokenIssuance": {
+      "lsfMPTCanClawback": 64,
+      "lsfMPTCanEscrow": 8,
+      "lsfMPTCanLock": 2,
+      "lsfMPTCanTrade": 16,
+      "lsfMPTCanTransfer": 32,
+      "lsfMPTLocked": 1,
+      "lsfMPTRequireAuth": 4
+    },
+    "MPTokenIssuanceMutable": {
+      "lsmfMPTCanMutateCanClawback": 64,
+      "lsmfMPTCanMutateCanEscrow": 8,
+      "lsmfMPTCanMutateCanLock": 2,
+      "lsmfMPTCanMutateCanTrade": 16,
+      "lsmfMPTCanMutateCanTransfer": 32,
+      "lsmfMPTCanMutateMetadata": 65536,
+      "lsmfMPTCanMutateRequireAuth": 4,
+      "lsmfMPTCanMutateTransferFee": 131072
+    },
+    "NFTokenOffer": {
+      "lsfSellNFToken": 1
+    },
+    "Offer": {
+      "lsfHybrid": 262144,
+      "lsfPassive": 65536,
+      "lsfSell": 131072
+    },
+    "RippleState": {
+      "lsfAMMNode": 16777216,
+      "lsfHighAuth": 524288,
+      "lsfHighDeepFreeze": 67108864,
+      "lsfHighFreeze": 8388608,
+      "lsfHighNoRipple": 2097152,
+      "lsfHighReserve": 131072,
+      "lsfLowAuth": 262144,
+      "lsfLowDeepFreeze": 33554432,
+      "lsfLowFreeze": 4194304,
+      "lsfLowNoRipple": 1048576,
+      "lsfLowReserve": 65536
+    },
+    "SignerList": {
+      "lsfOneOwnerCount": 65536
+    },
+    "Vault": {
+      "lsfVaultPrivate": 65536
+    }
+  },
+  "LEDGER_ENTRY_FORMATS": {
+    "AMM": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "TradingFee",
+        "optionality": 2
+      },
+      {
+        "name": "VoteSlots",
+        "optionality": 1
+      },
+      {
+        "name": "AuctionSlot",
+        "optionality": 1
+      },
+      {
+        "name": "LPTokenBalance",
+        "optionality": 0
+      },
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "Asset2",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 1
+      }
+    ],
+    "AccountRoot": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "Balance",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerCount",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "AccountTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "RegularKey",
+        "optionality": 1
+      },
+      {
+        "name": "EmailHash",
+        "optionality": 1
+      },
+      {
+        "name": "WalletLocator",
+        "optionality": 1
+      },
+      {
+        "name": "WalletSize",
+        "optionality": 1
+      },
+      {
+        "name": "MessageKey",
+        "optionality": 1
+      },
+      {
+        "name": "TransferRate",
+        "optionality": 1
+      },
+      {
+        "name": "Domain",
+        "optionality": 1
+      },
+      {
+        "name": "TickSize",
+        "optionality": 1
+      },
+      {
+        "name": "TicketCount",
+        "optionality": 1
+      },
+      {
+        "name": "NFTokenMinter",
+        "optionality": 1
+      },
+      {
+        "name": "MintedNFTokens",
+        "optionality": 2
+      },
+      {
+        "name": "BurnedNFTokens",
+        "optionality": 2
+      },
+      {
+        "name": "FirstNFTokenSequence",
+        "optionality": 1
+      },
+      {
+        "name": "AMMID",
+        "optionality": 1
+      },
+      {
+        "name": "VaultID",
+        "optionality": 1
+      },
+      {
+        "name": "LoanBrokerID",
+        "optionality": 1
+      }
+    ],
+    "Amendments": [
+      {
+        "name": "Amendments",
+        "optionality": 1
+      },
+      {
+        "name": "Majorities",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 1
+      }
+    ],
+    "Bridge": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "SignatureReward",
+        "optionality": 0
+      },
+      {
+        "name": "MinAccountCreateAmount",
+        "optionality": 1
+      },
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "XChainClaimID",
+        "optionality": 0
+      },
+      {
+        "name": "XChainAccountCreateCount",
+        "optionality": 0
+      },
+      {
+        "name": "XChainAccountClaimCount",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "Check": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "SendMax",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationNode",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "InvoiceID",
+        "optionality": 1
+      },
+      {
+        "name": "SourceTag",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "Credential": [
+      {
+        "name": "Subject",
+        "optionality": 0
+      },
+      {
+        "name": "Issuer",
+        "optionality": 0
+      },
+      {
+        "name": "CredentialType",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      },
+      {
+        "name": "IssuerNode",
+        "optionality": 0
+      },
+      {
+        "name": "SubjectNode",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "DID": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "DIDDocument",
+        "optionality": 1
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "Delegate": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Authorize",
+        "optionality": 0
+      },
+      {
+        "name": "Permissions",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationNode",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "DepositPreauth": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Authorize",
+        "optionality": 1
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "AuthorizeCredentials",
+        "optionality": 1
+      }
+    ],
+    "DirectoryNode": [
+      {
+        "name": "Owner",
+        "optionality": 1
+      },
+      {
+        "name": "TakerPaysCurrency",
+        "optionality": 1
+      },
+      {
+        "name": "TakerPaysIssuer",
+        "optionality": 1
+      },
+      {
+        "name": "TakerPaysMPT",
+        "optionality": 1
+      },
+      {
+        "name": "TakerGetsCurrency",
+        "optionality": 1
+      },
+      {
+        "name": "TakerGetsIssuer",
+        "optionality": 1
+      },
+      {
+        "name": "TakerGetsMPT",
+        "optionality": 1
+      },
+      {
+        "name": "ExchangeRate",
+        "optionality": 1
+      },
+      {
+        "name": "Indexes",
+        "optionality": 0
+      },
+      {
+        "name": "RootIndex",
+        "optionality": 0
+      },
+      {
+        "name": "IndexNext",
+        "optionality": 1
+      },
+      {
+        "name": "IndexPrevious",
+        "optionality": 1
+      },
+      {
+        "name": "NFTokenID",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      }
+    ],
+    "Escrow": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 1
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Condition",
+        "optionality": 1
+      },
+      {
+        "name": "CancelAfter",
+        "optionality": 1
+      },
+      {
+        "name": "FinishAfter",
+        "optionality": 1
+      },
+      {
+        "name": "SourceTag",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationNode",
+        "optionality": 1
+      },
+      {
+        "name": "TransferRate",
+        "optionality": 1
+      },
+      {
+        "name": "IssuerNode",
+        "optionality": 1
+      }
+    ],
+    "FeeSettings": [
+      {
+        "name": "BaseFee",
+        "optionality": 1
+      },
+      {
+        "name": "ReferenceFeeUnits",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveBase",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveIncrement",
+        "optionality": 1
+      },
+      {
+        "name": "BaseFeeDrops",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveBaseDrops",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveIncrementDrops",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 1
+      }
+    ],
+    "LedgerHashes": [
+      {
+        "name": "FirstLedgerSequence",
+        "optionality": 1
+      },
+      {
+        "name": "LastLedgerSequence",
+        "optionality": 1
+      },
+      {
+        "name": "Hashes",
+        "optionality": 0
+      }
+    ],
+    "Loan": [
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "LoanBrokerNode",
+        "optionality": 0
+      },
+      {
+        "name": "LoanBrokerID",
+        "optionality": 0
+      },
+      {
+        "name": "LoanSequence",
+        "optionality": 0
+      },
+      {
+        "name": "Borrower",
+        "optionality": 0
+      },
+      {
+        "name": "LoanOriginationFee",
+        "optionality": 2
+      },
+      {
+        "name": "LoanServiceFee",
+        "optionality": 2
+      },
+      {
+        "name": "LatePaymentFee",
+        "optionality": 2
+      },
+      {
+        "name": "ClosePaymentFee",
+        "optionality": 2
+      },
+      {
+        "name": "OverpaymentFee",
+        "optionality": 2
+      },
+      {
+        "name": "InterestRate",
+        "optionality": 2
+      },
+      {
+        "name": "LateInterestRate",
+        "optionality": 2
+      },
+      {
+        "name": "CloseInterestRate",
+        "optionality": 2
+      },
+      {
+        "name": "OverpaymentInterestRate",
+        "optionality": 2
+      },
+      {
+        "name": "StartDate",
+        "optionality": 0
+      },
+      {
+        "name": "PaymentInterval",
+        "optionality": 0
+      },
+      {
+        "name": "GracePeriod",
+        "optionality": 2
+      },
+      {
+        "name": "PreviousPaymentDueDate",
+        "optionality": 2
+      },
+      {
+        "name": "NextPaymentDueDate",
+        "optionality": 2
+      },
+      {
+        "name": "PaymentRemaining",
+        "optionality": 2
+      },
+      {
+        "name": "PeriodicPayment",
+        "optionality": 0
+      },
+      {
+        "name": "PrincipalOutstanding",
+        "optionality": 2
+      },
+      {
+        "name": "TotalValueOutstanding",
+        "optionality": 2
+      },
+      {
+        "name": "ManagementFeeOutstanding",
+        "optionality": 2
+      },
+      {
+        "name": "LoanScale",
+        "optionality": 2
+      }
+    ],
+    "LoanBroker": [
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "VaultNode",
+        "optionality": 0
+      },
+      {
+        "name": "VaultID",
+        "optionality": 0
+      },
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "LoanSequence",
+        "optionality": 0
+      },
+      {
+        "name": "Data",
+        "optionality": 2
+      },
+      {
+        "name": "ManagementFeeRate",
+        "optionality": 2
+      },
+      {
+        "name": "OwnerCount",
+        "optionality": 2
+      },
+      {
+        "name": "DebtTotal",
+        "optionality": 2
+      },
+      {
+        "name": "DebtMaximum",
+        "optionality": 2
+      },
+      {
+        "name": "CoverAvailable",
+        "optionality": 2
+      },
+      {
+        "name": "CoverRateMinimum",
+        "optionality": 2
+      },
+      {
+        "name": "CoverRateLiquidation",
+        "optionality": 2
+      }
+    ],
+    "MPToken": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "MPTAmount",
+        "optionality": 2
+      },
+      {
+        "name": "LockedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "MPTokenIssuance": [
+      {
+        "name": "Issuer",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "TransferFee",
+        "optionality": 2
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "AssetScale",
+        "optionality": 2
+      },
+      {
+        "name": "MaximumAmount",
+        "optionality": 1
+      },
+      {
+        "name": "OutstandingAmount",
+        "optionality": 0
+      },
+      {
+        "name": "LockedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "MPTokenMetadata",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      },
+      {
+        "name": "MutableFlags",
+        "optionality": 2
+      },
+      {
+        "name": "ReferenceHolding",
+        "optionality": 1
+      }
+    ],
+    "NFTokenOffer": [
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "NFTokenID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "NFTokenOfferNode",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 1
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "NFTokenPage": [
+      {
+        "name": "PreviousPageMin",
+        "optionality": 1
+      },
+      {
+        "name": "NextPageMin",
+        "optionality": 1
+      },
+      {
+        "name": "NFTokens",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "NegativeUNL": [
+      {
+        "name": "DisabledValidators",
+        "optionality": 1
+      },
+      {
+        "name": "ValidatorToDisable",
+        "optionality": 1
+      },
+      {
+        "name": "ValidatorToReEnable",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 1
+      }
+    ],
+    "Offer": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "TakerPays",
+        "optionality": 0
+      },
+      {
+        "name": "TakerGets",
+        "optionality": 0
+      },
+      {
+        "name": "BookDirectory",
+        "optionality": 0
+      },
+      {
+        "name": "BookNode",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      },
+      {
+        "name": "AdditionalBooks",
+        "optionality": 1
+      }
+    ],
+    "Oracle": [
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "OracleDocumentID",
+        "optionality": 1
+      },
+      {
+        "name": "Provider",
+        "optionality": 0
+      },
+      {
+        "name": "PriceDataSeries",
+        "optionality": 0
+      },
+      {
+        "name": "AssetClass",
+        "optionality": 0
+      },
+      {
+        "name": "LastUpdateTime",
+        "optionality": 0
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "PayChannel": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 1
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Balance",
+        "optionality": 0
+      },
+      {
+        "name": "PublicKey",
+        "optionality": 0
+      },
+      {
+        "name": "SettleDelay",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "CancelAfter",
+        "optionality": 1
+      },
+      {
+        "name": "SourceTag",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationNode",
+        "optionality": 1
+      }
+    ],
+    "PermissionedDomain": [
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "AcceptedCredentials",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "RippleState": [
+      {
+        "name": "Balance",
+        "optionality": 0
+      },
+      {
+        "name": "LowLimit",
+        "optionality": 0
+      },
+      {
+        "name": "HighLimit",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "LowNode",
+        "optionality": 1
+      },
+      {
+        "name": "LowQualityIn",
+        "optionality": 1
+      },
+      {
+        "name": "LowQualityOut",
+        "optionality": 1
+      },
+      {
+        "name": "HighNode",
+        "optionality": 1
+      },
+      {
+        "name": "HighQualityIn",
+        "optionality": 1
+      },
+      {
+        "name": "HighQualityOut",
+        "optionality": 1
+      }
+    ],
+    "SignerList": [
+      {
+        "name": "Owner",
+        "optionality": 1
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "SignerQuorum",
+        "optionality": 0
+      },
+      {
+        "name": "SignerEntries",
+        "optionality": 0
+      },
+      {
+        "name": "SignerListID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "Ticket": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "TicketSequence",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "Vault": [
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      },
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "AssetsTotal",
+        "optionality": 2
+      },
+      {
+        "name": "AssetsAvailable",
+        "optionality": 2
+      },
+      {
+        "name": "AssetsMaximum",
+        "optionality": 2
+      },
+      {
+        "name": "LossUnrealized",
+        "optionality": 2
+      },
+      {
+        "name": "ShareMPTID",
+        "optionality": 0
+      },
+      {
+        "name": "WithdrawalPolicy",
+        "optionality": 0
+      },
+      {
+        "name": "Scale",
+        "optionality": 2
+      }
+    ],
+    "XChainOwnedClaimID": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "XChainClaimID",
+        "optionality": 0
+      },
+      {
+        "name": "OtherChainSource",
+        "optionality": 0
+      },
+      {
+        "name": "XChainClaimAttestations",
+        "optionality": 0
+      },
+      {
+        "name": "SignatureReward",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "XChainOwnedCreateAccountClaimID": [
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "XChainAccountCreateCount",
+        "optionality": 0
+      },
+      {
+        "name": "XChainCreateAccountAttestations",
+        "optionality": 0
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "common": [
+      {
+        "name": "LedgerIndex",
+        "optionality": 1
+      },
+      {
+        "name": "LedgerEntryType",
+        "optionality": 0
+      },
+      {
+        "name": "Flags",
+        "optionality": 0
+      }
+    ]
+  },
   "LEDGER_ENTRY_TYPES": {
     "AMM": 121,
     "AccountRoot": 97,
@@ -3464,6 +4918,1488 @@
     "XChainOwnedClaimID": 113,
     "XChainOwnedCreateAccountClaimID": 116
   },
+  "TRANSACTION_FLAGS": {
+    "AMMClawback": {
+      "tfClawTwoAssets": 1
+    },
+    "AMMDeposit": {
+      "tfLPToken": 65536,
+      "tfLimitLPToken": 4194304,
+      "tfOneAssetLPToken": 2097152,
+      "tfSingleAsset": 524288,
+      "tfTwoAsset": 1048576,
+      "tfTwoAssetIfEmpty": 8388608
+    },
+    "AMMWithdraw": {
+      "tfLPToken": 65536,
+      "tfLimitLPToken": 4194304,
+      "tfOneAssetLPToken": 2097152,
+      "tfOneAssetWithdrawAll": 262144,
+      "tfSingleAsset": 524288,
+      "tfTwoAsset": 1048576,
+      "tfWithdrawAll": 131072
+    },
+    "AccountSet": {
+      "tfAllowXRP": 2097152,
+      "tfDisallowXRP": 1048576,
+      "tfOptionalAuth": 524288,
+      "tfOptionalDestTag": 131072,
+      "tfRequireAuth": 262144,
+      "tfRequireDestTag": 65536
+    },
+    "Batch": {
+      "tfAllOrNothing": 65536,
+      "tfIndependent": 524288,
+      "tfOnlyOne": 131072,
+      "tfUntilFailure": 262144
+    },
+    "EnableAmendment": {
+      "tfGotMajority": 65536,
+      "tfLostMajority": 131072
+    },
+    "LoanManage": {
+      "tfLoanDefault": 65536,
+      "tfLoanImpair": 131072,
+      "tfLoanUnimpair": 262144
+    },
+    "LoanPay": {
+      "tfLoanFullPayment": 131072,
+      "tfLoanLatePayment": 262144,
+      "tfLoanOverpayment": 65536
+    },
+    "LoanSet": {
+      "tfLoanOverpayment": 65536
+    },
+    "MPTokenAuthorize": {
+      "tfMPTUnauthorize": 1
+    },
+    "MPTokenIssuanceCreate": {
+      "tfMPTCanClawback": 64,
+      "tfMPTCanEscrow": 8,
+      "tfMPTCanLock": 2,
+      "tfMPTCanTrade": 16,
+      "tfMPTCanTransfer": 32,
+      "tfMPTRequireAuth": 4
+    },
+    "MPTokenIssuanceSet": {
+      "tfMPTLock": 1,
+      "tfMPTUnlock": 2
+    },
+    "NFTokenCreateOffer": {
+      "tfSellNFToken": 1
+    },
+    "NFTokenMint": {
+      "tfBurnable": 1,
+      "tfMutable": 16,
+      "tfOnlyXRP": 2,
+      "tfTransferable": 8
+    },
+    "OfferCreate": {
+      "tfFillOrKill": 262144,
+      "tfHybrid": 1048576,
+      "tfImmediateOrCancel": 131072,
+      "tfPassive": 65536,
+      "tfSell": 524288
+    },
+    "Payment": {
+      "tfLimitQuality": 262144,
+      "tfNoRippleDirect": 65536,
+      "tfPartialPayment": 131072
+    },
+    "PaymentChannelClaim": {
+      "tfClose": 131072,
+      "tfRenew": 65536
+    },
+    "TrustSet": {
+      "tfClearDeepFreeze": 8388608,
+      "tfClearFreeze": 2097152,
+      "tfClearNoRipple": 262144,
+      "tfSetDeepFreeze": 4194304,
+      "tfSetFreeze": 1048576,
+      "tfSetNoRipple": 131072,
+      "tfSetfAuth": 65536
+    },
+    "VaultCreate": {
+      "tfVaultPrivate": 65536,
+      "tfVaultShareNonTransferable": 131072
+    },
+    "XChainModifyBridge": {
+      "tfClearAccountCreateAmount": 65536
+    },
+    "universal": {
+      "tfFullyCanonicalSig": 2147483648,
+      "tfInnerBatchTxn": 1073741824
+    }
+  },
+  "TRANSACTION_FORMATS": {
+    "AMMBid": [
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "Asset2",
+        "optionality": 0
+      },
+      {
+        "name": "BidMin",
+        "optionality": 1
+      },
+      {
+        "name": "BidMax",
+        "optionality": 1
+      },
+      {
+        "name": "AuthAccounts",
+        "optionality": 1
+      }
+    ],
+    "AMMClawback": [
+      {
+        "name": "Holder",
+        "optionality": 0
+      },
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "Asset2",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      }
+    ],
+    "AMMCreate": [
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Amount2",
+        "optionality": 0
+      },
+      {
+        "name": "TradingFee",
+        "optionality": 0
+      }
+    ],
+    "AMMDelete": [
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "Asset2",
+        "optionality": 0
+      }
+    ],
+    "AMMDeposit": [
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "Asset2",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      },
+      {
+        "name": "Amount2",
+        "optionality": 1
+      },
+      {
+        "name": "EPrice",
+        "optionality": 1
+      },
+      {
+        "name": "LPTokenOut",
+        "optionality": 1
+      },
+      {
+        "name": "TradingFee",
+        "optionality": 1
+      }
+    ],
+    "AMMVote": [
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "Asset2",
+        "optionality": 0
+      },
+      {
+        "name": "TradingFee",
+        "optionality": 0
+      }
+    ],
+    "AMMWithdraw": [
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "Asset2",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      },
+      {
+        "name": "Amount2",
+        "optionality": 1
+      },
+      {
+        "name": "EPrice",
+        "optionality": 1
+      },
+      {
+        "name": "LPTokenIn",
+        "optionality": 1
+      }
+    ],
+    "AccountDelete": [
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "CredentialIDs",
+        "optionality": 1
+      }
+    ],
+    "AccountSet": [
+      {
+        "name": "EmailHash",
+        "optionality": 1
+      },
+      {
+        "name": "WalletLocator",
+        "optionality": 1
+      },
+      {
+        "name": "WalletSize",
+        "optionality": 1
+      },
+      {
+        "name": "MessageKey",
+        "optionality": 1
+      },
+      {
+        "name": "Domain",
+        "optionality": 1
+      },
+      {
+        "name": "TransferRate",
+        "optionality": 1
+      },
+      {
+        "name": "SetFlag",
+        "optionality": 1
+      },
+      {
+        "name": "ClearFlag",
+        "optionality": 1
+      },
+      {
+        "name": "TickSize",
+        "optionality": 1
+      },
+      {
+        "name": "NFTokenMinter",
+        "optionality": 1
+      }
+    ],
+    "Batch": [
+      {
+        "name": "RawTransactions",
+        "optionality": 0
+      },
+      {
+        "name": "BatchSigners",
+        "optionality": 1
+      }
+    ],
+    "CheckCancel": [
+      {
+        "name": "CheckID",
+        "optionality": 0
+      }
+    ],
+    "CheckCash": [
+      {
+        "name": "CheckID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      },
+      {
+        "name": "DeliverMin",
+        "optionality": 1
+      }
+    ],
+    "CheckCreate": [
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "SendMax",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "InvoiceID",
+        "optionality": 1
+      }
+    ],
+    "Clawback": [
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Holder",
+        "optionality": 1
+      }
+    ],
+    "CredentialAccept": [
+      {
+        "name": "Issuer",
+        "optionality": 0
+      },
+      {
+        "name": "CredentialType",
+        "optionality": 0
+      }
+    ],
+    "CredentialCreate": [
+      {
+        "name": "Subject",
+        "optionality": 0
+      },
+      {
+        "name": "CredentialType",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      }
+    ],
+    "CredentialDelete": [
+      {
+        "name": "Subject",
+        "optionality": 1
+      },
+      {
+        "name": "Issuer",
+        "optionality": 1
+      },
+      {
+        "name": "CredentialType",
+        "optionality": 0
+      }
+    ],
+    "DIDDelete": [],
+    "DIDSet": [
+      {
+        "name": "DIDDocument",
+        "optionality": 1
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      }
+    ],
+    "DelegateSet": [
+      {
+        "name": "Authorize",
+        "optionality": 0
+      },
+      {
+        "name": "Permissions",
+        "optionality": 0
+      }
+    ],
+    "DepositPreauth": [
+      {
+        "name": "Authorize",
+        "optionality": 1
+      },
+      {
+        "name": "Unauthorize",
+        "optionality": 1
+      },
+      {
+        "name": "AuthorizeCredentials",
+        "optionality": 1
+      },
+      {
+        "name": "UnauthorizeCredentials",
+        "optionality": 1
+      }
+    ],
+    "EnableAmendment": [
+      {
+        "name": "LedgerSequence",
+        "optionality": 0
+      },
+      {
+        "name": "Amendment",
+        "optionality": 0
+      }
+    ],
+    "EscrowCancel": [
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "OfferSequence",
+        "optionality": 0
+      }
+    ],
+    "EscrowCreate": [
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Condition",
+        "optionality": 1
+      },
+      {
+        "name": "CancelAfter",
+        "optionality": 1
+      },
+      {
+        "name": "FinishAfter",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      }
+    ],
+    "EscrowFinish": [
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "OfferSequence",
+        "optionality": 0
+      },
+      {
+        "name": "Fulfillment",
+        "optionality": 1
+      },
+      {
+        "name": "Condition",
+        "optionality": 1
+      },
+      {
+        "name": "CredentialIDs",
+        "optionality": 1
+      }
+    ],
+    "LedgerStateFix": [
+      {
+        "name": "LedgerFixType",
+        "optionality": 0
+      },
+      {
+        "name": "Owner",
+        "optionality": 1
+      },
+      {
+        "name": "BookDirectory",
+        "optionality": 1
+      }
+    ],
+    "LoanBrokerCoverClawback": [
+      {
+        "name": "LoanBrokerID",
+        "optionality": 1
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      }
+    ],
+    "LoanBrokerCoverDeposit": [
+      {
+        "name": "LoanBrokerID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      }
+    ],
+    "LoanBrokerCoverWithdraw": [
+      {
+        "name": "LoanBrokerID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      }
+    ],
+    "LoanBrokerDelete": [
+      {
+        "name": "LoanBrokerID",
+        "optionality": 0
+      }
+    ],
+    "LoanBrokerSet": [
+      {
+        "name": "VaultID",
+        "optionality": 0
+      },
+      {
+        "name": "LoanBrokerID",
+        "optionality": 1
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      },
+      {
+        "name": "ManagementFeeRate",
+        "optionality": 1
+      },
+      {
+        "name": "DebtMaximum",
+        "optionality": 1
+      },
+      {
+        "name": "CoverRateMinimum",
+        "optionality": 1
+      },
+      {
+        "name": "CoverRateLiquidation",
+        "optionality": 1
+      }
+    ],
+    "LoanDelete": [
+      {
+        "name": "LoanID",
+        "optionality": 0
+      }
+    ],
+    "LoanManage": [
+      {
+        "name": "LoanID",
+        "optionality": 0
+      }
+    ],
+    "LoanPay": [
+      {
+        "name": "LoanID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      }
+    ],
+    "LoanSet": [
+      {
+        "name": "LoanBrokerID",
+        "optionality": 0
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      },
+      {
+        "name": "Counterparty",
+        "optionality": 1
+      },
+      {
+        "name": "CounterpartySignature",
+        "optionality": 1
+      },
+      {
+        "name": "LoanOriginationFee",
+        "optionality": 1
+      },
+      {
+        "name": "LoanServiceFee",
+        "optionality": 1
+      },
+      {
+        "name": "LatePaymentFee",
+        "optionality": 1
+      },
+      {
+        "name": "ClosePaymentFee",
+        "optionality": 1
+      },
+      {
+        "name": "OverpaymentFee",
+        "optionality": 1
+      },
+      {
+        "name": "InterestRate",
+        "optionality": 1
+      },
+      {
+        "name": "LateInterestRate",
+        "optionality": 1
+      },
+      {
+        "name": "CloseInterestRate",
+        "optionality": 1
+      },
+      {
+        "name": "OverpaymentInterestRate",
+        "optionality": 1
+      },
+      {
+        "name": "PrincipalRequested",
+        "optionality": 0
+      },
+      {
+        "name": "PaymentTotal",
+        "optionality": 1
+      },
+      {
+        "name": "PaymentInterval",
+        "optionality": 1
+      },
+      {
+        "name": "GracePeriod",
+        "optionality": 1
+      }
+    ],
+    "MPTokenAuthorize": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "Holder",
+        "optionality": 1
+      }
+    ],
+    "MPTokenIssuanceCreate": [
+      {
+        "name": "AssetScale",
+        "optionality": 1
+      },
+      {
+        "name": "TransferFee",
+        "optionality": 1
+      },
+      {
+        "name": "MaximumAmount",
+        "optionality": 1
+      },
+      {
+        "name": "MPTokenMetadata",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      },
+      {
+        "name": "MutableFlags",
+        "optionality": 1
+      }
+    ],
+    "MPTokenIssuanceDestroy": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      }
+    ],
+    "MPTokenIssuanceSet": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "Holder",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      },
+      {
+        "name": "MPTokenMetadata",
+        "optionality": 1
+      },
+      {
+        "name": "TransferFee",
+        "optionality": 1
+      },
+      {
+        "name": "MutableFlags",
+        "optionality": 1
+      }
+    ],
+    "NFTokenAcceptOffer": [
+      {
+        "name": "NFTokenBuyOffer",
+        "optionality": 1
+      },
+      {
+        "name": "NFTokenSellOffer",
+        "optionality": 1
+      },
+      {
+        "name": "NFTokenBrokerFee",
+        "optionality": 1
+      }
+    ],
+    "NFTokenBurn": [
+      {
+        "name": "NFTokenID",
+        "optionality": 0
+      },
+      {
+        "name": "Owner",
+        "optionality": 1
+      }
+    ],
+    "NFTokenCancelOffer": [
+      {
+        "name": "NFTokenOffers",
+        "optionality": 0
+      }
+    ],
+    "NFTokenCreateOffer": [
+      {
+        "name": "NFTokenID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 1
+      },
+      {
+        "name": "Owner",
+        "optionality": 1
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      }
+    ],
+    "NFTokenMint": [
+      {
+        "name": "NFTokenTaxon",
+        "optionality": 0
+      },
+      {
+        "name": "TransferFee",
+        "optionality": 1
+      },
+      {
+        "name": "Issuer",
+        "optionality": 1
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      },
+      {
+        "name": "Destination",
+        "optionality": 1
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      }
+    ],
+    "NFTokenModify": [
+      {
+        "name": "NFTokenID",
+        "optionality": 0
+      },
+      {
+        "name": "Owner",
+        "optionality": 1
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      }
+    ],
+    "OfferCancel": [
+      {
+        "name": "OfferSequence",
+        "optionality": 0
+      }
+    ],
+    "OfferCreate": [
+      {
+        "name": "TakerPays",
+        "optionality": 0
+      },
+      {
+        "name": "TakerGets",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      },
+      {
+        "name": "OfferSequence",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      }
+    ],
+    "OracleDelete": [
+      {
+        "name": "OracleDocumentID",
+        "optionality": 0
+      }
+    ],
+    "OracleSet": [
+      {
+        "name": "OracleDocumentID",
+        "optionality": 0
+      },
+      {
+        "name": "Provider",
+        "optionality": 1
+      },
+      {
+        "name": "URI",
+        "optionality": 1
+      },
+      {
+        "name": "AssetClass",
+        "optionality": 1
+      },
+      {
+        "name": "LastUpdateTime",
+        "optionality": 0
+      },
+      {
+        "name": "PriceDataSeries",
+        "optionality": 0
+      }
+    ],
+    "Payment": [
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "SendMax",
+        "optionality": 1
+      },
+      {
+        "name": "Paths",
+        "optionality": 2
+      },
+      {
+        "name": "InvoiceID",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "DeliverMin",
+        "optionality": 1
+      },
+      {
+        "name": "CredentialIDs",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      }
+    ],
+    "PaymentChannelClaim": [
+      {
+        "name": "Channel",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      },
+      {
+        "name": "Balance",
+        "optionality": 1
+      },
+      {
+        "name": "Signature",
+        "optionality": 1
+      },
+      {
+        "name": "PublicKey",
+        "optionality": 1
+      },
+      {
+        "name": "CredentialIDs",
+        "optionality": 1
+      }
+    ],
+    "PaymentChannelCreate": [
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "SettleDelay",
+        "optionality": 0
+      },
+      {
+        "name": "PublicKey",
+        "optionality": 0
+      },
+      {
+        "name": "CancelAfter",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      }
+    ],
+    "PaymentChannelFund": [
+      {
+        "name": "Channel",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Expiration",
+        "optionality": 1
+      }
+    ],
+    "PermissionedDomainDelete": [
+      {
+        "name": "DomainID",
+        "optionality": 0
+      }
+    ],
+    "PermissionedDomainSet": [
+      {
+        "name": "DomainID",
+        "optionality": 1
+      },
+      {
+        "name": "AcceptedCredentials",
+        "optionality": 0
+      }
+    ],
+    "SetFee": [
+      {
+        "name": "LedgerSequence",
+        "optionality": 1
+      },
+      {
+        "name": "BaseFee",
+        "optionality": 1
+      },
+      {
+        "name": "ReferenceFeeUnits",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveBase",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveIncrement",
+        "optionality": 1
+      },
+      {
+        "name": "BaseFeeDrops",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveBaseDrops",
+        "optionality": 1
+      },
+      {
+        "name": "ReserveIncrementDrops",
+        "optionality": 1
+      }
+    ],
+    "SetRegularKey": [
+      {
+        "name": "RegularKey",
+        "optionality": 1
+      }
+    ],
+    "SignerListSet": [
+      {
+        "name": "SignerQuorum",
+        "optionality": 0
+      },
+      {
+        "name": "SignerEntries",
+        "optionality": 1
+      }
+    ],
+    "TicketCreate": [
+      {
+        "name": "TicketCount",
+        "optionality": 0
+      }
+    ],
+    "TrustSet": [
+      {
+        "name": "LimitAmount",
+        "optionality": 1
+      },
+      {
+        "name": "QualityIn",
+        "optionality": 1
+      },
+      {
+        "name": "QualityOut",
+        "optionality": 1
+      }
+    ],
+    "UNLModify": [
+      {
+        "name": "UNLModifyDisabling",
+        "optionality": 0
+      },
+      {
+        "name": "LedgerSequence",
+        "optionality": 0
+      },
+      {
+        "name": "UNLModifyValidator",
+        "optionality": 0
+      }
+    ],
+    "VaultClawback": [
+      {
+        "name": "VaultID",
+        "optionality": 0
+      },
+      {
+        "name": "Holder",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 1
+      }
+    ],
+    "VaultCreate": [
+      {
+        "name": "Asset",
+        "optionality": 0
+      },
+      {
+        "name": "AssetsMaximum",
+        "optionality": 1
+      },
+      {
+        "name": "MPTokenMetadata",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      },
+      {
+        "name": "WithdrawalPolicy",
+        "optionality": 1
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      },
+      {
+        "name": "Scale",
+        "optionality": 1
+      }
+    ],
+    "VaultDelete": [
+      {
+        "name": "VaultID",
+        "optionality": 0
+      }
+    ],
+    "VaultDeposit": [
+      {
+        "name": "VaultID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      }
+    ],
+    "VaultSet": [
+      {
+        "name": "VaultID",
+        "optionality": 0
+      },
+      {
+        "name": "AssetsMaximum",
+        "optionality": 1
+      },
+      {
+        "name": "DomainID",
+        "optionality": 1
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      }
+    ],
+    "VaultWithdraw": [
+      {
+        "name": "VaultID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 1
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      }
+    ],
+    "XChainAccountCreateCommit": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "SignatureReward",
+        "optionality": 0
+      }
+    ],
+    "XChainAddAccountCreateAttestation": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "AttestationSignerAccount",
+        "optionality": 0
+      },
+      {
+        "name": "PublicKey",
+        "optionality": 0
+      },
+      {
+        "name": "Signature",
+        "optionality": 0
+      },
+      {
+        "name": "OtherChainSource",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "AttestationRewardAccount",
+        "optionality": 0
+      },
+      {
+        "name": "WasLockingChainSend",
+        "optionality": 0
+      },
+      {
+        "name": "XChainAccountCreateCount",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "SignatureReward",
+        "optionality": 0
+      }
+    ],
+    "XChainAddClaimAttestation": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "AttestationSignerAccount",
+        "optionality": 0
+      },
+      {
+        "name": "PublicKey",
+        "optionality": 0
+      },
+      {
+        "name": "Signature",
+        "optionality": 0
+      },
+      {
+        "name": "OtherChainSource",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "AttestationRewardAccount",
+        "optionality": 0
+      },
+      {
+        "name": "WasLockingChainSend",
+        "optionality": 0
+      },
+      {
+        "name": "XChainClaimID",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 1
+      }
+    ],
+    "XChainClaim": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "XChainClaimID",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      }
+    ],
+    "XChainCommit": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "XChainClaimID",
+        "optionality": 0
+      },
+      {
+        "name": "Amount",
+        "optionality": 0
+      },
+      {
+        "name": "OtherChainDestination",
+        "optionality": 1
+      }
+    ],
+    "XChainCreateBridge": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "SignatureReward",
+        "optionality": 0
+      },
+      {
+        "name": "MinAccountCreateAmount",
+        "optionality": 1
+      }
+    ],
+    "XChainCreateClaimID": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "SignatureReward",
+        "optionality": 0
+      },
+      {
+        "name": "OtherChainSource",
+        "optionality": 0
+      }
+    ],
+    "XChainModifyBridge": [
+      {
+        "name": "XChainBridge",
+        "optionality": 0
+      },
+      {
+        "name": "SignatureReward",
+        "optionality": 1
+      },
+      {
+        "name": "MinAccountCreateAmount",
+        "optionality": 1
+      }
+    ],
+    "common": [
+      {
+        "name": "TransactionType",
+        "optionality": 0
+      },
+      {
+        "name": "Flags",
+        "optionality": 1
+      },
+      {
+        "name": "SourceTag",
+        "optionality": 1
+      },
+      {
+        "name": "Account",
+        "optionality": 0
+      },
+      {
+        "name": "Sequence",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "LastLedgerSequence",
+        "optionality": 1
+      },
+      {
+        "name": "AccountTxnID",
+        "optionality": 1
+      },
+      {
+        "name": "Fee",
+        "optionality": 0
+      },
+      {
+        "name": "OperationLimit",
+        "optionality": 1
+      },
+      {
+        "name": "Memos",
+        "optionality": 1
+      },
+      {
+        "name": "SigningPubKey",
+        "optionality": 0
+      },
+      {
+        "name": "TicketSequence",
+        "optionality": 1
+      },
+      {
+        "name": "TxnSignature",
+        "optionality": 1
+      },
+      {
+        "name": "Signers",
+        "optionality": 1
+      },
+      {
+        "name": "NetworkID",
+        "optionality": 1
+      },
+      {
+        "name": "Delegate",
+        "optionality": 1
+      }
+    ]
+  },
   "TRANSACTION_RESULTS": {
     "tecAMM_ACCOUNT": 168,
     "tecAMM_BALANCE": 163,
@@ -3485,7 +6421,6 @@
     "tecFAILED_PROCESSING": 105,
     "tecFROZEN": 137,
     "tecHAS_OBLIGATIONS": 151,
-    "tecHOOK_REJECTED": 153,
     "tecINCOMPLETE": 169,
     "tecINSUFFICIENT_FUNDS": 159,
     "tecINSUFFICIENT_PAYMENT": 161,
@@ -3505,7 +6440,6 @@
     "tecNFTOKEN_OFFER_TYPE_MISMATCH": 157,
     "tecNO_ALTERNATIVE_KEY": 130,
     "tecNO_AUTH": 134,
-    "tecNO_DELEGATE_PERMISSION": 198,
     "tecNO_DST": 124,
     "tecNO_DST_INSUF_XRP": 125,
     "tecNO_ENTRY": 140,
@@ -3549,7 +6483,6 @@
     "tecXCHAIN_SELF_COMMIT": 184,
     "tecXCHAIN_SENDING_ACCOUNT_MISMATCH": 179,
     "tecXCHAIN_WRONG_CHAIN": 176,
-
     "tefALREADY": -198,
     "tefBAD_ADD_AUTH": -197,
     "tefBAD_AUTH": -196,
@@ -3572,7 +6505,6 @@
     "tefPAST_SEQ": -190,
     "tefTOO_BIG": -181,
     "tefWRONG_PRIOR": -189,
-
     "telBAD_DOMAIN": -398,
     "telBAD_PATH_COUNT": -397,
     "telBAD_PUBLIC_KEY": -396,
@@ -3590,7 +6522,6 @@
     "telNO_DST_PARTIAL": -393,
     "telREQUIRES_NETWORK_ID": -385,
     "telWRONG_NETWORK": -386,
-
     "temARRAY_EMPTY": -253,
     "temARRAY_TOO_LARGE": -252,
     "temBAD_AMM_TOKENS": -261,
@@ -3600,6 +6531,7 @@
     "temBAD_FEE": -295,
     "temBAD_ISSUER": -294,
     "temBAD_LIMIT": -293,
+    "temBAD_MPT": -249,
     "temBAD_NFTOKEN_TRANSFER_FEE": -262,
     "temBAD_OFFER": -292,
     "temBAD_PATH": -291,
@@ -3641,11 +6573,11 @@
     "temXCHAIN_BRIDGE_BAD_REWARD_AMOUNT": -255,
     "temXCHAIN_BRIDGE_NONDOOR_OWNER": -257,
     "temXCHAIN_EQUAL_DOOR_ACCOUNTS": -260,
-
     "terADDRESS_COLLISION": -86,
     "terFUNDS_SPENT": -98,
     "terINSUF_FEE_B": -97,
     "terLAST": -91,
+    "terLOCKED": -84,
     "terNO_ACCOUNT": -96,
     "terNO_AMM": -87,
     "terNO_AUTH": -95,
@@ -3657,7 +6589,6 @@
     "terPRE_TICKET": -88,
     "terQUEUED": -89,
     "terRETRY": -99,
-
     "tesSUCCESS": 0
   },
   "TRANSACTION_TYPES": {
@@ -3748,6 +6679,8 @@
     "Hash160": 17,
     "Hash192": 21,
     "Hash256": 5,
+    "Hash384": 22,
+    "Hash512": 23,
     "Int32": 10,
     "Int64": 11,
     "Issue": 24,
@@ -3761,8 +6694,6 @@
     "Transaction": 10001,
     "UInt16": 1,
     "UInt32": 2,
-    "UInt384": 22,
-    "UInt512": 23,
     "UInt64": 3,
     "UInt8": 16,
     "UInt96": 20,
@@ -3770,5 +6701,6 @@
     "Validation": 10003,
     "Vector256": 19,
     "XChainBridge": 25
-  }
+  },
+  "hash": "C685734F5FEB756693B4BB978BBB3A158A65652E71EEB2977068B0D680689213"
 }


### PR DESCRIPTION
## High Level Overview of Change

- Updated `definitions.json` to match the latest `server_definitions` output from the rippled `develop` branch.
- Fixed Docker volume mount path in CI workflow (`/etc/opt/xrpld/` → `/etc/xrpld/`).
- Updated the "Updating `definitions.json`" section in CONTRIBUTING.md to reflect the new workflow (using `server_definitions` command instead of the local source generation script).

### Context of Change

Prep work for https://github.com/XRPLF/rippled/pull/7077, which introduces a new `ReferenceHolding` field (Hash256) on the `MPTokenIssuance` ledger object.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

- Existing tests should continue to pass.

## Future Tasks

- Update `generateDefinitions.js` script to use the `server_definitions` WebSocket command instead of parsing rippled source files directly.
- Add `ReferenceHolding` to the `MPTokenIssuance` ledger entry model in.
