### PR TITLE
feat: include expected type in validateRequiredField/validateOptionalField errors

### DIFF
--- a/packages/xrpl/HISTORY.md
+++ b/packages/xrpl/HISTORY.md
@@ -8,6 +8,7 @@ Subscribe to [the **xrpl-announce** mailing list](https://groups.google.com/g/xr
 
 ### Added
 * Add `ReferenceHolding` to `MPTokenIssuance` ledger object and `vault_info` response.
+* Include the expected field type in `ValidationError` messages thrown by transaction validators (e.g. `Payment: invalid field Fee: expected a string`). ([#2858](https://github.com/XRPLF/xrpl.js/issues/2858))
 
 ### Fixed
 * Add missing fields (`Sequence`, `DomainID`) to `MPTokenIssuance` ledger type, add missing fields (`VaultID` and `LoanBrokerID`) to `AccountRoot` ledger type and missing fields (`AssetScale`, `MaximumAmount`, `TransferFee`, `MPTokenMetadata`, `LockedAmount`) to `vault_info` response `shares` object. Fix incorrect optionality of `Flags`, `ShareMPTID`, `WithdrawalPolicy`, and `OwnerNode` in `VaultInfoResponse`.

--- a/packages/xrpl/src/models/transactions/AMMClawback.ts
+++ b/packages/xrpl/src/models/transactions/AMMClawback.ts
@@ -79,9 +79,13 @@ export interface AMMClawback extends BaseTransaction {
 export function validateAMMClawback(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Holder', isAccount)
+  validateRequiredField(tx, 'Holder', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'Asset', isIssuedCurrency)
+  validateRequiredField(tx, 'Asset', isIssuedCurrency, {
+    expectedType: 'an IssuedCurrency',
+  })
 
   const asset = tx.Asset
 
@@ -97,9 +101,13 @@ export function validateAMMClawback(tx: Record<string, unknown>): void {
     )
   }
 
-  validateRequiredField(tx, 'Asset2', isIssuedCurrency)
+  validateRequiredField(tx, 'Asset2', isIssuedCurrency, {
+    expectedType: 'an IssuedCurrency',
+  })
 
-  validateOptionalField(tx, 'Amount', isIssuedCurrencyAmount)
+  validateOptionalField(tx, 'Amount', isIssuedCurrencyAmount, {
+    expectedType: 'an IssuedCurrencyAmount',
+  })
 
   if (tx.Amount != null) {
     if (tx.Amount.currency !== asset.currency) {

--- a/packages/xrpl/src/models/transactions/CredentialAccept.ts
+++ b/packages/xrpl/src/models/transactions/CredentialAccept.ts
@@ -36,9 +36,9 @@ export interface CredentialAccept extends BaseTransaction {
 export function validateCredentialAccept(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Account', isString)
+  validateRequiredField(tx, 'Account', isString, { expectedType: 'a string' })
 
-  validateRequiredField(tx, 'Issuer', isString)
+  validateRequiredField(tx, 'Issuer', isString, { expectedType: 'a string' })
 
   validateCredentialType(tx)
 }

--- a/packages/xrpl/src/models/transactions/CredentialCreate.ts
+++ b/packages/xrpl/src/models/transactions/CredentialCreate.ts
@@ -47,13 +47,15 @@ export interface CredentialCreate extends BaseTransaction {
 export function validateCredentialCreate(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Account', isString)
+  validateRequiredField(tx, 'Account', isString, { expectedType: 'a string' })
 
-  validateRequiredField(tx, 'Subject', isString)
+  validateRequiredField(tx, 'Subject', isString, { expectedType: 'a string' })
 
   validateCredentialType(tx)
 
-  validateOptionalField(tx, 'Expiration', isNumber)
+  validateOptionalField(tx, 'Expiration', isNumber, {
+    expectedType: 'a number',
+  })
 
   validateURI(tx.URI)
 }

--- a/packages/xrpl/src/models/transactions/CredentialDelete.ts
+++ b/packages/xrpl/src/models/transactions/CredentialDelete.ts
@@ -45,11 +45,11 @@ export function validateCredentialDelete(tx: Record<string, unknown>): void {
     )
   }
 
-  validateRequiredField(tx, 'Account', isString)
+  validateRequiredField(tx, 'Account', isString, { expectedType: 'a string' })
 
   validateCredentialType(tx)
 
-  validateOptionalField(tx, 'Subject', isString)
+  validateOptionalField(tx, 'Subject', isString, { expectedType: 'a string' })
 
-  validateOptionalField(tx, 'Issuer', isString)
+  validateOptionalField(tx, 'Issuer', isString, { expectedType: 'a string' })
 }

--- a/packages/xrpl/src/models/transactions/DIDSet.ts
+++ b/packages/xrpl/src/models/transactions/DIDSet.ts
@@ -31,11 +31,13 @@ export interface DIDSet extends BaseTransaction {
 export function validateDIDSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateOptionalField(tx, 'Data', isString)
+  validateOptionalField(tx, 'Data', isString, { expectedType: 'a string' })
 
-  validateOptionalField(tx, 'DIDDocument', isString)
+  validateOptionalField(tx, 'DIDDocument', isString, {
+    expectedType: 'a string',
+  })
 
-  validateOptionalField(tx, 'URI', isString)
+  validateOptionalField(tx, 'URI', isString, { expectedType: 'a string' })
 
   if (
     tx.Data === undefined &&

--- a/packages/xrpl/src/models/transactions/MPTokenAuthorize.ts
+++ b/packages/xrpl/src/models/transactions/MPTokenAuthorize.ts
@@ -62,6 +62,10 @@ export interface MPTokenAuthorize extends BaseTransaction {
  */
 export function validateMPTokenAuthorize(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
-  validateRequiredField(tx, 'MPTokenIssuanceID', isString)
-  validateOptionalField(tx, 'Holder', isAccount)
+  validateRequiredField(tx, 'MPTokenIssuanceID', isString, {
+    expectedType: 'a string',
+  })
+  validateOptionalField(tx, 'Holder', isAccount, {
+    expectedType: 'a valid account',
+  })
 }

--- a/packages/xrpl/src/models/transactions/MPTokenIssuanceCreate.ts
+++ b/packages/xrpl/src/models/transactions/MPTokenIssuanceCreate.ts
@@ -138,10 +138,18 @@ export function validateMPTokenIssuanceCreate(
   tx: Record<string, unknown>,
 ): void {
   validateBaseTransaction(tx)
-  validateOptionalField(tx, 'MaximumAmount', isString)
-  validateOptionalField(tx, 'MPTokenMetadata', isString)
-  validateOptionalField(tx, 'TransferFee', isNumber)
-  validateOptionalField(tx, 'AssetScale', isNumber)
+  validateOptionalField(tx, 'MaximumAmount', isString, {
+    expectedType: 'a string',
+  })
+  validateOptionalField(tx, 'MPTokenMetadata', isString, {
+    expectedType: 'a string',
+  })
+  validateOptionalField(tx, 'TransferFee', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'AssetScale', isNumber, {
+    expectedType: 'a number',
+  })
 
   if (
     typeof tx.MPTokenMetadata === 'string' &&

--- a/packages/xrpl/src/models/transactions/MPTokenIssuanceDestroy.ts
+++ b/packages/xrpl/src/models/transactions/MPTokenIssuanceDestroy.ts
@@ -30,5 +30,7 @@ export function validateMPTokenIssuanceDestroy(
   tx: Record<string, unknown>,
 ): void {
   validateBaseTransaction(tx)
-  validateRequiredField(tx, 'MPTokenIssuanceID', isString)
+  validateRequiredField(tx, 'MPTokenIssuanceID', isString, {
+    expectedType: 'a string',
+  })
 }

--- a/packages/xrpl/src/models/transactions/MPTokenIssuanceSet.ts
+++ b/packages/xrpl/src/models/transactions/MPTokenIssuanceSet.ts
@@ -65,8 +65,12 @@ export interface MPTokenIssuanceSet extends BaseTransaction {
  */
 export function validateMPTokenIssuanceSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
-  validateRequiredField(tx, 'MPTokenIssuanceID', isString)
-  validateOptionalField(tx, 'Holder', isAccount)
+  validateRequiredField(tx, 'MPTokenIssuanceID', isString, {
+    expectedType: 'a string',
+  })
+  validateOptionalField(tx, 'Holder', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Not necessary
   const flags = (tx.Flags ?? 0) as number | MPTokenIssuanceSetFlagsInterface

--- a/packages/xrpl/src/models/transactions/NFTokenBurn.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenBurn.ts
@@ -47,6 +47,8 @@ export interface NFTokenBurn extends BaseTransaction {
  */
 export function validateNFTokenBurn(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
-  validateRequiredField(tx, 'NFTokenID', isString)
-  validateOptionalField(tx, 'Owner', isAccount)
+  validateRequiredField(tx, 'NFTokenID', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'Owner', isAccount, {
+    expectedType: 'a valid account',
+  })
 }

--- a/packages/xrpl/src/models/transactions/NFTokenCreateOffer.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenCreateOffer.ts
@@ -135,8 +135,12 @@ export function validateNFTokenCreateOffer(tx: Record<string, unknown>): void {
     )
   }
 
-  validateOptionalField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'Owner', isAccount)
+  validateOptionalField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'Owner', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   if (tx.NFTokenID == null) {
     throw new ValidationError('NFTokenCreateOffer: missing field NFTokenID')

--- a/packages/xrpl/src/models/transactions/NFTokenMint.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenMint.ts
@@ -152,7 +152,9 @@ export function validateNFTokenMint(tx: Record<string, unknown>): void {
     )
   }
 
-  validateOptionalField(tx, 'Issuer', isAccount)
+  validateOptionalField(tx, 'Issuer', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   if (typeof tx.URI === 'string' && tx.URI === '') {
     throw new ValidationError('NFTokenMint: URI must not be empty string')
@@ -174,7 +176,11 @@ export function validateNFTokenMint(tx: Record<string, unknown>): void {
     }
   }
 
-  validateOptionalField(tx, 'Amount', isAmount)
-  validateOptionalField(tx, 'Expiration', isNumber)
-  validateOptionalField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
+  validateOptionalField(tx, 'Expiration', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
 }

--- a/packages/xrpl/src/models/transactions/NFTokenModify.ts
+++ b/packages/xrpl/src/models/transactions/NFTokenModify.ts
@@ -52,9 +52,11 @@ export interface NFTokenModify extends BaseTransaction {
 export function validateNFTokenModify(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'NFTokenID', isString)
-  validateOptionalField(tx, 'Owner', isAccount)
-  validateOptionalField(tx, 'URI', isString)
+  validateRequiredField(tx, 'NFTokenID', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'Owner', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'URI', isString, { expectedType: 'a string' })
 
   if (tx.URI !== undefined && typeof tx.URI === 'string') {
     if (tx.URI === '') {

--- a/packages/xrpl/src/models/transactions/XChainAccountCreateCommit.ts
+++ b/packages/xrpl/src/models/transactions/XChainAccountCreateCommit.ts
@@ -59,11 +59,17 @@ export function validateXChainAccountCreateCommit(
 ): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 
-  validateRequiredField(tx, 'SignatureReward', isAmount)
+  validateRequiredField(tx, 'SignatureReward', isAmount, {
+    expectedType: 'an Amount',
+  })
 
-  validateRequiredField(tx, 'Destination', isAccount)
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 }

--- a/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddAccountCreateAttestation.ts
@@ -91,33 +91,47 @@ export function validateXChainAddAccountCreateAttestation(
 ): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 
-  validateRequiredField(tx, 'AttestationRewardAccount', isAccount)
+  validateRequiredField(tx, 'AttestationRewardAccount', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'AttestationSignerAccount', isAccount)
+  validateRequiredField(tx, 'AttestationSignerAccount', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'Destination', isAccount)
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'OtherChainSource', isAccount)
+  validateRequiredField(tx, 'OtherChainSource', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'PublicKey', isString)
+  validateRequiredField(tx, 'PublicKey', isString, { expectedType: 'a string' })
 
-  validateRequiredField(tx, 'Signature', isString)
+  validateRequiredField(tx, 'Signature', isString, { expectedType: 'a string' })
 
-  validateRequiredField(tx, 'SignatureReward', isAmount)
+  validateRequiredField(tx, 'SignatureReward', isAmount, {
+    expectedType: 'an Amount',
+  })
 
   validateRequiredField(
     tx,
     'WasLockingChainSend',
     (inp: unknown): inp is 0 | 1 => inp === 0 || inp === 1,
+    { expectedType: '0 or 1' },
   )
 
   validateRequiredField(
     tx,
     'XChainAccountCreateCount',
     (inp: unknown): inp is number | string => isNumber(inp) || isString(inp),
+    { expectedType: 'a number or string' },
   )
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 }

--- a/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
+++ b/packages/xrpl/src/models/transactions/XChainAddClaimAttestation.ts
@@ -87,31 +87,43 @@ export function validateXChainAddClaimAttestation(
 ): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 
-  validateRequiredField(tx, 'AttestationRewardAccount', isAccount)
+  validateRequiredField(tx, 'AttestationRewardAccount', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'AttestationSignerAccount', isAccount)
+  validateRequiredField(tx, 'AttestationSignerAccount', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateOptionalField(tx, 'Destination', isAccount)
+  validateOptionalField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'OtherChainSource', isAccount)
+  validateRequiredField(tx, 'OtherChainSource', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'PublicKey', isString)
+  validateRequiredField(tx, 'PublicKey', isString, { expectedType: 'a string' })
 
-  validateRequiredField(tx, 'Signature', isString)
+  validateRequiredField(tx, 'Signature', isString, { expectedType: 'a string' })
 
   validateRequiredField(
     tx,
     'WasLockingChainSend',
     (inp: unknown): inp is 0 | 1 => inp === 0 || inp === 1,
+    { expectedType: '0 or 1' },
   )
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 
   validateRequiredField(
     tx,
     'XChainClaimID',
     (inp: unknown): inp is number | string => isNumber(inp) || isString(inp),
+    { expectedType: 'a number or string' },
   )
 }

--- a/packages/xrpl/src/models/transactions/XChainClaim.ts
+++ b/packages/xrpl/src/models/transactions/XChainClaim.ts
@@ -63,17 +63,24 @@ export interface XChainClaim extends BaseTransaction {
 export function validateXChainClaim(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 
   validateRequiredField(
     tx,
     'XChainClaimID',
     (inp: unknown): inp is number | string => isNumber(inp) || isString(inp),
+    { expectedType: 'a number or string' },
   )
 
-  validateRequiredField(tx, 'Destination', isAccount)
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 }

--- a/packages/xrpl/src/models/transactions/XChainCommit.ts
+++ b/packages/xrpl/src/models/transactions/XChainCommit.ts
@@ -62,15 +62,20 @@ export interface XChainCommit extends BaseTransaction {
 export function validateXChainCommit(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 
   validateRequiredField(
     tx,
     'XChainClaimID',
     (inp: unknown): inp is number | string => isNumber(inp) || isString(inp),
+    { expectedType: 'a number or string' },
   )
 
-  validateOptionalField(tx, 'OtherChainDestination', isAccount)
+  validateOptionalField(tx, 'OtherChainDestination', isAccount, {
+    expectedType: 'a valid account',
+  })
 
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 }

--- a/packages/xrpl/src/models/transactions/XChainCreateBridge.ts
+++ b/packages/xrpl/src/models/transactions/XChainCreateBridge.ts
@@ -48,9 +48,15 @@ export interface XChainCreateBridge extends BaseTransaction {
 export function validateXChainCreateBridge(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 
-  validateRequiredField(tx, 'SignatureReward', isAmount)
+  validateRequiredField(tx, 'SignatureReward', isAmount, {
+    expectedType: 'an Amount',
+  })
 
-  validateOptionalField(tx, 'MinAccountCreateAmount', isAmount)
+  validateOptionalField(tx, 'MinAccountCreateAmount', isAmount, {
+    expectedType: 'an Amount',
+  })
 }

--- a/packages/xrpl/src/models/transactions/XChainCreateClaimID.ts
+++ b/packages/xrpl/src/models/transactions/XChainCreateClaimID.ts
@@ -46,9 +46,15 @@ export interface XChainCreateClaimID extends BaseTransaction {
 export function validateXChainCreateClaimID(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 
-  validateRequiredField(tx, 'SignatureReward', isAmount)
+  validateRequiredField(tx, 'SignatureReward', isAmount, {
+    expectedType: 'an Amount',
+  })
 
-  validateRequiredField(tx, 'OtherChainSource', isAccount)
+  validateRequiredField(tx, 'OtherChainSource', isAccount, {
+    expectedType: 'a valid account',
+  })
 }

--- a/packages/xrpl/src/models/transactions/XChainModifyBridge.ts
+++ b/packages/xrpl/src/models/transactions/XChainModifyBridge.ts
@@ -69,9 +69,15 @@ export interface XChainModifyBridge extends BaseTransaction {
 export function validateXChainModifyBridge(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'XChainBridge', isXChainBridge)
+  validateRequiredField(tx, 'XChainBridge', isXChainBridge, {
+    expectedType: 'an XChainBridge',
+  })
 
-  validateOptionalField(tx, 'SignatureReward', isAmount)
+  validateOptionalField(tx, 'SignatureReward', isAmount, {
+    expectedType: 'an Amount',
+  })
 
-  validateOptionalField(tx, 'MinAccountCreateAmount', isAmount)
+  validateOptionalField(tx, 'MinAccountCreateAmount', isAmount, {
+    expectedType: 'an Amount',
+  })
 }

--- a/packages/xrpl/src/models/transactions/accountDelete.ts
+++ b/packages/xrpl/src/models/transactions/accountDelete.ts
@@ -47,8 +47,12 @@ export interface AccountDelete extends BaseTransaction {
 export function validateAccountDelete(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 
   validateCredentialsList(
     tx.CredentialIDs,

--- a/packages/xrpl/src/models/transactions/accountSet.ts
+++ b/packages/xrpl/src/models/transactions/accountSet.ts
@@ -178,7 +178,9 @@ const MAX_TICK_SIZE = 15
 export function validateAccountSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateOptionalField(tx, 'NFTokenMinter', isAccount)
+  validateOptionalField(tx, 'NFTokenMinter', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   if (tx.ClearFlag !== undefined) {
     if (typeof tx.ClearFlag !== 'number') {

--- a/packages/xrpl/src/models/transactions/batch.ts
+++ b/packages/xrpl/src/models/transactions/batch.ts
@@ -84,22 +84,27 @@ function validateBatchInnerTransaction(
     )
   }
   validateOptionalField(tx, 'Fee', isValue('0'), {
+    expectedType: 'the exact value "0"',
     paramName: `RawTransactions[${index}].RawTransaction.Fee`,
     txType: 'Batch',
   })
   validateOptionalField(tx, 'SigningPubKey', isValue(''), {
+    expectedType: 'the exact value ""',
     paramName: `RawTransactions[${index}].RawTransaction.SigningPubKey`,
     txType: 'Batch',
   })
   validateOptionalField(tx, 'TxnSignature', isNull, {
+    expectedType: 'null',
     paramName: `RawTransactions[${index}].RawTransaction.TxnSignature`,
     txType: 'Batch',
   })
   validateOptionalField(tx, 'Signers', isNull, {
+    expectedType: 'null',
     paramName: `RawTransactions[${index}].RawTransaction.Signers`,
     txType: 'Batch',
   })
   validateOptionalField(tx, 'LastLedgerSequence', isNull, {
+    expectedType: 'null',
     paramName: `RawTransactions[${index}].RawTransaction.LastLedgerSequence`,
     txType: 'Batch',
   })
@@ -115,7 +120,9 @@ function validateBatchInnerTransaction(
 export function validateBatch(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'RawTransactions', isArray)
+  validateRequiredField(tx, 'RawTransactions', isArray, {
+    expectedType: 'an array',
+  })
 
   tx.RawTransactions.forEach((rawTxObj, index) => {
     if (!isRecord(rawTxObj)) {
@@ -124,6 +131,7 @@ export function validateBatch(tx: Record<string, unknown>): void {
       )
     }
     validateRequiredField(rawTxObj, 'RawTransaction', isRecord, {
+      expectedType: 'an object',
       paramName: `RawTransactions[${index}].RawTransaction`,
       txType: 'Batch',
     })
@@ -134,7 +142,9 @@ export function validateBatch(tx: Record<string, unknown>): void {
     // Full validation of each `RawTransaction` object is done in `validate` to avoid dependency cycles
   })
 
-  validateOptionalField(tx, 'BatchSigners', isArray)
+  validateOptionalField(tx, 'BatchSigners', isArray, {
+    expectedType: 'an array',
+  })
 
   tx.BatchSigners?.forEach((signerObj, index) => {
     if (!isRecord(signerObj)) {
@@ -143,24 +153,29 @@ export function validateBatch(tx: Record<string, unknown>): void {
 
     const signerRecord = signerObj
     validateRequiredField(signerRecord, 'BatchSigner', isRecord, {
+      expectedType: 'an object',
       paramName: `BatchSigners[${index}].BatchSigner`,
       txType: 'Batch',
     })
 
     const signer = signerRecord.BatchSigner
     validateRequiredField(signer, 'Account', isString, {
+      expectedType: 'a string',
       paramName: `BatchSigners[${index}].BatchSigner.Account`,
       txType: 'Batch',
     })
     validateOptionalField(signer, 'SigningPubKey', isString, {
+      expectedType: 'a string',
       paramName: `BatchSigners[${index}].BatchSigner.SigningPubKey`,
       txType: 'Batch',
     })
     validateOptionalField(signer, 'TxnSignature', isString, {
+      expectedType: 'a string',
       paramName: `BatchSigners[${index}].BatchSigner.TxnSignature`,
       txType: 'Batch',
     })
     validateOptionalField(signer, 'Signers', isArray, {
+      expectedType: 'an array',
       paramName: `BatchSigners[${index}].BatchSigner.Signers`,
       txType: 'Batch',
     })

--- a/packages/xrpl/src/models/transactions/checkCreate.ts
+++ b/packages/xrpl/src/models/transactions/checkCreate.ts
@@ -61,8 +61,12 @@ export function validateCheckCreate(tx: Record<string, unknown>): void {
     throw new ValidationError('CheckCreate: missing field SendMax')
   }
 
-  validateRequiredField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 
   if (typeof tx.SendMax !== 'string' && !isIssuedCurrencyAmount(tx.SendMax)) {
     throw new ValidationError('CheckCreate: invalid SendMax')

--- a/packages/xrpl/src/models/transactions/clawback.ts
+++ b/packages/xrpl/src/models/transactions/clawback.ts
@@ -44,8 +44,12 @@ export interface Clawback extends BaseTransaction {
  */
 export function validateClawback(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
-  validateRequiredField(tx, 'Amount', isClawbackAmount)
-  validateOptionalField(tx, 'Holder', isAccount)
+  validateRequiredField(tx, 'Amount', isClawbackAmount, {
+    expectedType: 'a ClawbackAmount',
+  })
+  validateOptionalField(tx, 'Holder', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   if (!isIssuedCurrencyAmount(tx.Amount) && !isMPTAmount(tx.Amount)) {
     throw new ValidationError('Clawback: invalid Amount')

--- a/packages/xrpl/src/models/transactions/common.ts
+++ b/packages/xrpl/src/models/transactions/common.ts
@@ -370,7 +370,28 @@ export function validateHexMetadata(
   )
 }
 
-/* eslint-disable @typescript-eslint/restrict-template-expressions -- tx.TransactionType is checked before any calls */
+interface FieldValidationErrorOptions {
+  txType?: string
+  paramName?: string
+  expectedType?: string
+}
+
+/**
+ * Format the invalid-field error shared by required and optional validators.
+ *
+ * @param txType - The transaction type throwing the error.
+ * @param paramName - The name of the parameter in the transaction with the error.
+ * @param expectedType - Human-readable type name to include in invalid-field errors.
+ * @returns The formatted invalid-field message.
+ */
+function invalidFieldMessage(
+  txType: string,
+  paramName: string,
+  expectedType?: string,
+): string {
+  const message = `${txType}: invalid field ${paramName}`
+  return expectedType == null ? message : `${message}: expected ${expectedType}`
+}
 
 /**
  * Verify the form and type of a required type for a transaction at runtime.
@@ -381,6 +402,7 @@ export function validateHexMetadata(
  * @param errorOpts - Extra values to make the error message easier to understand.
  * @param errorOpts.txType - The transaction type throwing the error.
  * @param errorOpts.paramName - The name of the parameter in the transaction with the error.
+ * @param errorOpts.expectedType - Human-readable type name to include in invalid-field errors.
  * @throws ValidationError if the parameter is missing or invalid.
  */
 // eslint-disable-next-line max-params -- helper function
@@ -392,22 +414,17 @@ export function validateRequiredField<
   tx: T,
   param: K,
   checkValidity: (inp: unknown) => inp is V,
-  errorOpts: {
-    txType?: string
-    paramName?: string
-  } = {},
+  errorOpts: FieldValidationErrorOptions = {},
 ): asserts tx is T & { [P in K]: V } {
-  const paramNameStr = errorOpts.paramName ?? param
-  const txType = errorOpts.txType ?? tx.TransactionType
+  const paramNameStr = String(errorOpts.paramName ?? param)
+  const txType = String(errorOpts.txType ?? tx.TransactionType)
   if (tx[param] == null) {
-    throw new ValidationError(
-      `${txType}: missing field ${String(paramNameStr)}`,
-    )
+    throw new ValidationError(`${txType}: missing field ${paramNameStr}`)
   }
 
   if (!checkValidity(tx[param])) {
     throw new ValidationError(
-      `${txType}: invalid field ${String(paramNameStr)}`,
+      invalidFieldMessage(txType, paramNameStr, errorOpts.expectedType),
     )
   }
 }
@@ -421,6 +438,7 @@ export function validateRequiredField<
  * @param errorOpts - Extra values to make the error message easier to understand.
  * @param errorOpts.txType - The transaction type throwing the error.
  * @param errorOpts.paramName - The name of the parameter in the transaction with the error.
+ * @param errorOpts.expectedType - Human-readable type name to include in invalid-field errors.
  * @throws ValidationError if the parameter is invalid.
  */
 // eslint-disable-next-line max-params -- helper function
@@ -432,21 +450,16 @@ export function validateOptionalField<
   tx: T,
   param: K,
   checkValidity: (inp: unknown) => inp is V,
-  errorOpts: {
-    txType?: string
-    paramName?: string
-  } = {},
+  errorOpts: FieldValidationErrorOptions = {},
 ): asserts tx is T & { [P in K]: V | undefined } {
-  const paramNameStr = errorOpts.paramName ?? param
-  const txType = errorOpts.txType ?? tx.TransactionType
+  const paramNameStr = String(errorOpts.paramName ?? param)
+  const txType = String(errorOpts.txType ?? tx.TransactionType)
   if (tx[param] !== undefined && !checkValidity(tx[param])) {
     throw new ValidationError(
-      `${txType}: invalid field ${String(paramNameStr)}`,
+      invalidFieldMessage(txType, paramNameStr, errorOpts.expectedType),
     )
   }
 }
-
-/* eslint-enable @typescript-eslint/restrict-template-expressions -- checked before */
 
 export enum GlobalFlags {
   tfInnerBatchTxn = 0x40000000,
@@ -568,15 +581,25 @@ export function validateBaseTransaction(
     )
   }
 
-  validateRequiredField(common, 'Account', isString)
+  validateRequiredField(common, 'Account', isString, {
+    expectedType: 'a string',
+  })
 
-  validateOptionalField(common, 'Fee', isString)
+  validateOptionalField(common, 'Fee', isString, {
+    expectedType: 'a string',
+  })
 
-  validateOptionalField(common, 'Sequence', isNumber)
+  validateOptionalField(common, 'Sequence', isNumber, {
+    expectedType: 'a number',
+  })
 
-  validateOptionalField(common, 'AccountTxnID', isString)
+  validateOptionalField(common, 'AccountTxnID', isString, {
+    expectedType: 'a string',
+  })
 
-  validateOptionalField(common, 'LastLedgerSequence', isNumber)
+  validateOptionalField(common, 'LastLedgerSequence', isNumber, {
+    expectedType: 'a number',
+  })
 
   const memos = common.Memos
   if (memos != null && (!isArray(memos) || !memos.every(isMemo))) {
@@ -592,17 +615,29 @@ export function validateBaseTransaction(
     throw new ValidationError('BaseTransaction: invalid Signers')
   }
 
-  validateOptionalField(common, 'SourceTag', isNumber)
+  validateOptionalField(common, 'SourceTag', isNumber, {
+    expectedType: 'a number',
+  })
 
-  validateOptionalField(common, 'SigningPubKey', isString)
+  validateOptionalField(common, 'SigningPubKey', isString, {
+    expectedType: 'a string',
+  })
 
-  validateOptionalField(common, 'TicketSequence', isNumber)
+  validateOptionalField(common, 'TicketSequence', isNumber, {
+    expectedType: 'a number',
+  })
 
-  validateOptionalField(common, 'TxnSignature', isString)
+  validateOptionalField(common, 'TxnSignature', isString, {
+    expectedType: 'a string',
+  })
 
-  validateOptionalField(common, 'NetworkID', isNumber)
+  validateOptionalField(common, 'NetworkID', isNumber, {
+    expectedType: 'a number',
+  })
 
-  validateOptionalField(common, 'Delegate', isAccount)
+  validateOptionalField(common, 'Delegate', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   const delegate = common.Delegate
   if (delegate != null && delegate === common.Account) {

--- a/packages/xrpl/src/models/transactions/delegateSet.ts
+++ b/packages/xrpl/src/models/transactions/delegateSet.ts
@@ -57,7 +57,9 @@ export interface DelegateSet extends BaseTransaction {
 export function validateDelegateSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Authorize', isAccount)
+  validateRequiredField(tx, 'Authorize', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   if (tx.Authorize === tx.Account) {
     throw new ValidationError(
@@ -65,7 +67,9 @@ export function validateDelegateSet(tx: Record<string, unknown>): void {
     )
   }
 
-  validateRequiredField(tx, 'Permissions', Array.isArray)
+  validateRequiredField(tx, 'Permissions', Array.isArray, {
+    expectedType: 'an array',
+  })
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- required for validation
   const permissions = tx.Permissions as DelegateSet['Permissions']

--- a/packages/xrpl/src/models/transactions/escrowCancel.ts
+++ b/packages/xrpl/src/models/transactions/escrowCancel.ts
@@ -33,7 +33,9 @@ export interface EscrowCancel extends BaseTransaction {
 export function validateEscrowCancel(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Owner', isAccount)
+  validateRequiredField(tx, 'Owner', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   if (tx.OfferSequence == null) {
     throw new ValidationError('EscrowCancel: missing OfferSequence')

--- a/packages/xrpl/src/models/transactions/escrowCreate.ts
+++ b/packages/xrpl/src/models/transactions/escrowCreate.ts
@@ -61,9 +61,13 @@ export interface EscrowCreate extends BaseTransaction {
 export function validateEscrowCreate(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Amount', isAmount)
-  validateRequiredField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 
   if (tx.CancelAfter === undefined && tx.FinishAfter === undefined) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/escrowFinish.ts
+++ b/packages/xrpl/src/models/transactions/escrowFinish.ts
@@ -49,7 +49,9 @@ export interface EscrowFinish extends BaseTransaction {
 export function validateEscrowFinish(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Owner', isAccount)
+  validateRequiredField(tx, 'Owner', isAccount, {
+    expectedType: 'a valid account',
+  })
 
   validateCredentialsList(
     tx.CredentialIDs,

--- a/packages/xrpl/src/models/transactions/loanBrokerCoverClawback.ts
+++ b/packages/xrpl/src/models/transactions/loanBrokerCoverClawback.ts
@@ -47,8 +47,12 @@ export function validateLoanBrokerCoverClawback(
 ): void {
   validateBaseTransaction(tx)
 
-  validateOptionalField(tx, 'LoanBrokerID', isString)
-  validateOptionalField(tx, 'Amount', isTokenAmount)
+  validateOptionalField(tx, 'LoanBrokerID', isString, {
+    expectedType: 'a string',
+  })
+  validateOptionalField(tx, 'Amount', isTokenAmount, {
+    expectedType: 'a token amount',
+  })
 
   if (tx.LoanBrokerID != null && !isLedgerEntryId(tx.LoanBrokerID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanBrokerCoverDeposit.ts
+++ b/packages/xrpl/src/models/transactions/loanBrokerCoverDeposit.ts
@@ -40,8 +40,10 @@ export function validateLoanBrokerCoverDeposit(
 ): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'LoanBrokerID', isString)
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'LoanBrokerID', isString, {
+    expectedType: 'a string',
+  })
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 
   if (!isLedgerEntryId(tx.LoanBrokerID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanBrokerCoverWithdraw.ts
+++ b/packages/xrpl/src/models/transactions/loanBrokerCoverWithdraw.ts
@@ -54,10 +54,16 @@ export function validateLoanBrokerCoverWithdraw(
 ): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'LoanBrokerID', isString)
-  validateRequiredField(tx, 'Amount', isAmount)
-  validateOptionalField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateRequiredField(tx, 'LoanBrokerID', isString, {
+    expectedType: 'a string',
+  })
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
+  validateOptionalField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 
   if (!isLedgerEntryId(tx.LoanBrokerID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanBrokerDelete.ts
+++ b/packages/xrpl/src/models/transactions/loanBrokerDelete.ts
@@ -31,7 +31,9 @@ export interface LoanBrokerDelete extends BaseTransaction {
 export function validateLoanBrokerDelete(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'LoanBrokerID', isString)
+  validateRequiredField(tx, 'LoanBrokerID', isString, {
+    expectedType: 'a string',
+  })
 
   if (!isLedgerEntryId(tx.LoanBrokerID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanBrokerSet.ts
+++ b/packages/xrpl/src/models/transactions/loanBrokerSet.ts
@@ -76,13 +76,23 @@ export interface LoanBrokerSet extends BaseTransaction {
 export function validateLoanBrokerSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'VaultID', isString)
-  validateOptionalField(tx, 'LoanBrokerID', isString)
-  validateOptionalField(tx, 'Data', isString)
-  validateOptionalField(tx, 'ManagementFeeRate', isNumber)
-  validateOptionalField(tx, 'DebtMaximum', isXRPLNumber)
-  validateOptionalField(tx, 'CoverRateMinimum', isNumber)
-  validateOptionalField(tx, 'CoverRateLiquidation', isNumber)
+  validateRequiredField(tx, 'VaultID', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'LoanBrokerID', isString, {
+    expectedType: 'a string',
+  })
+  validateOptionalField(tx, 'Data', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'ManagementFeeRate', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'DebtMaximum', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'CoverRateMinimum', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'CoverRateLiquidation', isNumber, {
+    expectedType: 'a number',
+  })
 
   if (!isLedgerEntryId(tx.VaultID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanDelete.ts
+++ b/packages/xrpl/src/models/transactions/loanDelete.ts
@@ -31,7 +31,7 @@ export interface LoanDelete extends BaseTransaction {
 export function validateLoanDelete(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'LoanID', isString)
+  validateRequiredField(tx, 'LoanID', isString, { expectedType: 'a string' })
 
   if (!isLedgerEntryId(tx.LoanID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanManage.ts
+++ b/packages/xrpl/src/models/transactions/loanManage.ts
@@ -69,7 +69,7 @@ export interface LoanManageFlagsInterface extends GlobalFlagsInterface {
 export function validateLoanManage(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'LoanID', isString)
+  validateRequiredField(tx, 'LoanID', isString, { expectedType: 'a string' })
 
   if (!isLedgerEntryId(tx.LoanID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanPay.ts
+++ b/packages/xrpl/src/models/transactions/loanPay.ts
@@ -74,8 +74,8 @@ export interface LoanPay extends BaseTransaction {
 export function validateLoanPay(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'LoanID', isString)
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'LoanID', isString, { expectedType: 'a string' })
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 
   if (!isLedgerEntryId(tx.LoanID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/loanSet.ts
+++ b/packages/xrpl/src/models/transactions/loanSet.ts
@@ -176,23 +176,55 @@ export interface LoanSetFlagsInterface extends GlobalFlagsInterface {
 export function validateLoanSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'LoanBrokerID', isString)
-  validateRequiredField(tx, 'PrincipalRequested', isXRPLNumber)
-  validateOptionalField(tx, 'CounterpartySignature', isRecord)
-  validateOptionalField(tx, 'Data', isString)
-  validateOptionalField(tx, 'Counterparty', isAccount)
-  validateOptionalField(tx, 'LoanOriginationFee', isXRPLNumber)
-  validateOptionalField(tx, 'LoanServiceFee', isXRPLNumber)
-  validateOptionalField(tx, 'LatePaymentFee', isXRPLNumber)
-  validateOptionalField(tx, 'ClosePaymentFee', isXRPLNumber)
-  validateOptionalField(tx, 'OverpaymentFee', isNumber)
-  validateOptionalField(tx, 'InterestRate', isNumber)
-  validateOptionalField(tx, 'LateInterestRate', isNumber)
-  validateOptionalField(tx, 'CloseInterestRate', isNumber)
-  validateOptionalField(tx, 'OverpaymentInterestRate', isNumber)
-  validateOptionalField(tx, 'PaymentTotal', isNumber)
-  validateOptionalField(tx, 'PaymentInterval', isNumber)
-  validateOptionalField(tx, 'GracePeriod', isNumber)
+  validateRequiredField(tx, 'LoanBrokerID', isString, {
+    expectedType: 'a string',
+  })
+  validateRequiredField(tx, 'PrincipalRequested', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'CounterpartySignature', isRecord, {
+    expectedType: 'an object',
+  })
+  validateOptionalField(tx, 'Data', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'Counterparty', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'LoanOriginationFee', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'LoanServiceFee', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'LatePaymentFee', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'ClosePaymentFee', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'OverpaymentFee', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'InterestRate', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'LateInterestRate', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'CloseInterestRate', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'OverpaymentInterestRate', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'PaymentTotal', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'PaymentInterval', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'GracePeriod', isNumber, {
+    expectedType: 'a number',
+  })
 
   if (!isLedgerEntryId(tx.LoanBrokerID)) {
     throw new ValidationError(

--- a/packages/xrpl/src/models/transactions/offerCreate.ts
+++ b/packages/xrpl/src/models/transactions/offerCreate.ts
@@ -153,6 +153,7 @@ export function validateOfferCreate(tx: Record<string, unknown>): void {
   }
 
   validateOptionalField(tx, 'DomainID', isDomainID, {
+    expectedType: 'a 64-character hex string',
     txType: 'OfferCreate',
     paramName: 'DomainID',
   })

--- a/packages/xrpl/src/models/transactions/oracleDelete.ts
+++ b/packages/xrpl/src/models/transactions/oracleDelete.ts
@@ -28,5 +28,7 @@ export interface OracleDelete extends BaseTransaction {
 export function validateOracleDelete(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'OracleDocumentID', isNumber)
+  validateRequiredField(tx, 'OracleDocumentID', isNumber, {
+    expectedType: 'a number',
+  })
 }

--- a/packages/xrpl/src/models/transactions/oracleSet.ts
+++ b/packages/xrpl/src/models/transactions/oracleSet.ts
@@ -77,15 +77,21 @@ export interface OracleSet extends BaseTransaction {
 export function validateOracleSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'OracleDocumentID', isNumber)
+  validateRequiredField(tx, 'OracleDocumentID', isNumber, {
+    expectedType: 'a number',
+  })
 
-  validateRequiredField(tx, 'LastUpdateTime', isNumber)
+  validateRequiredField(tx, 'LastUpdateTime', isNumber, {
+    expectedType: 'a number',
+  })
 
-  validateOptionalField(tx, 'Provider', isString)
+  validateOptionalField(tx, 'Provider', isString, { expectedType: 'a string' })
 
-  validateOptionalField(tx, 'URI', isString)
+  validateOptionalField(tx, 'URI', isString, { expectedType: 'a string' })
 
-  validateOptionalField(tx, 'AssetClass', isString)
+  validateOptionalField(tx, 'AssetClass', isString, {
+    expectedType: 'a string',
+  })
 
   /* eslint-disable max-statements, max-lines-per-function -- necessary to validate many fields */
   validateRequiredField(
@@ -190,6 +196,7 @@ export function validateOracleSet(tx: Record<string, unknown>): void {
       }
       return true
     },
+    { expectedType: 'a PriceData array' },
   )
   /* eslint-enable max-statements, max-lines-per-function */
 }

--- a/packages/xrpl/src/models/transactions/payment.ts
+++ b/packages/xrpl/src/models/transactions/payment.ts
@@ -198,8 +198,12 @@ export function validatePayment(tx: Record<string, unknown>): void {
     throw new ValidationError('PaymentTransaction: invalid Amount')
   }
 
-  validateRequiredField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 
   validateCredentialsList(
     tx.CredentialIDs,
@@ -213,6 +217,7 @@ export function validatePayment(tx: Record<string, unknown>): void {
   }
 
   validateOptionalField(tx, 'DomainID', isDomainID, {
+    expectedType: 'a 64-character hex string',
     txType: 'PaymentTransaction',
     paramName: 'DomainID',
   })

--- a/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
+++ b/packages/xrpl/src/models/transactions/paymentChannelCreate.ts
@@ -75,8 +75,12 @@ export function validatePaymentChannelCreate(
     throw new ValidationError('PaymentChannelCreate: Amount must be a string')
   }
 
-  validateRequiredField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateRequiredField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 
   if (tx.SettleDelay === undefined) {
     throw new ValidationError('PaymentChannelCreate: missing SettleDelay')

--- a/packages/xrpl/src/models/transactions/permissionedDomainDelete.ts
+++ b/packages/xrpl/src/models/transactions/permissionedDomainDelete.ts
@@ -24,5 +24,5 @@ export function validatePermissionedDomainDelete(
 ): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'DomainID', isString)
+  validateRequiredField(tx, 'DomainID', isString, { expectedType: 'a string' })
 }

--- a/packages/xrpl/src/models/transactions/permissionedDomainSet.ts
+++ b/packages/xrpl/src/models/transactions/permissionedDomainSet.ts
@@ -36,8 +36,10 @@ export function validatePermissionedDomainSet(
 ): void {
   validateBaseTransaction(tx)
 
-  validateOptionalField(tx, 'DomainID', isString)
-  validateRequiredField(tx, 'AcceptedCredentials', isArray)
+  validateOptionalField(tx, 'DomainID', isString, { expectedType: 'a string' })
+  validateRequiredField(tx, 'AcceptedCredentials', isArray, {
+    expectedType: 'an array',
+  })
 
   validateCredentialsList(
     tx.AcceptedCredentials,

--- a/packages/xrpl/src/models/transactions/signerListSet.ts
+++ b/packages/xrpl/src/models/transactions/signerListSet.ts
@@ -47,14 +47,18 @@ const HEX_WALLET_LOCATOR_REGEX = /^[0-9A-Fa-f]{64}$/u
 export function validateSignerListSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'SignerQuorum', isNumber)
+  validateRequiredField(tx, 'SignerQuorum', isNumber, {
+    expectedType: 'a number',
+  })
 
   // All other checks are for if SignerQuorum is greater than 0
   if (tx.SignerQuorum === 0) {
     return
   }
 
-  validateRequiredField(tx, 'SignerEntries', isArray)
+  validateRequiredField(tx, 'SignerEntries', isArray, {
+    expectedType: 'an array',
+  })
   if (tx.SignerEntries.length === 0) {
     throw new ValidationError(
       'SignerListSet: need at least 1 member in SignerEntries',

--- a/packages/xrpl/src/models/transactions/vaultClawback.ts
+++ b/packages/xrpl/src/models/transactions/vaultClawback.ts
@@ -49,7 +49,11 @@ export interface VaultClawback extends BaseTransaction {
 export function validateVaultClawback(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'VaultID', isString)
-  validateRequiredField(tx, 'Holder', isAccount)
-  validateOptionalField(tx, 'Amount', isClawbackAmount)
+  validateRequiredField(tx, 'VaultID', isString, { expectedType: 'a string' })
+  validateRequiredField(tx, 'Holder', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'Amount', isClawbackAmount, {
+    expectedType: 'a ClawbackAmount',
+  })
 }

--- a/packages/xrpl/src/models/transactions/vaultCreate.ts
+++ b/packages/xrpl/src/models/transactions/vaultCreate.ts
@@ -112,13 +112,19 @@ export interface VaultCreate extends BaseTransaction {
 export function validateVaultCreate(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'Asset', isCurrency)
-  validateOptionalField(tx, 'Data', isString)
-  validateOptionalField(tx, 'AssetsMaximum', isXRPLNumber)
-  validateOptionalField(tx, 'MPTokenMetadata', isString)
-  validateOptionalField(tx, 'WithdrawalPolicy', isNumber)
-  validateOptionalField(tx, 'DomainID', isString)
-  validateOptionalField(tx, 'Scale', isNumber)
+  validateRequiredField(tx, 'Asset', isCurrency, { expectedType: 'a Currency' })
+  validateOptionalField(tx, 'Data', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'AssetsMaximum', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'MPTokenMetadata', isString, {
+    expectedType: 'a string',
+  })
+  validateOptionalField(tx, 'WithdrawalPolicy', isNumber, {
+    expectedType: 'a number',
+  })
+  validateOptionalField(tx, 'DomainID', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'Scale', isNumber, { expectedType: 'a number' })
 
   if (tx.Data !== undefined) {
     const dataHex = tx.Data

--- a/packages/xrpl/src/models/transactions/vaultDelete.ts
+++ b/packages/xrpl/src/models/transactions/vaultDelete.ts
@@ -28,5 +28,5 @@ export interface VaultDelete extends BaseTransaction {
 export function validateVaultDelete(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'VaultID', isString)
+  validateRequiredField(tx, 'VaultID', isString, { expectedType: 'a string' })
 }

--- a/packages/xrpl/src/models/transactions/vaultDeposit.ts
+++ b/packages/xrpl/src/models/transactions/vaultDeposit.ts
@@ -37,6 +37,6 @@ export interface VaultDeposit extends BaseTransaction {
 export function validateVaultDeposit(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'VaultID', isString)
-  validateRequiredField(tx, 'Amount', isAmount)
+  validateRequiredField(tx, 'VaultID', isString, { expectedType: 'a string' })
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
 }

--- a/packages/xrpl/src/models/transactions/vaultSet.ts
+++ b/packages/xrpl/src/models/transactions/vaultSet.ts
@@ -51,10 +51,12 @@ export interface VaultSet extends BaseTransaction {
 export function validateVaultSet(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'VaultID', isString)
-  validateOptionalField(tx, 'Data', isString)
-  validateOptionalField(tx, 'AssetsMaximum', isXRPLNumber)
-  validateOptionalField(tx, 'DomainID', isString)
+  validateRequiredField(tx, 'VaultID', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'Data', isString, { expectedType: 'a string' })
+  validateOptionalField(tx, 'AssetsMaximum', isXRPLNumber, {
+    expectedType: 'an XRPL number string',
+  })
+  validateOptionalField(tx, 'DomainID', isString, { expectedType: 'a string' })
 
   if (tx.Data !== undefined) {
     const dataHex = tx.Data

--- a/packages/xrpl/src/models/transactions/vaultWithdraw.ts
+++ b/packages/xrpl/src/models/transactions/vaultWithdraw.ts
@@ -51,8 +51,12 @@ export interface VaultWithdraw extends BaseTransaction {
 export function validateVaultWithdraw(tx: Record<string, unknown>): void {
   validateBaseTransaction(tx)
 
-  validateRequiredField(tx, 'VaultID', isString)
-  validateRequiredField(tx, 'Amount', isAmount)
-  validateOptionalField(tx, 'Destination', isAccount)
-  validateOptionalField(tx, 'DestinationTag', isNumber)
+  validateRequiredField(tx, 'VaultID', isString, { expectedType: 'a string' })
+  validateRequiredField(tx, 'Amount', isAmount, { expectedType: 'an Amount' })
+  validateOptionalField(tx, 'Destination', isAccount, {
+    expectedType: 'a valid account',
+  })
+  validateOptionalField(tx, 'DestinationTag', isNumber, {
+    expectedType: 'a number',
+  })
 }

--- a/packages/xrpl/test/models/AMMClawback.test.ts
+++ b/packages/xrpl/test/models/AMMClawback.test.ts
@@ -59,7 +59,8 @@ describe('AMMClawback', function () {
 
   it(`throws w/ invalid field Holder`, function () {
     ammClawback.Holder = 1234
-    const errorMessage = 'AMMClawback: invalid field Holder'
+    const errorMessage =
+      'AMMClawback: invalid field Holder: expected a valid account'
     assertInvalid(ammClawback, errorMessage)
   })
 
@@ -77,7 +78,8 @@ describe('AMMClawback', function () {
 
   it(`throws w/ invalid field Asset`, function () {
     ammClawback.Asset = '1000'
-    const errorMessage = 'AMMClawback: invalid field Asset'
+    const errorMessage =
+      'AMMClawback: invalid field Asset: expected an IssuedCurrency'
     assertInvalid(ammClawback, errorMessage)
   })
 
@@ -95,13 +97,15 @@ describe('AMMClawback', function () {
 
   it(`throws w/ invalid field Asset2`, function () {
     ammClawback.Asset2 = '1000'
-    const errorMessage = 'AMMClawback: invalid field Asset2'
+    const errorMessage =
+      'AMMClawback: invalid field Asset2: expected an IssuedCurrency'
     assertInvalid(ammClawback, errorMessage)
   })
 
   it(`throws w/ invalid field Amount`, function () {
     ammClawback.Amount = 1000
-    const errorMessage = 'AMMClawback: invalid field Amount'
+    const errorMessage =
+      'AMMClawback: invalid field Amount: expected an IssuedCurrencyAmount'
     assertInvalid(ammClawback, errorMessage)
   })
 

--- a/packages/xrpl/test/models/CredentialAccept.test.ts
+++ b/packages/xrpl/test/models/CredentialAccept.test.ts
@@ -39,7 +39,8 @@ describe('CredentialAccept', function () {
 
   it(`throws w/ Account not a string`, function () {
     credentialAccept.Account = 123
-    const errorMessage = 'CredentialAccept: invalid field Account'
+    const errorMessage =
+      'CredentialAccept: invalid field Account: expected a string'
     assertInvalid(credentialAccept, errorMessage)
   })
 
@@ -51,7 +52,8 @@ describe('CredentialAccept', function () {
 
   it(`throws w/ Issuer not a string`, function () {
     credentialAccept.Issuer = 123
-    const errorMessage = 'CredentialAccept: invalid field Issuer'
+    const errorMessage =
+      'CredentialAccept: invalid field Issuer: expected a string'
     assertInvalid(credentialAccept, errorMessage)
   })
 

--- a/packages/xrpl/test/models/CredentialCreate.test.ts
+++ b/packages/xrpl/test/models/CredentialCreate.test.ts
@@ -41,7 +41,8 @@ describe('credentialCreate', function () {
 
   it(`throws w/ Account not string`, function () {
     credentialCreate.Account = 123
-    const errorMessage = 'CredentialCreate: invalid field Account'
+    const errorMessage =
+      'CredentialCreate: invalid field Account: expected a string'
     assertInvalid(credentialCreate, errorMessage)
   })
 
@@ -53,7 +54,8 @@ describe('credentialCreate', function () {
 
   it(`throws w/ Subject not string`, function () {
     credentialCreate.Subject = 123
-    const errorMessage = 'CredentialCreate: invalid field Subject'
+    const errorMessage =
+      'CredentialCreate: invalid field Subject: expected a string'
     assertInvalid(credentialCreate, errorMessage)
   })
 
@@ -86,7 +88,8 @@ describe('credentialCreate', function () {
 
   it(`throws w/ Expiration field not number`, function () {
     credentialCreate.Expiration = 'this is not a number'
-    const errorMessage = 'CredentialCreate: invalid field Expiration'
+    const errorMessage =
+      'CredentialCreate: invalid field Expiration: expected a number'
     assertInvalid(credentialCreate, errorMessage)
   })
 

--- a/packages/xrpl/test/models/CredentialDelete.test.ts
+++ b/packages/xrpl/test/models/CredentialDelete.test.ts
@@ -40,19 +40,22 @@ describe('CredentialDelete', function () {
 
   it(`throws w/ Account not string`, function () {
     credentialDelete.Account = 123
-    const errorMessage = 'CredentialDelete: invalid field Account'
+    const errorMessage =
+      'CredentialDelete: invalid field Account: expected a string'
     assertInvalid(credentialDelete, errorMessage)
   })
 
   it(`throws w/ Subject not string`, function () {
     credentialDelete.Subject = 123
-    const errorMessage = 'CredentialDelete: invalid field Subject'
+    const errorMessage =
+      'CredentialDelete: invalid field Subject: expected a string'
     assertInvalid(credentialDelete, errorMessage)
   })
 
   it(`throws w/ Issuer not string`, function () {
     credentialDelete.Issuer = 123
-    const errorMessage = 'CredentialDelete: invalid field Issuer'
+    const errorMessage =
+      'CredentialDelete: invalid field Issuer: expected a string'
     assertInvalid(credentialDelete, errorMessage)
   })
 

--- a/packages/xrpl/test/models/DIDSet.test.ts
+++ b/packages/xrpl/test/models/DIDSet.test.ts
@@ -33,19 +33,19 @@ describe('DIDSet', function () {
   it('throws w/ invalid Data', function () {
     tx.Data = 123
 
-    assertInvalid(tx, 'DIDSet: invalid field Data')
+    assertInvalid(tx, 'DIDSet: invalid field Data: expected a string')
   })
 
   it('throws w/ invalid DIDDocument', function () {
     tx.DIDDocument = 123
 
-    assertInvalid(tx, 'DIDSet: invalid field DIDDocument')
+    assertInvalid(tx, 'DIDSet: invalid field DIDDocument: expected a string')
   })
 
   it('throws w/ invalid URI', function () {
     tx.URI = 123
 
-    assertInvalid(tx, 'DIDSet: invalid field URI')
+    assertInvalid(tx, 'DIDSet: invalid field URI: expected a string')
   })
 
   it('throws w/ empty DID', function () {

--- a/packages/xrpl/test/models/XChainAccountCreateCommit.test.ts
+++ b/packages/xrpl/test/models/XChainAccountCreateCommit.test.ts
@@ -50,7 +50,10 @@ describe('XChainAccountCreateCommit', function () {
   it('throws w/ invalid XChainBridge', function () {
     tx.XChainBridge = { XChainDoor: 'test' }
 
-    assertInvalid(tx, 'XChainAccountCreateCommit: invalid field XChainBridge')
+    assertInvalid(
+      tx,
+      'XChainAccountCreateCommit: invalid field XChainBridge: expected an XChainBridge',
+    )
   })
 
   it('throws w/ missing SignatureReward', function () {
@@ -67,7 +70,7 @@ describe('XChainAccountCreateCommit', function () {
 
     assertInvalid(
       tx,
-      'XChainAccountCreateCommit: invalid field SignatureReward',
+      'XChainAccountCreateCommit: invalid field SignatureReward: expected an Amount',
     )
   })
 
@@ -80,7 +83,10 @@ describe('XChainAccountCreateCommit', function () {
   it('throws w/ invalid Destination', function () {
     tx.Destination = 123
 
-    assertInvalid(tx, 'XChainAccountCreateCommit: invalid field Destination')
+    assertInvalid(
+      tx,
+      'XChainAccountCreateCommit: invalid field Destination: expected a valid account',
+    )
   })
 
   it('throws w/ missing Amount', function () {
@@ -92,6 +98,9 @@ describe('XChainAccountCreateCommit', function () {
   it('throws w/ invalid Amount', function () {
     tx.Amount = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainAccountCreateCommit: invalid field Amount')
+    assertInvalid(
+      tx,
+      'XChainAccountCreateCommit: invalid field Amount: expected an Amount',
+    )
   })
 })

--- a/packages/xrpl/test/models/XChainAddAccountCreateAttestation.test.ts
+++ b/packages/xrpl/test/models/XChainAddAccountCreateAttestation.test.ts
@@ -64,7 +64,10 @@ describe('XChainAddAccountCreateAttestation', function () {
   it('throws w/ invalid Amount', function () {
     tx.Amount = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainAddAccountCreateAttestation: invalid field Amount')
+    assertInvalid(
+      tx,
+      'XChainAddAccountCreateAttestation: invalid field Amount: expected an Amount',
+    )
   })
 
   it('throws w/ missing AttestationRewardAccount', function () {
@@ -81,7 +84,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field AttestationRewardAccount',
+      'XChainAddAccountCreateAttestation: invalid field AttestationRewardAccount: expected a valid account',
     )
   })
 
@@ -99,7 +102,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field AttestationSignerAccount',
+      'XChainAddAccountCreateAttestation: invalid field AttestationSignerAccount: expected a valid account',
     )
   })
 
@@ -117,7 +120,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field Destination',
+      'XChainAddAccountCreateAttestation: invalid field Destination: expected a valid account',
     )
   })
 
@@ -135,7 +138,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field OtherChainSource',
+      'XChainAddAccountCreateAttestation: invalid field OtherChainSource: expected a valid account',
     )
   })
 
@@ -153,7 +156,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field PublicKey',
+      'XChainAddAccountCreateAttestation: invalid field PublicKey: expected a string',
     )
   })
 
@@ -171,7 +174,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field Signature',
+      'XChainAddAccountCreateAttestation: invalid field Signature: expected a string',
     )
   })
 
@@ -189,7 +192,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field SignatureReward',
+      'XChainAddAccountCreateAttestation: invalid field SignatureReward: expected an Amount',
     )
   })
 
@@ -207,7 +210,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field WasLockingChainSend',
+      'XChainAddAccountCreateAttestation: invalid field WasLockingChainSend: expected 0 or 1',
     )
   })
 
@@ -225,7 +228,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field XChainAccountCreateCount',
+      'XChainAddAccountCreateAttestation: invalid field XChainAccountCreateCount: expected a number or string',
     )
   })
 
@@ -243,7 +246,7 @@ describe('XChainAddAccountCreateAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddAccountCreateAttestation: invalid field XChainBridge',
+      'XChainAddAccountCreateAttestation: invalid field XChainBridge: expected an XChainBridge',
     )
   })
 })

--- a/packages/xrpl/test/models/XChainAddClaimAttestation.test.ts
+++ b/packages/xrpl/test/models/XChainAddClaimAttestation.test.ts
@@ -58,7 +58,10 @@ describe('XChainAddClaimAttestation', function () {
   it('throws w/ invalid Amount', function () {
     tx.Amount = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainAddClaimAttestation: invalid field Amount')
+    assertInvalid(
+      tx,
+      'XChainAddClaimAttestation: invalid field Amount: expected an Amount',
+    )
   })
 
   it('throws w/ missing AttestationRewardAccount', function () {
@@ -75,7 +78,7 @@ describe('XChainAddClaimAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddClaimAttestation: invalid field AttestationRewardAccount',
+      'XChainAddClaimAttestation: invalid field AttestationRewardAccount: expected a valid account',
     )
   })
 
@@ -93,14 +96,17 @@ describe('XChainAddClaimAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddClaimAttestation: invalid field AttestationSignerAccount',
+      'XChainAddClaimAttestation: invalid field AttestationSignerAccount: expected a valid account',
     )
   })
 
   it('throws w/ invalid Destination', function () {
     tx.Destination = 123
 
-    assertInvalid(tx, 'XChainAddClaimAttestation: invalid field Destination')
+    assertInvalid(
+      tx,
+      'XChainAddClaimAttestation: invalid field Destination: expected a valid account',
+    )
   })
 
   it('throws w/ missing OtherChainSource', function () {
@@ -117,7 +123,7 @@ describe('XChainAddClaimAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddClaimAttestation: invalid field OtherChainSource',
+      'XChainAddClaimAttestation: invalid field OtherChainSource: expected a valid account',
     )
   })
 
@@ -130,7 +136,10 @@ describe('XChainAddClaimAttestation', function () {
   it('throws w/ invalid PublicKey', function () {
     tx.PublicKey = 123
 
-    assertInvalid(tx, 'XChainAddClaimAttestation: invalid field PublicKey')
+    assertInvalid(
+      tx,
+      'XChainAddClaimAttestation: invalid field PublicKey: expected a string',
+    )
   })
 
   it('throws w/ missing Signature', function () {
@@ -142,7 +151,10 @@ describe('XChainAddClaimAttestation', function () {
   it('throws w/ invalid Signature', function () {
     tx.Signature = 123
 
-    assertInvalid(tx, 'XChainAddClaimAttestation: invalid field Signature')
+    assertInvalid(
+      tx,
+      'XChainAddClaimAttestation: invalid field Signature: expected a string',
+    )
   })
 
   it('throws w/ missing WasLockingChainSend', function () {
@@ -159,7 +171,7 @@ describe('XChainAddClaimAttestation', function () {
 
     assertInvalid(
       tx,
-      'XChainAddClaimAttestation: invalid field WasLockingChainSend',
+      'XChainAddClaimAttestation: invalid field WasLockingChainSend: expected 0 or 1',
     )
   })
 
@@ -172,7 +184,10 @@ describe('XChainAddClaimAttestation', function () {
   it('throws w/ invalid XChainBridge', function () {
     tx.XChainBridge = { XChainDoor: 'test' }
 
-    assertInvalid(tx, 'XChainAddClaimAttestation: invalid field XChainBridge')
+    assertInvalid(
+      tx,
+      'XChainAddClaimAttestation: invalid field XChainBridge: expected an XChainBridge',
+    )
   })
 
   it('throws w/ missing XChainClaimID', function () {
@@ -184,6 +199,9 @@ describe('XChainAddClaimAttestation', function () {
   it('throws w/ invalid XChainClaimID', function () {
     tx.XChainClaimID = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainAddClaimAttestation: invalid field XChainClaimID')
+    assertInvalid(
+      tx,
+      'XChainAddClaimAttestation: invalid field XChainClaimID: expected a number or string',
+    )
   })
 })

--- a/packages/xrpl/test/models/XChainClaim.test.ts
+++ b/packages/xrpl/test/models/XChainClaim.test.ts
@@ -49,7 +49,10 @@ describe('XChainClaim', function () {
   it('throws w/ invalid XChainBridge', function () {
     tx.XChainBridge = { XChainDoor: 'test' }
 
-    assertInvalid(tx, 'XChainClaim: invalid field XChainBridge')
+    assertInvalid(
+      tx,
+      'XChainClaim: invalid field XChainBridge: expected an XChainBridge',
+    )
   })
 
   it('throws w/ missing XChainClaimID', function () {
@@ -61,7 +64,10 @@ describe('XChainClaim', function () {
   it('throws w/ invalid XChainClaimID', function () {
     tx.XChainClaimID = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainClaim: invalid field XChainClaimID')
+    assertInvalid(
+      tx,
+      'XChainClaim: invalid field XChainClaimID: expected a number or string',
+    )
   })
 
   it('throws w/ missing Destination', function () {
@@ -73,13 +79,19 @@ describe('XChainClaim', function () {
   it('throws w/ invalid Destination', function () {
     tx.Destination = 123
 
-    assertInvalid(tx, 'XChainClaim: invalid field Destination')
+    assertInvalid(
+      tx,
+      'XChainClaim: invalid field Destination: expected a valid account',
+    )
   })
 
   it('throws w/ invalid DestinationTag', function () {
     tx.DestinationTag = 'number'
 
-    assertInvalid(tx, 'XChainClaim: invalid field DestinationTag')
+    assertInvalid(
+      tx,
+      'XChainClaim: invalid field DestinationTag: expected a number',
+    )
   })
 
   it('throws w/ missing Amount', function () {
@@ -91,6 +103,6 @@ describe('XChainClaim', function () {
   it('throws w/ invalid Amount', function () {
     tx.Amount = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainClaim: invalid field Amount')
+    assertInvalid(tx, 'XChainClaim: invalid field Amount: expected an Amount')
   })
 })

--- a/packages/xrpl/test/models/XChainCommit.test.ts
+++ b/packages/xrpl/test/models/XChainCommit.test.ts
@@ -48,7 +48,10 @@ describe('XChainCommit', function () {
   it('throws w/ invalid XChainBridge', function () {
     tx.XChainBridge = { XChainDoor: 'test' }
 
-    assertInvalid(tx, 'XChainCommit: invalid field XChainBridge')
+    assertInvalid(
+      tx,
+      'XChainCommit: invalid field XChainBridge: expected an XChainBridge',
+    )
   })
 
   it('throws w/ missing XChainClaimID', function () {
@@ -60,13 +63,19 @@ describe('XChainCommit', function () {
   it('throws w/ invalid XChainClaimID', function () {
     tx.XChainClaimID = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainCommit: invalid field XChainClaimID')
+    assertInvalid(
+      tx,
+      'XChainCommit: invalid field XChainClaimID: expected a number or string',
+    )
   })
 
   it('throws w/ invalid OtherChainDestination', function () {
     tx.OtherChainDestination = 123
 
-    assertInvalid(tx, 'XChainCommit: invalid field OtherChainDestination')
+    assertInvalid(
+      tx,
+      'XChainCommit: invalid field OtherChainDestination: expected a valid account',
+    )
   })
 
   it('throws w/ missing Amount', function () {
@@ -78,6 +87,6 @@ describe('XChainCommit', function () {
   it('throws w/ invalid Amount', function () {
     tx.Amount = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainCommit: invalid field Amount')
+    assertInvalid(tx, 'XChainCommit: invalid field Amount: expected an Amount')
   })
 })

--- a/packages/xrpl/test/models/XChainCreateBridge.test.ts
+++ b/packages/xrpl/test/models/XChainCreateBridge.test.ts
@@ -49,7 +49,10 @@ describe('XChainCreateBridge', function () {
   it('throws w/ invalid XChainBridge', function () {
     tx.XChainBridge = { XChainDoor: 'test' }
 
-    assertInvalid(tx, 'XChainCreateBridge: invalid field XChainBridge')
+    assertInvalid(
+      tx,
+      'XChainCreateBridge: invalid field XChainBridge: expected an XChainBridge',
+    )
   })
 
   it('throws w/ missing SignatureReward', function () {
@@ -61,7 +64,10 @@ describe('XChainCreateBridge', function () {
   it('throws w/ invalid SignatureReward', function () {
     tx.SignatureReward = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainCreateBridge: invalid field SignatureReward')
+    assertInvalid(
+      tx,
+      'XChainCreateBridge: invalid field SignatureReward: expected an Amount',
+    )
   })
 
   it('throws w/ invalid MinAccountCreateAmount', function () {
@@ -69,7 +75,7 @@ describe('XChainCreateBridge', function () {
 
     assertInvalid(
       tx,
-      'XChainCreateBridge: invalid field MinAccountCreateAmount',
+      'XChainCreateBridge: invalid field MinAccountCreateAmount: expected an Amount',
     )
   })
 })

--- a/packages/xrpl/test/models/XChainCreateClaimID.test.ts
+++ b/packages/xrpl/test/models/XChainCreateClaimID.test.ts
@@ -49,7 +49,10 @@ describe('XChainCreateClaimID', function () {
   it('throws w/ invalid XChainBridge', function () {
     tx.XChainBridge = { XChainDoor: 'test' }
 
-    assertInvalid(tx, 'XChainCreateClaimID: invalid field XChainBridge')
+    assertInvalid(
+      tx,
+      'XChainCreateClaimID: invalid field XChainBridge: expected an XChainBridge',
+    )
   })
 
   it('throws w/ missing SignatureReward', function () {
@@ -61,7 +64,10 @@ describe('XChainCreateClaimID', function () {
   it('throws w/ invalid SignatureReward', function () {
     tx.SignatureReward = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainCreateClaimID: invalid field SignatureReward')
+    assertInvalid(
+      tx,
+      'XChainCreateClaimID: invalid field SignatureReward: expected an Amount',
+    )
   })
 
   it('throws w/ missing OtherChainSource', function () {
@@ -73,6 +79,9 @@ describe('XChainCreateClaimID', function () {
   it('throws w/ invalid OtherChainSource', function () {
     tx.OtherChainSource = 123
 
-    assertInvalid(tx, 'XChainCreateClaimID: invalid field OtherChainSource')
+    assertInvalid(
+      tx,
+      'XChainCreateClaimID: invalid field OtherChainSource: expected a valid account',
+    )
   })
 })

--- a/packages/xrpl/test/models/XChainModifyBridge.test.ts
+++ b/packages/xrpl/test/models/XChainModifyBridge.test.ts
@@ -49,13 +49,19 @@ describe('XChainModifyBridge', function () {
   it('throws w/ invalid XChainBridge', function () {
     tx.XChainBridge = { XChainDoor: 'test' }
 
-    assertInvalid(tx, 'XChainModifyBridge: invalid field XChainBridge')
+    assertInvalid(
+      tx,
+      'XChainModifyBridge: invalid field XChainBridge: expected an XChainBridge',
+    )
   })
 
   it('throws w/ invalid SignatureReward', function () {
     tx.SignatureReward = { currency: 'ETH' }
 
-    assertInvalid(tx, 'XChainModifyBridge: invalid field SignatureReward')
+    assertInvalid(
+      tx,
+      'XChainModifyBridge: invalid field SignatureReward: expected an Amount',
+    )
   })
 
   it('throws w/ invalid MinAccountCreateAmount', function () {
@@ -63,7 +69,7 @@ describe('XChainModifyBridge', function () {
 
     assertInvalid(
       tx,
-      'XChainModifyBridge: invalid field MinAccountCreateAmount',
+      'XChainModifyBridge: invalid field MinAccountCreateAmount: expected an Amount',
     )
   })
 })

--- a/packages/xrpl/test/models/accountDelete.test.ts
+++ b/packages/xrpl/test/models/accountDelete.test.ts
@@ -40,13 +40,15 @@ describe('AccountDelete', function () {
 
   it(`throws w/ invalid Destination`, function () {
     validAccountDelete.Destination = 65478965
-    const errorMessage = 'AccountDelete: invalid field Destination'
+    const errorMessage =
+      'AccountDelete: invalid field Destination: expected a valid account'
     assertInvalid(validAccountDelete, errorMessage)
   })
 
   it(`throws w/ invalid DestinationTag`, function () {
     validAccountDelete.DestinationTag = 'gvftyujnbv'
-    const errorMessage = 'AccountDelete: invalid field DestinationTag'
+    const errorMessage =
+      'AccountDelete: invalid field DestinationTag: expected a number'
     assertInvalid(validAccountDelete, errorMessage)
   })
 

--- a/packages/xrpl/test/models/accountSet.test.ts
+++ b/packages/xrpl/test/models/accountSet.test.ts
@@ -72,6 +72,9 @@ describe('AccountSet', function () {
 
   it(`throws w/ invalid NFTokenMinter`, function () {
     tx.NFTokenMinter = ''
-    assertInvalid(tx, 'AccountSet: invalid field NFTokenMinter')
+    assertInvalid(
+      tx,
+      'AccountSet: invalid field NFTokenMinter: expected a valid account',
+    )
   })
 })

--- a/packages/xrpl/test/models/baseTransaction.test.ts
+++ b/packages/xrpl/test/models/baseTransaction.test.ts
@@ -80,7 +80,7 @@ describe('BaseTransaction', function () {
       Fee: 1000,
     } as any
 
-    assertInvalid(invalidFee, 'Payment: invalid field Fee')
+    assertInvalid(invalidFee, 'Payment: invalid field Fee: expected a string')
   })
 
   it(`Handles invalid Sequence`, function () {
@@ -90,7 +90,10 @@ describe('BaseTransaction', function () {
       Sequence: '145',
     } as any
 
-    assertInvalid(invalidSeq, 'Payment: invalid field Sequence')
+    assertInvalid(
+      invalidSeq,
+      'Payment: invalid field Sequence: expected a number',
+    )
   })
 
   it(`Handles invalid AccountTxnID`, function () {
@@ -100,7 +103,10 @@ describe('BaseTransaction', function () {
       AccountTxnID: ['WRONG'],
     } as any
 
-    assertInvalid(invalidID, 'Payment: invalid field AccountTxnID')
+    assertInvalid(
+      invalidID,
+      'Payment: invalid field AccountTxnID: expected a string',
+    )
   })
 
   it(`Handles invalid LastLedgerSequence`, function () {
@@ -112,7 +118,7 @@ describe('BaseTransaction', function () {
 
     assertInvalid(
       invalidLastLedgerSequence,
-      'Payment: invalid field LastLedgerSequence',
+      'Payment: invalid field LastLedgerSequence: expected a number',
     )
   })
 
@@ -123,7 +129,10 @@ describe('BaseTransaction', function () {
       SourceTag: ['ARRAY'],
     } as any
 
-    assertInvalid(invalidSourceTag, 'Payment: invalid field SourceTag')
+    assertInvalid(
+      invalidSourceTag,
+      'Payment: invalid field SourceTag: expected a number',
+    )
   })
 
   it(`Handles invalid SigningPubKey`, function () {
@@ -133,7 +142,10 @@ describe('BaseTransaction', function () {
       SigningPubKey: 1000,
     } as any
 
-    assertInvalid(invalidSigningPubKey, 'Payment: invalid field SigningPubKey')
+    assertInvalid(
+      invalidSigningPubKey,
+      'Payment: invalid field SigningPubKey: expected a string',
+    )
   })
 
   it(`Handles invalid TicketSequence`, function () {
@@ -145,7 +157,7 @@ describe('BaseTransaction', function () {
 
     assertInvalid(
       invalidTicketSequence,
-      'Payment: invalid field TicketSequence',
+      'Payment: invalid field TicketSequence: expected a number',
     )
   })
 
@@ -156,7 +168,10 @@ describe('BaseTransaction', function () {
       TxnSignature: 1000,
     } as any
 
-    assertInvalid(invalidTxnSignature, 'Payment: invalid field TxnSignature')
+    assertInvalid(
+      invalidTxnSignature,
+      'Payment: invalid field TxnSignature: expected a string',
+    )
   })
 
   it(`Handles invalid Signers`, function () {
@@ -206,7 +221,10 @@ describe('BaseTransaction', function () {
       TransactionType: 'Payment',
       NetworkID: '1024',
     }
-    assertInvalid(invalidNetworkID, 'Payment: invalid field NetworkID')
+    assertInvalid(
+      invalidNetworkID,
+      'Payment: invalid field NetworkID: expected a number',
+    )
   })
 
   it(`Handles invalid Delegate`, function () {
@@ -215,7 +233,10 @@ describe('BaseTransaction', function () {
       TransactionType: 'Payment',
       Delegate: 1234,
     }
-    assertInvalid(invalidDelegate, 'Payment: invalid field Delegate')
+    assertInvalid(
+      invalidDelegate,
+      'Payment: invalid field Delegate: expected a valid account',
+    )
   })
 
   it(`Handles Account and Delegate being the same error`, function () {

--- a/packages/xrpl/test/models/batch.test.ts
+++ b/packages/xrpl/test/models/batch.test.ts
@@ -103,7 +103,7 @@ describe('Batch', function () {
 
   it('throws w/ invalid BatchSigners', function () {
     tx.BatchSigners = 0
-    assertInvalid(tx, 'Batch: invalid field BatchSigners')
+    assertInvalid(tx, 'Batch: invalid field BatchSigners: expected an array')
   })
 
   it('throws w/ missing RawTransactions', function () {
@@ -113,7 +113,7 @@ describe('Batch', function () {
 
   it('throws w/ invalid RawTransactions', function () {
     tx.RawTransactions = 0
-    assertInvalid(tx, 'Batch: invalid field RawTransactions')
+    assertInvalid(tx, 'Batch: invalid field RawTransactions: expected an array')
   })
 
   it('throws w/ invalid RawTransactions object', function () {
@@ -123,7 +123,10 @@ describe('Batch', function () {
 
   it('throws w/ invalid RawTransactions.RawTransaction object', function () {
     tx.RawTransactions = [{ RawTransaction: 0 }]
-    assertInvalid(tx, 'Batch: invalid field RawTransactions[0].RawTransaction')
+    assertInvalid(
+      tx,
+      'Batch: invalid field RawTransactions[0].RawTransaction: expected an object',
+    )
   })
 
   it('throws w/ nested Batch', function () {

--- a/packages/xrpl/test/models/checkCreate.test.ts
+++ b/packages/xrpl/test/models/checkCreate.test.ts
@@ -40,7 +40,10 @@ describe('CheckCreate', function () {
       Fee: '12',
     } as any
 
-    assertInvalid(invalidDestination, 'CheckCreate: invalid field Destination')
+    assertInvalid(
+      invalidDestination,
+      'CheckCreate: invalid field Destination: expected a valid account',
+    )
   })
 
   it(`throws w/ invalid SendMax`, function () {
@@ -74,7 +77,7 @@ describe('CheckCreate', function () {
 
     assertInvalid(
       invalidDestinationTag,
-      'CheckCreate: invalid field DestinationTag',
+      'CheckCreate: invalid field DestinationTag: expected a number',
     )
   })
 

--- a/packages/xrpl/test/models/clawback.test.ts
+++ b/packages/xrpl/test/models/clawback.test.ts
@@ -41,7 +41,10 @@ describe('Clawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
     } as any
 
-    assertInvalid(invalidAmount, 'Clawback: invalid field Amount')
+    assertInvalid(
+      invalidAmount,
+      'Clawback: invalid field Amount: expected a ClawbackAmount',
+    )
 
     const invalidStrAmount = {
       TransactionType: 'Clawback',
@@ -49,7 +52,10 @@ describe('Clawback', function () {
       Account: 'rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm',
     } as any
 
-    assertInvalid(invalidStrAmount, 'Clawback: invalid field Amount')
+    assertInvalid(
+      invalidStrAmount,
+      'Clawback: invalid field Amount: expected a ClawbackAmount',
+    )
   })
 
   it(`throws w/ invalid holder Account`, function () {

--- a/packages/xrpl/test/models/delegateSet.test.ts
+++ b/packages/xrpl/test/models/delegateSet.test.ts
@@ -49,7 +49,8 @@ describe('DelegateSet', function () {
 
   it(`throws w/ invalid field Permissions`, function () {
     tx.Permissions = 'TrustlineAuthorize'
-    const errorMessage = 'DelegateSet: invalid field Permissions'
+    const errorMessage =
+      'DelegateSet: invalid field Permissions: expected an array'
     assertInvalid(tx, errorMessage)
   })
 

--- a/packages/xrpl/test/models/escrowCancel.test.ts
+++ b/packages/xrpl/test/models/escrowCancel.test.ts
@@ -47,7 +47,10 @@ describe('EscrowCancel', function () {
   it(`Invalid Owner`, function () {
     cancel.Owner = 10
 
-    assertInvalid(cancel, 'EscrowCancel: invalid field Owner')
+    assertInvalid(
+      cancel,
+      'EscrowCancel: invalid field Owner: expected a valid account',
+    )
   })
 
   it(`Invalid OfferSequence`, function () {

--- a/packages/xrpl/test/models/escrowCreate.test.ts
+++ b/packages/xrpl/test/models/escrowCreate.test.ts
@@ -47,13 +47,19 @@ describe('EscrowCreate', function () {
   it(`throws w/ invalid Destination`, function () {
     escrow.Destination = 10
 
-    assertInvalid(escrow, 'EscrowCreate: invalid field Destination')
+    assertInvalid(
+      escrow,
+      'EscrowCreate: invalid field Destination: expected a valid account',
+    )
   })
 
   it(`throws w/ invalid Amount`, function () {
     escrow.Amount = 1000
 
-    assertInvalid(escrow, 'EscrowCreate: invalid field Amount')
+    assertInvalid(
+      escrow,
+      'EscrowCreate: invalid field Amount: expected an Amount',
+    )
   })
 
   it(`invalid CancelAfter`, function () {
@@ -77,7 +83,10 @@ describe('EscrowCreate', function () {
   it(`invalid DestinationTag`, function () {
     escrow.DestinationTag = '100'
 
-    assertInvalid(escrow, 'EscrowCreate: invalid field DestinationTag')
+    assertInvalid(
+      escrow,
+      'EscrowCreate: invalid field DestinationTag: expected a number',
+    )
   })
 
   it(`Missing both CancelAfter and FinishAfter`, function () {

--- a/packages/xrpl/test/models/escrowFinish.test.ts
+++ b/packages/xrpl/test/models/escrowFinish.test.ts
@@ -48,7 +48,10 @@ describe('EscrowFinish', function () {
   it(`throws w/ invalid Owner`, function () {
     escrow.Owner = 0x15415253
 
-    assertInvalid(escrow, 'EscrowFinish: invalid field Owner')
+    assertInvalid(
+      escrow,
+      'EscrowFinish: invalid field Owner: expected a valid account',
+    )
   })
 
   it(`throws w/ invalid OfferSequence`, function () {

--- a/packages/xrpl/test/models/loanBrokerCoverClawback.test.ts
+++ b/packages/xrpl/test/models/loanBrokerCoverClawback.test.ts
@@ -40,10 +40,16 @@ describe('unit test LoanBrokerCoverClawback', () => {
       mpt_issuanceId: '0000012FFD9EE5DA93AC614B4DB94D7E0FCE415CA51BED47',
       value: '1000000',
     }
-    assertInvalid(tx, 'LoanBrokerCoverClawback: invalid field Amount')
+    assertInvalid(
+      tx,
+      'LoanBrokerCoverClawback: invalid field Amount: expected a token amount',
+    )
 
     tx.Amount = '100'
-    assertInvalid(tx, 'LoanBrokerCoverClawback: invalid field Amount')
+    assertInvalid(
+      tx,
+      'LoanBrokerCoverClawback: invalid field Amount: expected a token amount',
+    )
   })
 
   test('missing LoanBrokerId and Amount', () => {

--- a/packages/xrpl/test/models/loanBrokerCoverDeposit.test.ts
+++ b/packages/xrpl/test/models/loanBrokerCoverDeposit.test.ts
@@ -43,7 +43,10 @@ describe('unit test LoanBrokerCoverDeposit', () => {
       mpt_issuanceId: '0000012FFD9EE5DA93AC614B4DB94D7E0FCE415CA51BED47',
       value: '1000000',
     }
-    assertInvalid(tx, 'LoanBrokerCoverDeposit: invalid field Amount')
+    assertInvalid(
+      tx,
+      'LoanBrokerCoverDeposit: invalid field Amount: expected an Amount',
+    )
 
     delete tx.Amount
     assertInvalid(tx, 'LoanBrokerCoverDeposit: missing field Amount')

--- a/packages/xrpl/test/models/loanBrokerCoverWithdraw.test.ts
+++ b/packages/xrpl/test/models/loanBrokerCoverWithdraw.test.ts
@@ -35,8 +35,30 @@ describe('unit test LoanBrokerCoverWithdraw', () => {
       'LoanBrokerCoverWithdraw: LoanBrokerID must be 64 characters hexadecimal string',
     )
 
+    tx.LoanBrokerID = 12345
+    assertInvalid(
+      tx,
+      'LoanBrokerCoverWithdraw: invalid field LoanBrokerID: expected a string',
+    )
+
     delete tx.LoanBrokerID
     assertInvalid(tx, 'LoanBrokerCoverWithdraw: missing field LoanBrokerID')
+  })
+
+  test('incorrect Destination', () => {
+    tx.Destination = 12345
+    assertInvalid(
+      tx,
+      'LoanBrokerCoverWithdraw: invalid field Destination: expected a valid account',
+    )
+  })
+
+  test('incorrect DestinationTag', () => {
+    tx.DestinationTag = 'INCORRECT_VALUE'
+    assertInvalid(
+      tx,
+      'LoanBrokerCoverWithdraw: invalid field DestinationTag: expected a number',
+    )
   })
 
   test('incorrect Amount', () => {
@@ -44,7 +66,10 @@ describe('unit test LoanBrokerCoverWithdraw', () => {
       mpt_issuanceId: '0000012FFD9EE5DA93AC614B4DB94D7E0FCE415CA51BED47',
       value: '1000000',
     }
-    assertInvalid(tx, 'LoanBrokerCoverWithdraw: invalid field Amount')
+    assertInvalid(
+      tx,
+      'LoanBrokerCoverWithdraw: invalid field Amount: expected an Amount',
+    )
 
     delete tx.Amount
     assertInvalid(tx, 'LoanBrokerCoverWithdraw: missing field Amount')

--- a/packages/xrpl/test/models/loanBrokerDelete.test.ts
+++ b/packages/xrpl/test/models/loanBrokerDelete.test.ts
@@ -30,6 +30,12 @@ describe('unit test LoanBrokerDelete', () => {
       'LoanBrokerDelete: LoanBrokerID must be 64 characters hexadecimal string',
     )
 
+    tx.LoanBrokerID = 12345
+    assertInvalid(
+      tx,
+      'LoanBrokerDelete: invalid field LoanBrokerID: expected a string',
+    )
+
     delete tx.LoanBrokerID
     assertInvalid(tx, 'LoanBrokerDelete: missing field LoanBrokerID')
   })

--- a/packages/xrpl/test/models/loanPay.test.ts
+++ b/packages/xrpl/test/models/loanPay.test.ts
@@ -81,6 +81,6 @@ describe('unit test LoanPay', () => {
 
   test('invalid Amount', () => {
     tx.Amount = 123
-    assertInvalid(tx, 'LoanPay: invalid field Amount')
+    assertInvalid(tx, 'LoanPay: invalid field Amount: expected an Amount')
   })
 })

--- a/packages/xrpl/test/models/offerCreate.test.ts
+++ b/packages/xrpl/test/models/offerCreate.test.ts
@@ -121,7 +121,10 @@ describe('OfferCreate', function () {
       TransactionType: 'OfferCreate',
     } as any
 
-    assertInvalid(offerTx, 'OfferCreate: invalid field DomainID')
+    assertInvalid(
+      offerTx,
+      'OfferCreate: invalid field DomainID: expected a 64-character hex string',
+    )
   })
 
   it(`throws -- invalid DomainID , exceeds expected length`, function () {
@@ -137,7 +140,10 @@ describe('OfferCreate', function () {
       TransactionType: 'OfferCreate',
     } as any
 
-    assertInvalid(offerTx, 'OfferCreate: invalid field DomainID')
+    assertInvalid(
+      offerTx,
+      'OfferCreate: invalid field DomainID: expected a 64-character hex string',
+    )
   })
 
   it(`throws -- invalid DomainID , falls short of expected length`, function () {
@@ -153,7 +159,10 @@ describe('OfferCreate', function () {
       TransactionType: 'OfferCreate',
     } as any
 
-    assertInvalid(offerTx, 'OfferCreate: invalid field DomainID')
+    assertInvalid(
+      offerTx,
+      'OfferCreate: invalid field DomainID: expected a 64-character hex string',
+    )
   })
 
   it(`throws -- invalid flag (interface) specified without DomainID`, function () {

--- a/packages/xrpl/test/models/oracleDelete.test.ts
+++ b/packages/xrpl/test/models/oracleDelete.test.ts
@@ -33,7 +33,8 @@ describe('OracleDelete', function () {
 
   it(`throws w/ invalid OracleDocumentID`, function () {
     tx.OracleDocumentID = '1234'
-    const errorMessage = 'OracleDelete: invalid field OracleDocumentID'
+    const errorMessage =
+      'OracleDelete: invalid field OracleDocumentID: expected a number'
     assertInvalid(tx, errorMessage)
   })
 })

--- a/packages/xrpl/test/models/oracleSet.test.ts
+++ b/packages/xrpl/test/models/oracleSet.test.ts
@@ -49,7 +49,8 @@ describe('OracleSet', function () {
 
   it(`throws w/ invalid OracleDocumentID`, function () {
     tx.OracleDocumentID = '1234'
-    const errorMessage = 'OracleSet: invalid field OracleDocumentID'
+    const errorMessage =
+      'OracleSet: invalid field OracleDocumentID: expected a number'
     assertInvalid(tx, errorMessage)
   })
 
@@ -61,25 +62,27 @@ describe('OracleSet', function () {
 
   it(`throws w/ invalid LastUpdateTime`, function () {
     tx.LastUpdateTime = '768062172'
-    const errorMessage = 'OracleSet: invalid field LastUpdateTime'
+    const errorMessage =
+      'OracleSet: invalid field LastUpdateTime: expected a number'
     assertInvalid(tx, errorMessage)
   })
 
   it(`throws w/ missing invalid Provider`, function () {
     tx.Provider = 1234
-    const errorMessage = 'OracleSet: invalid field Provider'
+    const errorMessage = 'OracleSet: invalid field Provider: expected a string'
     assertInvalid(tx, errorMessage)
   })
 
   it(`throws w/ missing invalid URI`, function () {
     tx.URI = 1234
-    const errorMessage = 'OracleSet: invalid field URI'
+    const errorMessage = 'OracleSet: invalid field URI: expected a string'
     assertInvalid(tx, errorMessage)
   })
 
   it(`throws w/ missing invalid AssetClass`, function () {
     tx.AssetClass = 1234
-    const errorMessage = 'OracleSet: invalid field AssetClass'
+    const errorMessage =
+      'OracleSet: invalid field AssetClass: expected a string'
     assertInvalid(tx, errorMessage)
   })
 

--- a/packages/xrpl/test/models/payment.test.ts
+++ b/packages/xrpl/test/models/payment.test.ts
@@ -59,7 +59,10 @@ describe('Payment', function () {
       DomainID: { sampleDictKey: 1 },
     } as any
 
-    assertInvalid(paymentTx, 'PaymentTransaction: invalid field DomainID')
+    assertInvalid(
+      paymentTx,
+      'PaymentTransaction: invalid field DomainID: expected a 64-character hex string',
+    )
   })
 
   it(`throws -- invalid DomainID , exceeds expected length`, function () {
@@ -71,7 +74,10 @@ describe('Payment', function () {
       DomainID: '5'.repeat(65),
     } as any
 
-    assertInvalid(paymentTx, 'PaymentTransaction: invalid field DomainID')
+    assertInvalid(
+      paymentTx,
+      'PaymentTransaction: invalid field DomainID: expected a 64-character hex string',
+    )
   })
 
   it(`throws -- invalid DomainID , falls short of expected length`, function () {
@@ -83,7 +89,10 @@ describe('Payment', function () {
       DomainID: '5'.repeat(63),
     } as any
 
-    assertInvalid(paymentTx, 'PaymentTransaction: invalid field DomainID')
+    assertInvalid(
+      paymentTx,
+      'PaymentTransaction: invalid field DomainID: expected a 64-character hex string',
+    )
   })
 
   it(`Verifies memos correctly`, function () {
@@ -128,12 +137,18 @@ describe('Payment', function () {
 
   it(`throws when Destination is invalid`, function () {
     payment.Destination = 7896214
-    assertInvalid(payment, 'Payment: invalid field Destination')
+    assertInvalid(
+      payment,
+      'Payment: invalid field Destination: expected a valid account',
+    )
   })
 
   it(`throws when Destination is invalid classic address`, function () {
     payment.Destination = 'rABCD'
-    assertInvalid(payment, 'Payment: invalid field Destination')
+    assertInvalid(
+      payment,
+      'Payment: invalid field Destination: expected a valid account',
+    )
   })
 
   it(`does not throw when Destination is a valid x-address`, function () {
@@ -143,12 +158,18 @@ describe('Payment', function () {
 
   it(`throws when Destination is an empty string`, function () {
     payment.Destination = ''
-    assertInvalid(payment, 'Payment: invalid field Destination')
+    assertInvalid(
+      payment,
+      'Payment: invalid field Destination: expected a valid account',
+    )
   })
 
   it(`throws when DestinationTag is not a number`, function () {
     payment.DestinationTag = '1'
-    assertInvalid(payment, 'Payment: invalid field DestinationTag')
+    assertInvalid(
+      payment,
+      'Payment: invalid field DestinationTag: expected a number',
+    )
   })
 
   it(`throws when InvoiceID is not a string`, function () {

--- a/packages/xrpl/test/models/paymentChannelCreate.test.ts
+++ b/packages/xrpl/test/models/paymentChannelCreate.test.ts
@@ -74,7 +74,10 @@ describe('PaymentChannelCreate', function () {
   it(`invalid Destination`, function () {
     channel.Destination = 10
 
-    assertInvalid(channel, 'PaymentChannelCreate: invalid field Destination')
+    assertInvalid(
+      channel,
+      'PaymentChannelCreate: invalid field Destination: expected a valid account',
+    )
   })
 
   it(`invalid SettleDelay`, function () {
@@ -92,7 +95,10 @@ describe('PaymentChannelCreate', function () {
   it(`invalid DestinationTag`, function () {
     channel.DestinationTag = '10'
 
-    assertInvalid(channel, 'PaymentChannelCreate: invalid field DestinationTag')
+    assertInvalid(
+      channel,
+      'PaymentChannelCreate: invalid field DestinationTag: expected a number',
+    )
   })
 
   it(`invalid CancelAfter`, function () {

--- a/packages/xrpl/test/models/permissionedDomainDelete.test.ts
+++ b/packages/xrpl/test/models/permissionedDomainDelete.test.ts
@@ -35,7 +35,8 @@ describe('PermissionedDomainDelete', function () {
 
   it(`throws w/ invalid DomainID`, function () {
     tx.DomainID = 1234
-    const errorMessage = 'PermissionedDomainDelete: invalid field DomainID'
+    const errorMessage =
+      'PermissionedDomainDelete: invalid field DomainID: expected a string'
     assertInvalid(tx, errorMessage)
   })
 })

--- a/packages/xrpl/test/models/permissionedDomainSet.test.ts
+++ b/packages/xrpl/test/models/permissionedDomainSet.test.ts
@@ -40,7 +40,8 @@ describe('PermissionedDomainSet', function () {
   it(`throws with invalid field DomainID`, function () {
     // DomainID is expected to be a string
     tx.DomainID = 1234
-    const errorMessage = 'PermissionedDomainSet: invalid field DomainID'
+    const errorMessage =
+      'PermissionedDomainSet: invalid field DomainID: expected a string'
     assertInvalid(tx, errorMessage)
   })
 
@@ -72,7 +73,7 @@ describe('PermissionedDomainSet', function () {
     tx.AcceptedCredentials = 'AcceptedCredentials is not an array'
     assertInvalid(
       tx,
-      'PermissionedDomainSet: invalid field AcceptedCredentials',
+      'PermissionedDomainSet: invalid field AcceptedCredentials: expected an array',
     )
   })
 

--- a/packages/xrpl/test/models/signerListSet.test.ts
+++ b/packages/xrpl/test/models/signerListSet.test.ts
@@ -66,7 +66,10 @@ describe('SignerListSet', function () {
   it(`throws w/ invalid SignerEntries`, function () {
     signerListSetTx.SignerEntries = 'khgfgyhujk'
 
-    assertInvalid(signerListSetTx, 'SignerListSet: invalid field SignerEntries')
+    assertInvalid(
+      signerListSetTx,
+      'SignerListSet: invalid field SignerEntries: expected an array',
+    )
   })
 
   it(`throws w/ maximum of 32 members allowed in SignerEntries`, function () {

--- a/packages/xrpl/test/models/vaultClawback.test.ts
+++ b/packages/xrpl/test/models/vaultClawback.test.ts
@@ -42,7 +42,7 @@ describe('VaultClawback', function () {
   it('throws w/ invalid VaultID', function () {
     // @ts-expect-error for test
     tx.VaultID = 123
-    assertInvalid(tx, 'VaultClawback: invalid field VaultID')
+    assertInvalid(tx, 'VaultClawback: invalid field VaultID: expected a string')
   })
 
   it('throws w/ missing Holder', function () {
@@ -54,12 +54,18 @@ describe('VaultClawback', function () {
   it('throws w/ invalid Holder', function () {
     // @ts-expect-error for test
     tx.Holder = 123
-    assertInvalid(tx, 'VaultClawback: invalid field Holder')
+    assertInvalid(
+      tx,
+      'VaultClawback: invalid field Holder: expected a valid account',
+    )
   })
 
   it('throws w/ string Amount', function () {
     // @ts-expect-error for test
     tx.Amount = '123456'
-    assertInvalid(tx, 'VaultClawback: invalid field Amount')
+    assertInvalid(
+      tx,
+      'VaultClawback: invalid field Amount: expected a ClawbackAmount',
+    )
   })
 })

--- a/packages/xrpl/test/models/vaultCreate.test.ts
+++ b/packages/xrpl/test/models/vaultCreate.test.ts
@@ -58,7 +58,7 @@ describe('VaultCreate', function () {
   it('throws w/ invalid Asset', function () {
     // @ts-expect-error for test
     tx.Asset = 123
-    assertInvalid(tx, 'VaultCreate: invalid field Asset')
+    assertInvalid(tx, 'VaultCreate: invalid field Asset: expected a Currency')
   })
 
   it('throws w/ Data field not hex', function () {
@@ -90,7 +90,10 @@ describe('VaultCreate', function () {
   it('throws w/ non-number WithdrawalPolicy', function () {
     // @ts-expect-error for test
     tx.WithdrawalPolicy = 'invalid'
-    assertInvalid(tx, 'VaultCreate: invalid field WithdrawalPolicy')
+    assertInvalid(
+      tx,
+      'VaultCreate: invalid field WithdrawalPolicy: expected a number',
+    )
   })
 
   it('allows DomainID when tfVaultPrivate flag set', function () {
@@ -188,7 +191,7 @@ describe('VaultCreate', function () {
       }
       // @ts-expect-error for test
       tx.Scale = 'invalid'
-      assertInvalid(tx, 'VaultCreate: invalid field Scale')
+      assertInvalid(tx, 'VaultCreate: invalid field Scale: expected a number')
     })
 
     it('allows no Scale for IOU asset', function () {

--- a/packages/xrpl/test/models/vaultDelete.test.ts
+++ b/packages/xrpl/test/models/vaultDelete.test.ts
@@ -35,6 +35,6 @@ describe('VaultDelete', function () {
   it('throws w/ invalid VaultID', function () {
     // @ts-expect-error for test
     tx.VaultID = 123
-    assertInvalid(tx, 'VaultDelete: invalid field VaultID')
+    assertInvalid(tx, 'VaultDelete: invalid field VaultID: expected a string')
   })
 })

--- a/packages/xrpl/test/models/vaultDeposit.test.ts
+++ b/packages/xrpl/test/models/vaultDeposit.test.ts
@@ -36,7 +36,7 @@ describe('VaultDeposit', function () {
   it('throws w/ invalid VaultID', function () {
     // @ts-expect-error for test
     tx.VaultID = 123
-    assertInvalid(tx, 'VaultDeposit: invalid field VaultID')
+    assertInvalid(tx, 'VaultDeposit: invalid field VaultID: expected a string')
   })
 
   it('throws w/ missing Amount', function () {
@@ -48,6 +48,6 @@ describe('VaultDeposit', function () {
   it('throws w/ non-string Amount', function () {
     // @ts-expect-error for test
     tx.Amount = 123
-    assertInvalid(tx, 'VaultDeposit: invalid field Amount')
+    assertInvalid(tx, 'VaultDeposit: invalid field Amount: expected an Amount')
   })
 })

--- a/packages/xrpl/test/models/vaultSet.test.ts
+++ b/packages/xrpl/test/models/vaultSet.test.ts
@@ -37,7 +37,7 @@ describe('VaultSet', function () {
   it('throws w/ non-string VaultID', function () {
     // @ts-expect-error for test
     tx.VaultID = 123456
-    assertInvalid(tx, 'VaultSet: invalid field VaultID')
+    assertInvalid(tx, 'VaultSet: invalid field VaultID: expected a string')
   })
 
   it('throws w/ Data field not hex', function () {
@@ -52,18 +52,21 @@ describe('VaultSet', function () {
 
   it('throws w/ non-XRPLNumber AssetsMaximum', function () {
     tx.AssetsMaximum = 'notanumber'
-    assertInvalid(tx, 'VaultSet: invalid field AssetsMaximum')
+    assertInvalid(
+      tx,
+      'VaultSet: invalid field AssetsMaximum: expected an XRPL number string',
+    )
   })
 
   it('throws w/ non-string Data', function () {
     // @ts-expect-error for test
     tx.Data = 1234
-    assertInvalid(tx, 'VaultSet: invalid field Data')
+    assertInvalid(tx, 'VaultSet: invalid field Data: expected a string')
   })
 
   it('throws w/ non-string DomainID', function () {
     // @ts-expect-error for test
     tx.DomainID = 1234
-    assertInvalid(tx, 'VaultSet: invalid field DomainID')
+    assertInvalid(tx, 'VaultSet: invalid field DomainID: expected a string')
   })
 })

--- a/packages/xrpl/test/models/vaultWithdraw.test.ts
+++ b/packages/xrpl/test/models/vaultWithdraw.test.ts
@@ -40,7 +40,7 @@ describe('VaultWithdraw', function () {
   it('throws w/ invalid VaultID', function () {
     // @ts-expect-error for test
     tx.VaultID = 123
-    assertInvalid(tx, 'VaultWithdraw: invalid field VaultID')
+    assertInvalid(tx, 'VaultWithdraw: invalid field VaultID: expected a string')
   })
 
   it('throws w/ missing Amount', function () {
@@ -52,7 +52,7 @@ describe('VaultWithdraw', function () {
   it('throws w/ non-string Amount', function () {
     // @ts-expect-error for test
     tx.Amount = 123
-    assertInvalid(tx, 'VaultWithdraw: invalid field Amount')
+    assertInvalid(tx, 'VaultWithdraw: invalid field Amount: expected an Amount')
   })
 
   it('verifies valid VaultWithdraw with Destination', function () {
@@ -65,6 +65,9 @@ describe('VaultWithdraw', function () {
   it('throws w/ invalid Destination', function () {
     // @ts-expect-error for test
     tx.Destination = 123
-    assertInvalid(tx, 'VaultWithdraw: invalid field Destination')
+    assertInvalid(
+      tx,
+      'VaultWithdraw: invalid field Destination: expected a valid account',
+    )
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Closes #2858.

`validateRequiredField` and `validateOptionalField` error messages now state the expected type, per the discussion in #2829:

- Before: `Payment: invalid field Fee`
- After: `Payment: invalid field Fee: expected a string`

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Details

- Both helpers gain an optional `expectedType` on the existing `errorOpts` object — fully additive, all existing call patterns compile and behave unchanged when it's omitted. Missing-field errors are unchanged.
- Every `validateRequiredField`/`validateOptionalField` call site under `src/models/transactions` (181 sites) now supplies the expected type, derived from the predicate actually used (`isString` → "a string", `isAccount` → "a valid account", etc.), with consistent phrasing throughout.
- All exact-match message assertions in the model tests were updated to the new strings (assertions became more specific, none weakened).
- Changelog entry added under Unreleased.

## Testing

- `npm test -w xrpl` — 116 suites / 1035 tests passing.
- `npm run lint -w xrpl` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)