### PR TITLE
ci: Adopt PR-hygiene workflows from XRPLF/actions and rippled

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: quarterly
     time: "15:00"
   open-pull-requests-limit: 30
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: quarterly
+    time: "15:00"
+  open-pull-requests-limit: 30

--- a/.github/scripts/check-pr-description.py
+++ b/.github/scripts/check-pr-description.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+"""
+Checks that a pull request description has been customized from the
+pull_request_template.md. Exits with code 1 if the description is empty
+or identical to the template (ignoring HTML comments and whitespace).
+
+Usage:
+    python check-pr-description.py --template-file TEMPLATE --pr-body-file BODY
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def normalize(text: str) -> str:
+    """Strip HTML comments, trim lines, and remove blank lines."""
+    # Remove HTML comments (possibly multi-line)
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+    # Strip each line and drop empties
+    lines = [line.strip() for line in text.splitlines()]
+    lines = [line for line in lines if line]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that a PR description differs from the template."
+    )
+    parser.add_argument(
+        "--template-file",
+        type=Path,
+        required=True,
+        help="Path to the pull request template file.",
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        type=Path,
+        required=True,
+        help="Path to a file containing the PR body text.",
+    )
+    args = parser.parse_args()
+
+    template_path: Path = args.template_file
+    pr_body_path: Path = args.pr_body_file
+
+    if not template_path.is_file():
+        print(f"::error::Template file {template_path} not found")
+        return 1
+
+    if not pr_body_path.is_file():
+        print(f"::error::PR body file {pr_body_path} not found")
+        return 1
+
+    template = template_path.read_text(encoding="utf-8")
+    pr_body = pr_body_path.read_text(encoding="utf-8")
+
+    # Check if the PR body is empty or whitespace-only
+    if not pr_body.strip():
+        print(
+            "::error::PR description is empty. "
+            "Please fill in the pull request template."
+        )
+        return 1
+
+    norm_template = normalize(template)
+    norm_pr_body = normalize(pr_body)
+
+    if norm_pr_body == norm_template:
+        print(
+            "::error::PR description (ignoring HTML comments) is identical"
+            " to the template. Please fill in the details of your change."
+            f"\n\nVisible template content:\n---\n{norm_template}\n---"
+            f"\n\nVisible PR description content:\n---\n{norm_pr_body}\n---"
+        )
+        return 1
+
+    print("PR description has been customized from the template.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-pr-commits.yml
+++ b/.github/workflows/check-pr-commits.yml
@@ -1,0 +1,13 @@
+name: Check PR commits
+
+on:
+  pull_request_target:
+
+# The action needs to have write permissions to post comments on the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check_commits:
+    uses: XRPLF/actions/.github/workflows/check-pr-commits.yml@ed23185d25693c9a724c3d05ae4a58371b0f72b8

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -1,0 +1,31 @@
+name: Check PR description
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+
+jobs:
+  check_description:
+    if: ${{ github.event.pull_request.draft != true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Write PR body to file
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printenv PR_BODY >pr_body.md
+
+      - name: Check PR description differs from template
+        run: |
+          python3 .github/scripts/check-pr-description.py \
+              --template-file .github/pull_request_template.md \
+              --pr-body-file pr_body.md

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,17 @@
+name: Check PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+
+jobs:
+  check_title:
+    if: ${{ github.event.pull_request.draft != true }}
+    uses: XRPLF/actions/.github/workflows/check-pr-title.yml@ed23185d25693c9a724c3d05ae4a58371b0f72b8

--- a/.github/workflows/conflicting-pr.yml
+++ b/.github/workflows/conflicting-pr.yml
@@ -1,0 +1,26 @@
+name: Label PRs with merge conflicts
+
+on:
+  # So that PRs touching the same files as the push are updated.
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolved.
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs.
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'IgnoreConflicts') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PRs are dirty
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
+        with:
+          dirtyLabel: "PR: has conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This PR has conflicts, please resolve them in order for the PR to be reviewed."
+          commentOnClean: "All conflicts have been resolved. Assigned reviewers can now start or resume their review."

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -140,7 +140,6 @@ jobs:
         run: npm ci
 
       - run: npm run build
-      - run: npm run lint
 
   unit:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_unit_tests != false }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,78 @@
+name: Run pre-commit hooks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  run-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - name: Setup npm version 10
+        run: npm i -g npm@10 --registry=https://registry.npmjs.org
+
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-deps-24.x-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-24.x-
+
+      - name: Install Dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit
+        env:
+          MESSAGE: |
+            One or more files did not pass lint/formatting checks.
+
+            To run the checks (and autofix what can be autofixed) locally, run:
+              pre-commit run --all-files
+
+            Then commit and push the changes.
+        run: |
+          set +e
+          pre-commit run --all-files --show-diff-on-failure --color always --verbose
+          rc=$?
+          set -e
+
+          if [ $rc -ne 0 ]; then
+              git status
+              echo "${MESSAGE}"
+              exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# Common tasks
+#
+# - Run on all files:   pre-commit run --all-files
+# - Register git hooks: pre-commit install --hook-type pre-commit
+#
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        description: Run ESLint (with autofix) across all packages
+        entry: npx lerna run lint --stream -- --fix
+        language: system
+        pass_filenames: false
+        types_or: [ts, tsx, javascript, jsx]


### PR DESCRIPTION
## High Level Overview of Change

Adopts the PR-hygiene layer of CI already used in `XRPLF/rippled` (and its shared `XRPLF/actions` repo), adapted for this JS/TS monorepo. See the investigation behind this in-session for what was and wasn't applicable (C++/Nix/packaging-specific workflows were excluded).

### Context of Change

xrpl.js's CI covered build/test/docs/release but had no automated PR hygiene (title/description checks, merge-conflict labeling, signed-commit enforcement) and no `pre-commit`-based lint step, unlike `rippled`. This PR brings that baseline over:

- **`check-pr-title.yml`** — calls `XRPLF/actions`'s reusable conventional-commit title checker.
- **`check-pr-commits.yml`** — calls `XRPLF/actions`'s reusable unsigned-commit checker; comments on PRs with unsigned commits and instructions to sign them.
- **`check-pr-description.yml`** + **`.github/scripts/check-pr-description.py`** — fails if a PR description is empty or unmodified from `pull_request_template.md` (script ported from rippled, generic/no rippled-specific logic).
- **`conflicting-pr.yml`** — labels PRs with merge conflicts (ported from rippled verbatim).
- **`.pre-commit-config.yaml`** + **`pre-commit.yml`** — replaces the plain `npm run lint` step in `nodejs.yml`'s `build-and-lint` job with a `pre-commit` hook that runs `lerna run lint --stream -- --fix` (verified `--fix` is correctly forwarded to each package's `eslint` invocation).
- **`dependabot.yml`** — added a `github-actions` ecosystem entry so pinned action SHAs (e.g. `actions/checkout@sha`) get automatic update PRs, alongside the existing npm entry.

Workflows calling into `XRPLF/actions` are pinned to a specific commit SHA (`ed23185d25693c9a724c3d05ae4a58371b0f72b8`), matching the pattern rippled uses.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Did you update HISTORY.md?

- [x] No, this change does not impact library users

## Test Plan

- Validated all new/modified YAML files parse correctly.
- Manually verified `.github/scripts/check-pr-description.py` correctly rejects an unmodified template and accepts a customized description.
- Verified `lerna run lint --stream -- --fix` forwards `--fix` into each package's underlying `eslint` invocation.
- These workflows are already exercised in production in `rippled`, so no additional end-to-end test-PR verification was done for the `XRPLF/actions`-backed checks themselves.

Note: `check-pr-commits.yml` will require all commits in PRs to be signed going forward — flagging this as a policy change alongside the tooling change.