### PR TITLE
Fix raw GitHub API error leaking into release Slack notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,11 +469,22 @@ jobs:
                   expanded+=("${entry#User:}")
                   ;;
                 Team:*)
-                  local slug="${entry#Team:}"
-                  logins="$(GH_TOKEN="$GH_TOKEN" gh api --paginate \
-                    "orgs/$org/teams/$slug/members" \
-                    -q '.[].login' 2>/dev/null || true)"
-                  if [ -n "$logins" ]; then
+                  local slug="${entry#Team:}" team_json team_ok
+                  # NOTE: reading org team membership needs a token with org-read
+                  # access (e.g. a PAT/fine-grained token with org "Members" read
+                  # permission). The default GITHUB_TOKEN does not have this, so this
+                  # will fail here and fall through to the team-URL fallback below.
+                  if team_json="$(curl -sSf \
+                    -H "Authorization: Bearer $GH_TOKEN" \
+                    -H "Accept: application/vnd.github+json" \
+                    "https://api.github.com/orgs/$org/teams/$slug/members")"; then
+                    team_ok=true
+                  else
+                    team_ok=false
+                    team_json=""
+                  fi
+                  logins="$(printf '%s' "$team_json" | jq -r '.[].login' 2>/dev/null || true)"
+                  if [ "$team_ok" = true ] && [ -n "$logins" ]; then
                     while IFS= read -r member; do
                       [ -n "$member" ] && expanded+=("$member")
                     done <<< "$logins"


### PR DESCRIPTION
## Summary
- The `ask_for_dev_team_review` job's team-reviewer expansion calls `GET orgs/{org}/teams/{team_slug}/members` to resolve a required-reviewer Team into individual logins.
- The default `GITHUB_TOKEN` has no org-read scope, so this call reliably 404s (confirmed against the run that triggered [XRPLF/xrpl.js#34479436173](https://github.com/XRPLF/xrpl.js/actions/runs/34479436173)) — but the prior `gh api ... 2>/dev/null || true` guard let the raw `{"message":"Not Found",...}` error body leak straight into the release Slack notification.
- This ports the same explicit success/failure check (`team_ok`) that `xrpl-py`'s release workflow already uses for the identical lookup, so a failed team-members call now falls through cleanly to the `slug (team URL)` fallback text instead of leaking the raw API error.

## Test plan
- [ ] Trigger the release workflow (or a dry run) against an environment with a Team-type required reviewer and confirm the Slack message shows `slug (url)` fallback text, not raw JSON, when the token lacks org-read access.
- [ ] Confirm behavior is unchanged when the token *can* read team membership (individual logins still listed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)