### PR TITLE
chore: replace deprecated convertStringToHex/convertHexToString usages with stringToHex/hexToString

### DIFF
--- a/packages/xrpl/src/models/transactions/NFTokenMint.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenMint.ts
@@ -100,7 +100,7 @@ export interface NFTokenMint extends BaseTransaction {
    * opaque issuer-specific encoding. The URI is NOT checked for validity, but
    * the field is limited to a maximum length of 256 bytes.
    *
-   * This field must be hex-encoded. You can use `convertStringToHex` to
+   * This field must be hex-encoded. You can use `stringToHex` to
    * convert this field to the proper encoding.
    *
    * This field must not be an empty string. Omit it from the transaction or

--- a/packages/xrpl/src/models/transactions/NFTokenModify.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenModify.ts
@@ -34,7 +34,7 @@ export interface NFTokenModify extends BaseTransaction {
    * opaque issuer-specific encoding. The URI is NOT checked for validity, but
    * the field is limited to a maximum length of 256 bytes.
    *
-   * This field must be hex-encoded. You can use `convertStringToHex` to
+   * This field must be hex-encoded. You can use `stringToHex` to
    * convert this field to the proper encoding.
    *
    * This field must not be an empty string. Omit it from the transaction or

--- a/packages/xrpl/test/integration/integration.test.ts
+++ b/packages/xrpl/test/integration/integration.test.ts
@@ -1,8 +1,8 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import { Client, SubmitResponse } from '../../src'
 import { AccountSet, SignerListSet } from '../../src/models/transactions'
-import { convertStringToHex } from '../../src/utils'
 import { multisign } from '../../src/Wallet/signer'
 
 import serverUrl from './serverUrl'
@@ -74,7 +74,7 @@ describe('integration tests', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const { tx_blob: tx_blob1 } = signerWallet1.sign(accountSetTx, true)

--- a/packages/xrpl/test/integration/regularKey.test.ts
+++ b/packages/xrpl/test/integration/regularKey.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
@@ -10,7 +11,6 @@ import {
   OfferCreate,
   ECDSA,
 } from '../../src'
-import { convertStringToHex } from '../../src/utils'
 import { multisign } from '../../src/Wallet/signer'
 
 import serverUrl from './serverUrl'
@@ -85,7 +85,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: regularKeyWallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       await testTransaction(testContext.client, accountSet, regularKeyWallet)
@@ -103,7 +103,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: masterWallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       await testTransaction(testContext.client, accountSet, masterWallet)
@@ -259,7 +259,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = regularKeyWallet.sign(accountSetTx, true)
@@ -319,7 +319,7 @@ describe('regular key', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = sameKeyDefaultAddressWallet.sign(accountSetTx, true)

--- a/packages/xrpl/test/integration/requests/accountNFTs.test.ts
+++ b/packages/xrpl/test/integration/requests/accountNFTs.test.ts
@@ -1,10 +1,7 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
-import {
-  convertStringToHex,
-  AccountNFTsRequest,
-  NFTokenMint,
-} from '../../../src'
+import { AccountNFTsRequest, NFTokenMint } from '../../../src'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -28,7 +25,7 @@ describe('account_nfts', function () {
       const mintTx: NFTokenMint = {
         TransactionType: 'NFTokenMint',
         Account: testContext.wallet.address,
-        URI: convertStringToHex(uri),
+        URI: stringToHex(uri),
         NFTokenTaxon: 0,
       }
       // eslint-disable-next-line no-await-in-loop -- Sequential minting required for test setup

--- a/packages/xrpl/test/integration/requests/nftBuyOffers.test.ts
+++ b/packages/xrpl/test/integration/requests/nftBuyOffers.test.ts
@@ -1,7 +1,7 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
-  convertStringToHex,
   getNFTokenID,
   NFTokenCreateOffer,
   NFTokenMint,
@@ -33,7 +33,7 @@ describe('nft_buy_offers', function () {
     const mintTx: NFTokenMint = {
       TransactionType: 'NFTokenMint',
       Account: testContext.wallet.address,
-      URI: convertStringToHex('https://example.com/nft'),
+      URI: stringToHex('https://example.com/nft'),
       NFTokenTaxon: 0,
       Flags: NFTokenMintFlags.tfTransferable,
     }

--- a/packages/xrpl/test/integration/requests/nftSellOffers.test.ts
+++ b/packages/xrpl/test/integration/requests/nftSellOffers.test.ts
@@ -1,7 +1,7 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
-  convertStringToHex,
   getNFTokenID,
   NFTokenCreateOffer,
   NFTokenCreateOfferFlags,
@@ -33,7 +33,7 @@ describe('nft_sell_offers', function () {
     const mintTx: NFTokenMint = {
       TransactionType: 'NFTokenMint',
       Account: testContext.wallet.address,
-      URI: convertStringToHex('https://example.com/nft'),
+      URI: stringToHex('https://example.com/nft'),
       NFTokenTaxon: 0,
     }
     const mintResponse = await testTransaction(

--- a/packages/xrpl/test/integration/requests/submit.test.ts
+++ b/packages/xrpl/test/integration/requests/submit.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 import { decode } from 'ripple-binary-codec'
 
@@ -8,7 +9,6 @@ import {
   hashes,
   SubmittableTransaction,
 } from '../../../src'
-import { convertStringToHex } from '../../../src/utils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -35,7 +35,7 @@ describe('submit', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       const autofilledTx = await testContext.client.autofill(accountSet)

--- a/packages/xrpl/test/integration/requests/submitMultisigned.test.ts
+++ b/packages/xrpl/test/integration/requests/submitMultisigned.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 import { decode } from 'ripple-binary-codec'
 
@@ -11,7 +12,6 @@ import {
   SubmitMultisignedRequest,
   SubmitMultisignedV1Response,
 } from '../../../src'
-import { convertStringToHex } from '../../../src/utils'
 import { multisign } from '../../../src/Wallet/signer'
 import serverUrl from '../serverUrl'
 import {
@@ -75,7 +75,7 @@ describe('submit_multisigned', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = signerWallet1.sign(accountSetTx, true)
@@ -148,7 +148,7 @@ describe('submit_multisigned', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const accountSetTx = await client.autofill(accountSet, 2)
       const signed1 = signerWallet1.sign(accountSetTx, true)

--- a/packages/xrpl/test/integration/requests/tx.test.ts
+++ b/packages/xrpl/test/integration/requests/tx.test.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
@@ -8,7 +9,6 @@ import {
   TxResponse,
   TxV1Response,
 } from '../../../src'
-import { convertStringToHex } from '../../../src/utils'
 import serverUrl from '../serverUrl'
 import {
   setupClient,
@@ -35,7 +35,7 @@ describe('tx', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: account,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       const response: SubmitResponse = await testContext.client.submit(
@@ -82,7 +82,7 @@ describe('tx', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: account,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       const response: SubmitResponse = await testContext.client.submit(

--- a/packages/xrpl/test/integration/submitAndWait.test.ts
+++ b/packages/xrpl/test/integration/submitAndWait.test.ts
@@ -1,6 +1,7 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
-import { AccountSet, convertStringToHex, ValidationError } from '../../src'
+import { AccountSet, ValidationError } from '../../src'
 import { assertRejects } from '../testUtils'
 
 import serverUrl from './serverUrl'
@@ -35,7 +36,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       let retries = 10
@@ -88,7 +89,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
 
       await assertRejects(
@@ -106,7 +107,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const { tx_blob: signedAccountSet } = testContext.wallet.sign(
         await testContext.client.autofill(accountSet),
@@ -129,7 +130,7 @@ describe('client.submitAndWait', function () {
       const accountSet: AccountSet = {
         TransactionType: 'AccountSet',
         Account: testContext.wallet.classicAddress,
-        Domain: convertStringToHex('example.com'),
+        Domain: stringToHex('example.com'),
       }
       const { tx_blob: signedAccountSet } = testContext.wallet.sign(
         await testContext.client.autofill(accountSet),

--- a/packages/xrpl/test/integration/transactions/nftokenMint.test.ts
+++ b/packages/xrpl/test/integration/transactions/nftokenMint.test.ts
@@ -1,8 +1,8 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
   AccountInfoRequest,
-  convertStringToHex,
   getNFTokenID,
   NFTokenMint,
   TransactionMetadata,
@@ -39,7 +39,7 @@ describe('NFTokenMint', function () {
       const tx: NFTokenMint = {
         TransactionType: 'NFTokenMint',
         Account: testContext.wallet.address,
-        URI: convertStringToHex('https://www.google.com'),
+        URI: stringToHex('https://www.google.com'),
         NFTokenTaxon: 0,
       }
       const response = await testTransaction(
@@ -125,7 +125,7 @@ describe('NFTokenMint', function () {
       const tx: NFTokenMint = {
         TransactionType: 'NFTokenMint',
         Account: testContext.wallet.address,
-        URI: convertStringToHex('https://www.google.com'),
+        URI: stringToHex('https://www.google.com'),
         NFTokenTaxon: 0,
         Amount: xrpToDrops(1),
         Expiration: unixTimeToRippleTime(Date.now() + 1000 * 60 * 60 * 24),

--- a/packages/xrpl/test/integration/transactions/nftokenModify.test.ts
+++ b/packages/xrpl/test/integration/transactions/nftokenModify.test.ts
@@ -1,9 +1,9 @@
+import { stringToHex } from '@xrplf/isomorphic/utils'
 import { assert } from 'chai'
 
 import {
   NFTokenModify,
   NFTokenMintFlags,
-  convertStringToHex,
   getNFTokenID,
   NFTokenMint,
   TransactionMetadata,
@@ -33,8 +33,8 @@ describe('NFTokenModify', function () {
   it(
     'modify NFToken URI',
     async function () {
-      const oldUri = convertStringToHex('https://www.google.com')
-      const newUri = convertStringToHex('https://www.youtube.com')
+      const oldUri = stringToHex('https://www.google.com')
+      const newUri = stringToHex('https://www.youtube.com')
 
       const mutableMint: NFTokenMint = {
         TransactionType: 'NFTokenMint',


### PR DESCRIPTION
## High Level Overview of Change

Closes #2698.

Replaces all remaining usages of the deprecated `convertStringToHex` / `convertHexToString` helpers with `stringToHex` / `hexToString` from `@xrplf/isomorphic/utils`, per the deprecation notes in `packages/xrpl/src/utils/stringConversion.ts`.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Details

- 21 call sites migrated across 11 integration test files.
- 2 JSDoc references updated (`NFTokenMint.ts`, `NFTokenModify.ts`) — comment text only, no runtime changes.
- Intentionally untouched: the deprecated wrapper definitions and their re-exports (public API), `test/utils/hexConversion.test.ts` (dedicated tests for the deprecated wrappers), and `HISTORY.md`.
- No behavior change: the deprecated wrappers are one-line delegates to `stringToHex`/`hexToString`, so semantics and casing are identical by construction.

## Testing

- `npm test -w xrpl -- test/utils/hexConversion.test.ts test/models/NFTokenMint.test.ts test/models/NFTokenModify.test.ts` — 3 suites / 14 tests passing.
- Full build (`npm run build`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)