### PR TITLE
fix: reject out-of-range MPT amounts instead of encoding truncated values

### DIFF
--- a/packages/ripple-binary-codec/HISTORY.md
+++ b/packages/ripple-binary-codec/HISTORY.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+* Reject out-of-range MPT amounts (outside `[0, 2^63 - 1]`) instead of encoding truncated values. Previously a single-bit mask only rejected values with bit 63 set, so values `>= 2^64` passed validation and serialized to only their low 64 bits, signing a different amount than was validated (#3368).
+
 ## 2.8.0 (2026-06-04)
 
 ### Fixed

--- a/packages/ripple-binary-codec/src/types/amount.ts
+++ b/packages/ripple-binary-codec/src/types/amount.ts
@@ -17,7 +17,10 @@ const MAX_IOU_PRECISION = 16
 const MAX_DROPS = new BigNumber('1e17')
 const MIN_XRP = new BigNumber('1e-6')
 const mask = BigInt(0x00000000ffffffff)
-const mptMask = BigInt(0x8000000000000000)
+// MPT amounts are serialized as a signed 64-bit integer, so the largest
+// representable value is 2^63 - 1. Values outside [0, 2^63 - 1] cannot be
+// encoded without truncation and must be rejected.
+const MAX_MPT_AMOUNT = new BigNumber('9223372036854775807')
 
 /**
  * BigNumber configuration for Amount IOUs
@@ -322,7 +325,11 @@ class Amount extends SerializedType {
         throw new Error(`${amount.toString()} is an illegal amount`)
       }
 
-      if (Number(BigInt(amount) & BigInt(mptMask)) != 0) {
+      // The previous bit-mask check (`& 0x8000000000000000`) only rejected
+      // values with bit 63 set, so any value >= 2^64 (bit 63 clear) slipped
+      // through and the serializer wrote only the low 64 bits, signing a
+      // different, truncated amount. Compare against the true maximum instead.
+      if (decimal.gt(MAX_MPT_AMOUNT)) {
         throw new Error(`${amount.toString()} is an illegal amount`)
       }
     }

--- a/packages/ripple-binary-codec/test/amount.test.ts
+++ b/packages/ripple-binary-codec/test/amount.test.ts
@@ -90,6 +90,75 @@ describe('Amount', function () {
     )
   })
 
+  it('accepts the maximum valid MPT amount (2^63 - 1) and round-trips it', function () {
+    const fixture = {
+      value: '9223372036854775807',
+      mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    }
+    const amt = Amount.from(fixture)
+    expect(amt.toJSON()).toEqual(fixture)
+  })
+
+  it('accepts a zero MPT amount', function () {
+    const fixture = {
+      value: '0',
+      mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    }
+    const amt = Amount.from(fixture)
+    expect(amt.toJSON()).toEqual(fixture)
+  })
+
+  it('rejects an MPT amount one above the maximum (2^63)', function () {
+    const mpt = {
+      value: '9223372036854775808',
+      mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    }
+    expect(() => Amount.from(mpt)).toThrow(
+      new Error(mpt.value + ' is an illegal amount'),
+    )
+  })
+
+  it('rejects an out-of-range MPT amount of 2^64 instead of encoding a truncated 0', function () {
+    const mpt = {
+      value: '18446744073709551616',
+      mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    }
+    expect(() => Amount.from(mpt)).toThrow(
+      new Error(mpt.value + ' is an illegal amount'),
+    )
+  })
+
+  it('rejects an out-of-range MPT amount of 2^64 + 5 instead of encoding a truncated 5', function () {
+    const mpt = {
+      value: '18446744073709551621',
+      mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    }
+    // Regression for #3368: this value previously passed validation and the
+    // serializer wrote only the low 64 bits, signing "5" instead of failing.
+    expect(() => Amount.from(mpt)).toThrow(
+      new Error(mpt.value + ' is an illegal amount'),
+    )
+    // Prove the truncation path is closed: encoding must throw, never produce
+    // an Amount whose JSON value is the truncated "5".
+    let encoded: unknown
+    try {
+      encoded = Amount.from(mpt).toJSON()
+    } catch {
+      encoded = undefined
+    }
+    expect(encoded).toBeUndefined()
+  })
+
+  it('rejects a negative MPT amount', function () {
+    const mpt = {
+      value: '-1',
+      mpt_issuance_id: '00002403C84A0A28E0190E208E982C352BBD5006600555CF',
+    }
+    expect(() => Amount.from(mpt)).toThrow(
+      new Error(mpt.value + ' is an illegal amount'),
+    )
+  })
+
   it('toJSON() does not mutate internal buffer for native XRP amounts', function () {
     const amt = Amount.from('1000000')
     const serializedHexBeforeJsonCalls = amt.toHex()


### PR DESCRIPTION
## High Level Overview of Change

Closes #3368.

MPT amounts are serialized as a signed 64-bit integer, so the valid range is `[0, 2^63 − 1]`. `Amount.assertMptIsValid` in `ripple-binary-codec` validated with a single-bit mask (`BigInt(amount) & 0x8000000000000000`), which only rejects values whose **bit 63 is set**. Any value ≥ 2^64 has bit 63 clear, passed validation, and the serializer wrote only the low 64 bits — so `"18446744073709551616"` (2^64) signed as `"0"` and `"18446744073709551621"` (2^64 + 5) signed as `"5"`. A caller could `validate()` and `Wallet.sign()` one amount and produce a `tx_blob` containing a different, truncated amount.

The fix replaces the bit-mask check with a full magnitude check against the true maximum (`2^63 − 1`) using the existing BigNumber comparison style, and removes the now-unused mask constant. Negative-value and non-numeric handling are preserved exactly (same `<amount> is an illegal amount` error type and message shape).

### Context of Change

The bug dates to the original MPT amount support in the codec. Since every signing path serializes through the codec, encoding now rejects out-of-range values before any blob is produced. Model-level `isMPTAmount` in `packages/xrpl` remains a shape-only guard (unchanged); the codec is the correct single choke point, and a model-layer range check would be a larger, separable change.

Boundary semantics match rippled: `9223372036854775807` (2^63 − 1) encodes and round-trips; `9223372036854775808` (2^63) and above throw.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Did you update HISTORY.md?

- [x] Yes (`packages/ripple-binary-codec/HISTORY.md`, Unreleased)

## Test Plan

New tests in `packages/ripple-binary-codec/test/amount.test.ts` (7 added, suite now 1253 passing):

- `"9223372036854775807"` (2^63 − 1) and `"0"` encode and round-trip exactly.
- `"9223372036854775808"` (2^63), `"18446744073709551616"` (2^64), `"18446744073709551621"` (2^64 + 5), and `"-1"` all throw `... is an illegal amount` (messages asserted).
- Explicit regression assertion that encoding 2^64 + 5 **throws and can never yield the truncated value `"5"`**.

`npm test` in `packages/ripple-binary-codec`: 19 suites / 1253 tests pass. `npm run lint`: clean.