### PR TITLE
ci: support private xrpld images

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,6 +63,7 @@ jobs:
   resolve_xrpld_image:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions: {}
     outputs:
       image: ${{ steps.resolve.outputs.image }}
       is_private: ${{ steps.resolve.outputs.is_private }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,6 @@
 name: Node.js CI
 
 env:
-  XRPLD_DOCKER_IMAGE: rippleci/xrpld:develop
   GIT_REF: ${{ inputs.git_ref || github.ref }}
 
 on:
@@ -15,6 +14,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
+    inputs:
+      use_private_xrpld_image:
+        description: "Use a private xrpld image from the Ripple GitLab registry"
+        required: false
+        type: boolean
+        default: false
+      xrpld_image_version:
+        description: "Private xrpld version without the private- prefix (for example, 3.3.0-rc2)"
+        required: false
+        type: string
   workflow_call:
     inputs:
       git_ref:
@@ -36,8 +45,70 @@ on:
         required: false
         type: boolean
         default: true
+      use_private_xrpld_image:
+        description: "Use a private xrpld image from the Ripple GitLab registry"
+        required: false
+        type: boolean
+        default: false
+      xrpld_image_version:
+        description: "Private xrpld version without the private- prefix (for example, 3.3.0-rc2)"
+        required: false
+        type: string
+    secrets:
+      GITLAB_REGISTRY_USERNAME:
+        description: "GitLab deploy-token username with read_registry access"
+        required: false
+      GITLAB_REGISTRY_TOKEN:
+        description: "GitLab deploy token with read_registry access"
+        required: false
 
 jobs:
+  resolve_xrpld_image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+      is_private: ${{ steps.resolve.outputs.is_private }}
+
+    steps:
+      - name: Resolve xrpld image
+        id: resolve
+        env:
+          USE_PRIVATE_XRPLD_IMAGE: ${{ inputs.use_private_xrpld_image }}
+          XRPLD_IMAGE_VERSION: ${{ inputs.xrpld_image_version }}
+          GITLAB_REGISTRY_USERNAME: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${USE_PRIVATE_XRPLD_IMAGE}" == "true" ]]; then
+            if ! [[ "${XRPLD_IMAGE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(b|rc)[0-9]+)?$ ]]; then
+              echo "xrpld_image_version must use X.Y.Z, X.Y.Z-bN, or X.Y.Z-rcN format." >&2
+              exit 1
+            fi
+
+            if [[ -z "${GITLAB_REGISTRY_USERNAME}" || -z "${GITLAB_REGISTRY_TOKEN}" ]]; then
+              echo "GITLAB_REGISTRY_USERNAME and GITLAB_REGISTRY_TOKEN secrets are required for private xrpld images." >&2
+              exit 1
+            fi
+
+            XRPLD_DOCKER_IMAGE="registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-${XRPLD_IMAGE_VERSION}"
+            IS_PRIVATE="true"
+          else
+            if [[ -n "${XRPLD_IMAGE_VERSION}" ]]; then
+              echo "xrpld_image_version must be empty unless use_private_xrpld_image is enabled." >&2
+              exit 1
+            fi
+
+            XRPLD_DOCKER_IMAGE="rippleci/xrpld:develop"
+            IS_PRIVATE="false"
+          fi
+
+          {
+            echo "image=${XRPLD_DOCKER_IMAGE}"
+            echo "is_private=${IS_PRIVATE}"
+          } >> "${GITHUB_OUTPUT}"
+
   build-and-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -126,8 +197,11 @@ jobs:
 
   integration:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_integration_tests != false }}
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
 
     strategy:
       matrix:
@@ -139,6 +213,16 @@ jobs:
           ref: ${{ env.GIT_REF }}
           fetch-depth: 0
 
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
+
       - name: Run docker in background
         run: |
           docker run \
@@ -146,7 +230,7 @@ jobs:
             --publish 6006:6006 \
             --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" \
             --name xrpld-service \
-            ${{ env.XRPLD_DOCKER_IMAGE }} --standalone
+            "${XRPLD_DOCKER_IMAGE}" --standalone
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -186,8 +270,11 @@ jobs:
 
   browser:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_browser_tests != false }}
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
 
     strategy:
       matrix:
@@ -204,6 +291,16 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
+
       - name: Run docker in background
         run: |
           docker run \
@@ -211,7 +308,7 @@ jobs:
             --publish 6006:6006 \
             --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" \
             --name xrpld-service \
-            ${{ env.XRPLD_DOCKER_IMAGE }} --standalone
+            "${XRPLD_DOCKER_IMAGE}" --standalone
 
       - name: Setup npm version 10
         run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,16 +14,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
-    inputs:
-      use_private_xrpld_image:
-        description: "Use a private xrpld image from the Ripple GitLab registry"
-        required: false
-        type: boolean
-        default: false
-      xrpld_image_version:
-        description: "Private xrpld version without the private- prefix (for example, 3.3.0-rc2)"
-        required: false
-        type: string
   workflow_call:
     inputs:
       git_ref:
@@ -45,15 +35,6 @@ on:
         required: false
         type: boolean
         default: true
-      use_private_xrpld_image:
-        description: "Use a private xrpld image from the Ripple GitLab registry"
-        required: false
-        type: boolean
-        default: false
-      xrpld_image_version:
-        description: "Private xrpld version without the private- prefix (for example, 3.3.0-rc2)"
-        required: false
-        type: string
     secrets:
       GITLAB_REGISTRY_TOKEN:
         description: "GitLab deploy token with read_registry access"
@@ -63,48 +44,60 @@ jobs:
   resolve_xrpld_image:
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    permissions: {}
+    permissions:
+      contents: read
     outputs:
       image: ${{ steps.resolve.outputs.image }}
       is_private: ${{ steps.resolve.outputs.is_private }}
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
       - name: Resolve xrpld image
         id: resolve
         env:
-          USE_PRIVATE_XRPLD_IMAGE: ${{ inputs.use_private_xrpld_image }}
-          XRPLD_IMAGE_VERSION: ${{ inputs.xrpld_image_version }}
+          IMAGE_CONFIG_FILE: .github/xrpld-image.env
+          DEFAULT_IMAGE: rippleci/xrpld:develop
+          PRIVATE_IMAGE_REPO: registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private
           GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
           GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
 
-          if [[ "${USE_PRIVATE_XRPLD_IMAGE}" == "true" ]]; then
-            if ! [[ "${XRPLD_IMAGE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(b|rc)[0-9]+)?$ ]]; then
-              echo "xrpld_image_version must use X.Y.Z, X.Y.Z-bN, or X.Y.Z-rcN format." >&2
-              exit 1
-            fi
-
-            if [[ -z "${GITLAB_REGISTRY_USERNAME}" || -z "${GITLAB_REGISTRY_TOKEN}" ]]; then
-              echo "The GITLAB_REGISTRY_USERNAME variable and GITLAB_REGISTRY_TOKEN secret are required for private xrpld images." >&2
-              exit 1
-            fi
-
-            XRPLD_DOCKER_IMAGE="registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-${XRPLD_IMAGE_VERSION}"
-            IS_PRIVATE="true"
-          else
-            if [[ -n "${XRPLD_IMAGE_VERSION}" ]]; then
-              echo "xrpld_image_version must be empty unless use_private_xrpld_image is enabled." >&2
-              exit 1
-            fi
-
-            XRPLD_DOCKER_IMAGE="rippleci/xrpld:develop"
-            IS_PRIVATE="false"
+          # Read the requested private version from the committed config file.
+          # The file is never sourced: on fork pull requests its contents are
+          # untrusted, so we only extract the value and validate it strictly.
+          PRIVATE_VERSION=""
+          if [[ -f "${IMAGE_CONFIG_FILE}" ]]; then
+            RAW_LINE="$(grep -E '^[[:space:]]*XRPLD_PRIVATE_VERSION[[:space:]]*=' "${IMAGE_CONFIG_FILE}" | tail -n1 || true)"
+            PRIVATE_VERSION="$(printf '%s' "${RAW_LINE#*=}" | tr -d "[:space:]\"'")"
           fi
 
+          if [[ -z "${PRIVATE_VERSION}" ]]; then
+            echo "No private xrpld version configured in ${IMAGE_CONFIG_FILE}; using default image ${DEFAULT_IMAGE}."
+            {
+              echo "image=${DEFAULT_IMAGE}"
+              echo "is_private=false"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! [[ "${PRIVATE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(b|rc)[0-9]+)?$ ]]; then
+            echo "XRPLD_PRIVATE_VERSION in ${IMAGE_CONFIG_FILE} must use X.Y.Z, X.Y.Z-bN, or X.Y.Z-rcN format (got '${PRIVATE_VERSION}')." >&2
+            exit 1
+          fi
+
+          if [[ -z "${GITLAB_REGISTRY_USERNAME}" || -z "${GITLAB_REGISTRY_TOKEN}" ]]; then
+            echo "A private xrpld version (${PRIVATE_VERSION}) is configured but the GITLAB_REGISTRY_USERNAME variable and GITLAB_REGISTRY_TOKEN secret are unavailable. These are not exposed to fork pull requests; run the private build from a branch in this repository, or clear XRPLD_PRIVATE_VERSION to use the default image." >&2
+            exit 1
+          fi
+
+          echo "Using private xrpld image for version ${PRIVATE_VERSION}."
           {
-            echo "image=${XRPLD_DOCKER_IMAGE}"
-            echo "is_private=${IS_PRIVATE}"
+            echo "image=${PRIVATE_IMAGE_REPO}:private-${PRIVATE_VERSION}"
+            echo "is_private=true"
           } >> "${GITHUB_OUTPUT}"
 
   build-and-lint:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -55,9 +55,6 @@ on:
         required: false
         type: string
     secrets:
-      GITLAB_REGISTRY_USERNAME:
-        description: "GitLab deploy-token username with read_registry access"
-        required: false
       GITLAB_REGISTRY_TOKEN:
         description: "GitLab deploy token with read_registry access"
         required: false
@@ -76,7 +73,7 @@ jobs:
         env:
           USE_PRIVATE_XRPLD_IMAGE: ${{ inputs.use_private_xrpld_image }}
           XRPLD_IMAGE_VERSION: ${{ inputs.xrpld_image_version }}
-          GITLAB_REGISTRY_USERNAME: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
           GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
@@ -88,7 +85,7 @@ jobs:
             fi
 
             if [[ -z "${GITLAB_REGISTRY_USERNAME}" || -z "${GITLAB_REGISTRY_TOKEN}" ]]; then
-              echo "GITLAB_REGISTRY_USERNAME and GITLAB_REGISTRY_TOKEN secrets are required for private xrpld images." >&2
+              echo "The GITLAB_REGISTRY_USERNAME variable and GITLAB_REGISTRY_TOKEN secret are required for private xrpld images." >&2
               exit 1
             fi
 
@@ -216,7 +213,7 @@ jobs:
       - name: Log in to the private GitLab registry
         if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
         env:
-          GITLAB_REGISTRY_USERNAME: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
           GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
         run: |
           printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
@@ -294,7 +291,7 @@ jobs:
       - name: Log in to the private GitLab registry
         if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
         env:
-          GITLAB_REGISTRY_USERNAME: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
           GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
         run: |
           printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \

--- a/.github/xrpld-image.env
+++ b/.github/xrpld-image.env
@@ -1,0 +1,14 @@
+# xrpld image selection for the Node.js CI integration and browser tests.
+#
+# Set XRPLD_PRIVATE_VERSION to a private xrpld release (for example, 3.3.0-rc2
+# or 3.3.0-b1) to run the tests against the private image:
+#   registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>
+#
+# Leave it empty to use the default public image rippleci/xrpld:develop.
+#
+# Private pulls require the repository variable GITLAB_REGISTRY_USERNAME and the
+# repository secret GITLAB_REGISTRY_TOKEN (a GitLab deploy token with
+# read_registry access). These credentials are not exposed to fork pull
+# requests, so a private version must be tested from a branch in this
+# repository; a fork pull request with a private version set will fail fast.
+XRPLD_PRIVATE_VERSION=

--- a/.github/xrpld-image.env
+++ b/.github/xrpld-image.env
@@ -11,4 +11,4 @@
 # read_registry access). These credentials are not exposed to fork pull
 # requests, so a private version must be tested from a branch in this
 # repository; a fork pull request with a private version set will fail fast.
-XRPLD_PRIVATE_VERSION=3.3.0-rc2
+XRPLD_PRIVATE_VERSION=

--- a/.github/xrpld-image.env
+++ b/.github/xrpld-image.env
@@ -11,4 +11,4 @@
 # read_registry access). These credentials are not exposed to fork pull
 # requests, so a private version must be tested from a branch in this
 # repository; a fork pull request with a private version set will fail fast.
-XRPLD_PRIVATE_VERSION=
+XRPLD_PRIVATE_VERSION=3.3.0-rc2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Breaking down the command:
 
 Maintainers can run integration and browser tests against a private xrpld image from the **Node.js CI** workflow in GitHub Actions. Enable `use_private_xrpld_image` and enter `xrpld_image_version` without the `private-` prefix (for example, `3.3.0-rc2`). The workflow pulls `registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>`.
 
-Private image access requires the repository secrets `GITLAB_REGISTRY_USERNAME` and `GITLAB_REGISTRY_TOKEN`, configured with a GitLab deploy token that has `read_registry` access. Credentials are not accepted as workflow inputs.
+Private image access requires the repository variable `GITLAB_REGISTRY_USERNAME` and repository secret `GITLAB_REGISTRY_TOKEN`, configured with a GitLab deploy token that has `read_registry` access. Credentials are not accepted as workflow inputs.
 
 Note to Contributors: When you're done, stop and remove the container with `docker stop xrpld-service && docker rm xrpld-service`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,9 @@ Breaking down the command:
 * `rippleci/xrpld:develop` is the image, regularly rebuilt from the `develop` branch of `rippled`. Omitting the tag resolves to `:latest`.
 * `--standalone` is passed to the image's entrypoint (`xrpld`) to start the node in standalone mode.
 
-Maintainers can run integration and browser tests against a private xrpld image from the **Node.js CI** workflow in GitHub Actions. Enable `use_private_xrpld_image` and enter `xrpld_image_version` without the `private-` prefix (for example, `3.3.0-rc2`). The workflow pulls `registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>`.
+Maintainers can run integration and browser tests against a private xrpld image by committing a version to `.github/xrpld-image.env`. Set `XRPLD_PRIVATE_VERSION` to the version without the `private-` prefix (for example, `XRPLD_PRIVATE_VERSION=3.3.0-rc2`); every workflow run triggered afterwards — including pull request runs — pulls `registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>`. Leave the value empty to use the default public image `rippleci/xrpld:develop`.
 
-Private image access requires the repository variable `GITLAB_REGISTRY_USERNAME` and repository secret `GITLAB_REGISTRY_TOKEN`, configured with a GitLab deploy token that has `read_registry` access. Credentials are not accepted as workflow inputs.
+Private image access requires the repository variable `GITLAB_REGISTRY_USERNAME` and repository secret `GITLAB_REGISTRY_TOKEN`, configured with a GitLab deploy token that has `read_registry` access. These credentials are not exposed to fork pull requests, so a private version must be tested from a branch in this repository; a fork pull request with a private version set will fail fast rather than silently fall back.
 
 Note to Contributors: When you're done, stop and remove the container with `docker stop xrpld-service && docker rm xrpld-service`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,10 @@ Breaking down the command:
 * `rippleci/xrpld:develop` is the image, regularly rebuilt from the `develop` branch of `rippled`. Omitting the tag resolves to `:latest`.
 * `--standalone` is passed to the image's entrypoint (`xrpld`) to start the node in standalone mode.
 
+Maintainers can run integration and browser tests against a private xrpld image from the **Node.js CI** workflow in GitHub Actions. Enable `use_private_xrpld_image` and enter `xrpld_image_version` without the `private-` prefix (for example, `3.3.0-rc2`). The workflow pulls `registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>`.
+
+Private image access requires the repository secrets `GITLAB_REGISTRY_USERNAME` and `GITLAB_REGISTRY_TOKEN`, configured with a GitLab deploy token that has `read_registry` access. Credentials are not accepted as workflow inputs.
+
 Note to Contributors: When you're done, stop and remove the container with `docker stop xrpld-service && docker rm xrpld-service`.
 
 ### Faucet Tests


### PR DESCRIPTION
## High Level Overview of Change

- Drive xrpld image selection from a committed config file, `.github/xrpld-image.env`, so pull-request-triggered CI can run against a private xrpld image without manual workflow dispatch.
- Add a `resolve_xrpld_image` job that reads `XRPLD_PRIVATE_VERSION` from the config file: when set, integration and browser tests use the private GitLab image; when empty, they use the default public image.
- Authenticate private pulls with the `GITLAB_REGISTRY_USERNAME` repository variable and read-only `GITLAB_REGISTRY_TOKEN` deploy-token secret.
- Preserve `rippleci/xrpld:develop` as the default for normal CI and releases.
- Document the config-file workflow and required repository credentials.

### Context of Change

Private xrpl.js builds need to run integration and browser tests against xrpld images published only to the Ripple GitLab registry. Selecting the image from a committed config file means a branch (including a PR branch in this repository) can opt into a private image simply by setting `XRPLD_PRIVATE_VERSION`, with no manual `workflow_dispatch` step.

The resolver never sources the config file: it extracts the value and validates it against a strict `X.Y.Z`, `X.Y.Z-bN`, or `X.Y.Z-rcN` pattern before constructing `private-<version>`, avoiding arbitrary image references and shell injection. When a private version is configured but the registry credentials are unavailable — as happens on fork pull requests, where GitHub withholds secrets — the job fails fast with a clear message rather than silently falling back.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

### Did you update HISTORY.md?

- [ ] Yes
- [x] No, this change does not impact library users

## Test Plan

- Parsed `.github/workflows/nodejs.yml` with a YAML loader.
- Ran the resolver's config-file parsing locally against empty, quoted, whitespace-padded, and commented values.
- Verified the version regex accepts `X.Y.Z`, `X.Y.Z-bN`, and `X.Y.Z-rcN` and rejects malformed versions and shell-injection attempts.
- Ran the full CI suite through GitHub Actions with the config file both empty (default image) and set to a private version.

### CI validation result

- **Private image path works.** With `XRPLD_PRIVATE_VERSION=3.3.0-rc2` committed, `resolve_xrpld_image` correctly read the config, validated the version, and selected the private image `registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-3.3.0-rc2`. On this fork PR the job then failed fast — by design — because GitHub does not expose the `GITLAB_REGISTRY_TOKEN` secret to fork pull requests. A full private pull must therefore be validated from a branch in this repository.
- **Default path is green.** With `XRPLD_PRIVATE_VERSION` cleared, `resolve_xrpld_image` resolves to `rippleci/xrpld:develop` and all required checks pass: `resolve_xrpld_image`, `unit`, `integration`, and `browser`. This PR is merged with the config value empty so it uses the default image.

> Note: to test the private image, set `XRPLD_PRIVATE_VERSION` on a branch pushed directly to this repository (not a fork), so the registry credentials are available.
