### PR TITLE
fix: use base fee for VaultCreate autofill

### DIFF
--- a/packages/xrpl/src/sugar/autofill.ts
+++ b/packages/xrpl/src/sugar/autofill.ts
@@ -326,11 +326,9 @@ async function calculateFeePerTransactionType(
   const netFeeDrops = xrpToDrops(netFeeXRP)
   let baseFee = new BigNumber(netFeeDrops)
 
-  const isSpecialTxCost = [
-    'AccountDelete',
-    'AMMCreate',
-    'VaultCreate',
-  ].includes(tx.TransactionType)
+  const isSpecialTxCost = ['AccountDelete', 'AMMCreate'].includes(
+    tx.TransactionType,
+  )
 
   // EscrowFinish Transaction with Fulfillment
   if (tx.TransactionType === 'EscrowFinish' && tx.Fulfillment != null) {

--- a/packages/xrpl/test/client/autofill.test.ts
+++ b/packages/xrpl/test/client/autofill.test.ts
@@ -7,6 +7,8 @@ import {
   Payment,
   Transaction,
   Batch,
+  VaultCreate,
+  VaultWithdrawalPolicy,
   type LoanSet,
 } from '../../src'
 import { ValidationError } from '../../src/errors'
@@ -350,6 +352,29 @@ describe('client.autofill', function () {
       const txResult = await testContext.client.autofill(tx)
 
       assert.strictEqual(txResult.Fee, '2000000')
+    })
+
+    it('should autofill the network Fee of a VaultCreate transaction', async function () {
+      const tx: VaultCreate = {
+        Account: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
+        TransactionType: 'VaultCreate',
+        Asset: { currency: 'XRP' },
+        WithdrawalPolicy:
+          VaultWithdrawalPolicy.vaultStrategyFirstComeFirstServe,
+      }
+      testContext.mockRippled!.addResponse(
+        'account_info',
+        rippled.account_info.normal,
+      )
+      testContext.mockRippled!.addResponse('ledger', rippled.ledger.normal)
+      testContext.mockRippled!.addResponse(
+        'server_info',
+        rippled.server_info.normal,
+      )
+
+      const txResult = await testContext.client.autofill(tx)
+
+      assert.strictEqual(txResult.Fee, '12')
     })
 
     it('should autofill Fee of an EscrowFinish transaction with signersCount', async function () {


### PR DESCRIPTION
Fixes #3427.

## Summary

Remove `VaultCreate` from the transaction types that receive the two-XRP special fee during autofill. `VaultCreate` now uses the network base fee, while `AccountDelete` and `AMMCreate` retain their existing special cost.

## Testing

- `npm run build`
- `npm test -w xrpl -- --runInBand test/client/autofill.test.ts` (22 tests)
- `npm run lint -w xrpl`

The new regression test autofills a valid `VaultCreate` transaction and expects the mocked network fee of 12 drops.
