### PR TITLE
docs: add Vultisig to APPLICATIONS.md

### DIFF
--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -78,6 +78,10 @@ Warning: Use at your own risk.
 
 ## Wallets and wallet tools
 
+- **[Vultisig](https://vultisig.com)**
+
+  Vultisig is an open-source, self-custodial multi-chain wallet that uses multi-party computation (MPC) threshold signing instead of a seed phrase. It supports XRP send and receive, destination tags, and trust lines on iOS, Android, desktop, and as a browser extension. The source code is available at [https://github.com/vultisig](https://github.com/vultisig).
+
 - **[Joey Wallet](https://joeywallet.xyz)**
 
   Joey Wallet is a secure, self-custody cryptocurrency wallet and gateway to Web3 decentralized applications (dApps) on the XRP Ledger (XRPL). Documentation and integration details are located at [https://docs.joeywallet.xyz/](https://docs.joeywallet.xyz).


### PR DESCRIPTION
Adds Vultisig to the Wallets section of APPLICATIONS.md, per the file's own invitation.

Vultisig is a real xrpl.js consumer, not just an XRP-supporting wallet: our SDK's core chain package declares `xrpl@^5.0.0` as a direct dependency and uses `Client` for XRPL connectivity (`github.com/vultisig/vultisig-sdk`, `packages/core/chain/chains/ripple/client.ts`). Feature claims in the entry (destination tags, trust lines) map to shipped code.

## receipts

no runtime changes

Docs-only, one entry added at the top of the Wallets section matching the format of the most recent wallet-add PR (#3082).